### PR TITLE
Prevent Optimizer from taking in non-unique emitter instances

### DIFF
--- a/ribs/optimizers/_optimizer.py
+++ b/ribs/optimizers/_optimizer.py
@@ -16,6 +16,12 @@ class Optimizer:
     solutions with the same dimension (that is, their ``solution_dim`` attribute
     must be the same).
 
+    .. warning:: If you are constructing many emitters at once, do not do
+        something like ``[EmitterClass(...)] * 5``, as this creates a list with
+        the same instance of ``EmitterClass`` in each position. Instead, use
+        ``[EmitterClass(...) for _ in range 5]``, which creates 5 separate
+        instances of ``EmitterClass``.
+
     Args:
         archive (ribs.archives.ArchiveBase): An archive object, selected from
             :mod:`ribs.archives`.
@@ -25,11 +31,23 @@ class Optimizer:
         ValueError: The emitters passed in do not have the same solution
             dimensions.
         ValueError: There is no emitter passed in.
+        ValueError: The same emitter instance was passed in multiple times. Each
+            emitter should be a separate instance (see the warning above).
     """
 
     def __init__(self, archive, emitters):
         if len(emitters) == 0:
             raise ValueError("Pass in at least one emitter to the optimizer.")
+
+        emitter_ids = set(id(e) for e in emitters)
+        if len(emitter_ids) != len(emitters):
+            raise ValueError(
+                "Not all emitters passed in were unique (i.e. some emitters "
+                "had the same id). If emitters were created with something "
+                "like [EmitterClass(...)] * n, instead use "
+                "[EmitterClass(...) for _ in range(n)] so that all emitters "
+                "are unique instances.")
+
         self._solution_dim = emitters[0].solution_dim
 
         for idx, emitter in enumerate(emitters[1:]):

--- a/ribs/optimizers/_optimizer.py
+++ b/ribs/optimizers/_optimizer.py
@@ -19,7 +19,7 @@ class Optimizer:
     .. warning:: If you are constructing many emitters at once, do not do
         something like ``[EmitterClass(...)] * 5``, as this creates a list with
         the same instance of ``EmitterClass`` in each position. Instead, use
-        ``[EmitterClass(...) for _ in range 5]``, which creates 5 separate
+        ``[EmitterClass(...) for _ in range 5]``, which creates 5 unique
         instances of ``EmitterClass``.
 
     Args:
@@ -32,7 +32,7 @@ class Optimizer:
             dimensions.
         ValueError: There is no emitter passed in.
         ValueError: The same emitter instance was passed in multiple times. Each
-            emitter should be a separate instance (see the warning above).
+            emitter should be a unique instance (see the warning above).
     """
 
     def __init__(self, archive, emitters):

--- a/tests/core/optimizers/optimizer_test.py
+++ b/tests/core/optimizers/optimizer_test.py
@@ -23,6 +23,17 @@ def test_init_fails_with_no_emitters():
         Optimizer(archive, emitters)
 
 
+def test_init_fails_on_non_unique_emitter_instances():
+    archive = GridArchive([100, 100], [(-1, 1), (-1, 1)])
+
+    # All emitters are the same object. This is bad because the same emitter
+    # gets called multiple times.
+    emitters = [GaussianEmitter(archive, [0.0, 0.0], 1, batch_size=1)] * 5
+
+    with pytest.raises(ValueError):
+        Optimizer(archive, emitters)
+
+
 def test_init_fails_with_mismatched_emitters():
     archive = GridArchive([100, 100], [(-1, 1), (-1, 1)])
     emitters = [
@@ -88,14 +99,3 @@ def test_tell_fails_when_ask_not_called(_optimizer_fixture):
     optimizer, _ = _optimizer_fixture
     with pytest.raises(RuntimeError):
         optimizer.tell(None, None)
-
-
-def test_using_the_same_emitter_fails():
-    archive = GridArchive([100, 100], [(-1, 1), (-1, 1)])
-
-    # All emitters are the same object. This is bad because the same emitter
-    # gets called multiple times.
-    emitters = [GaussianEmitter(archive, [0.0, 0.0], 1, batch_size=1)] * 5
-
-    with pytest.raises(ValueError):
-        Optimizer(archive, emitters)

--- a/tests/core/optimizers/optimizer_test.py
+++ b/tests/core/optimizers/optimizer_test.py
@@ -64,7 +64,7 @@ def test_tell_inserts_solutions_into_archive(_optimizer_fixture):
     assert len(optimizer.archive.as_pandas()) == num_solutions
 
 
-def test_tell_inserts_solutions_with_multiple_emitters(_optimizer_fixture):
+def test_tell_inserts_solutions_with_multiple_emitters():
     archive = GridArchive([100, 100], [(-1, 1), (-1, 1)])
     emitters = [
         GaussianEmitter(archive, [0.0, 0.0], 1, batch_size=1),
@@ -88,3 +88,14 @@ def test_tell_fails_when_ask_not_called(_optimizer_fixture):
     optimizer, _ = _optimizer_fixture
     with pytest.raises(RuntimeError):
         optimizer.tell(None, None)
+
+
+def test_using_the_same_emitter_fails():
+    archive = GridArchive([100, 100], [(-1, 1), (-1, 1)])
+
+    # All emitters are the same object. This is bad because the same emitter
+    # gets called multiple times.
+    emitters = [GaussianEmitter(archive, [0.0, 0.0], 1, batch_size=1)] * 5
+
+    with pytest.raises(ValueError):
+        Optimizer(archive, emitters)

--- a/tests/core/optimizers/optimizer_test.py
+++ b/tests/core/optimizers/optimizer_test.py
@@ -26,7 +26,7 @@ def test_init_fails_with_no_emitters():
 def test_init_fails_on_non_unique_emitter_instances():
     archive = GridArchive([100, 100], [(-1, 1), (-1, 1)])
 
-    # All emitters are the same object. This is bad because the same emitter
+    # All emitters are the same instance. This is bad because the same emitter
     # gets called multiple times.
     emitters = [GaussianEmitter(archive, [0.0, 0.0], 1, batch_size=1)] * 5
 


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the PR's purpose here. -->

Users were previously able to do something like:

```python
emitters = [GaussianEmitter(...)] * 5
optimizer = Optimizer(archive, emitters)
```

However, this is incorrect because `emitters` now contains 5 of the same instance of `GaussianEmitter`, when it should really contain 5 unique instances, which one would get if they instead did:

```python
emitters = [GaussianEmitter(...) for _ in range(5)]
```

This PR makes sure `Optimizer` cannot take in an `emitters` list where any of the members have the same `id()`.

## Changelog Description

<!-- Please provide a one-line description we can use in the changelog. -->

Fixed a bug where Optimizer is able to take in non-unique emitter instances

## TODO

<!-- Notable points that this PR has either accomplished or will accomplish. -->

- [x] Add test for this bug
- [x] Fix the bug
- [x] Add warning in documentation

## Questions

<!-- Any concerns or points of confusion? -->

## Status

- [x] I have read the guidelines in
      [CONTRIBUTING.md](https://github.com/icaros-usc/pyribs/blob/master/CONTRIBUTING.md).
- [x] I have formatted my code using `yapf`
- [x] I have tested my code by running `pytest` (`tox` is run in CI/CD)
- [x] I have linted my code with `pylint`
- [x] This PR is ready to go
