### PR TITLE
Add coverage test and fix GridArchive epsilon bug

### DIFF
--- a/ribs/archives/_grid_archive.py
+++ b/ribs/archives/_grid_archive.py
@@ -4,7 +4,7 @@ from numba import jit
 
 from ribs.archives._archive_base import ArchiveBase, require_init
 
-_EPSILON = 1e-9
+_EPSILON = 1e-6
 
 
 class GridArchive(ArchiveBase):

--- a/tox.ini
+++ b/tox.ini
@@ -32,4 +32,4 @@ commands =
     pip install -U pip
     ribs_core: pytest --basetemp={envtmpdir} tests/core
     ribs_extras: pytest --basetemp={envtmpdir} tests/extras
-    ribs_coverage: pytest --basetemp={envtmpdir} -c pytest_no_benchmark.ini tests
+    ribs_coverage: NUMBA_DISABLE_JIT=1 pytest --basetemp={envtmpdir} -c pytest_no_benchmark.ini tests

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py36,py37,py38}-ribs_{core,extras}, pylint
+envlist = {py36,py37,py38}-ribs_{core,extras,coverage}, pylint
 
 [gh-actions]
 python =
@@ -22,7 +22,9 @@ deps =
     .[dev]
     ribs_core: .
     ribs_extras: .[all]
+    ribs_coverage: .[all]
 commands =
     pip install -U pip
     ribs_core: pytest --basetemp={envtmpdir} tests/core
     ribs_extras: pytest --basetemp={envtmpdir} tests/extras
+    ribs_coverage: pytest --basetemp={envtmpdir} -c pytest_no_benchmark.ini tests

--- a/tox.ini
+++ b/tox.ini
@@ -1,3 +1,8 @@
+# Tests for CI.
+# - core: ribs core (e.g. archive, emitters, optimizers)
+# - extras: ribs extras (e.g. visualize)
+# - coverage: everything, but with Numba disabled so we can check test coverage
+
 [tox]
 envlist = {py36,py37,py38}-ribs_{core,extras,coverage}, pylint
 

--- a/tox.ini
+++ b/tox.ini
@@ -23,6 +23,7 @@ commands = pylint ribs tests
 [testenv]
 setenv =
     PYTHONPATH = {toxinidir}
+    ribs_coverage: NUMBA_DISABLE_JIT=1
 deps =
     .[dev]
     ribs_core: .
@@ -32,4 +33,4 @@ commands =
     pip install -U pip
     ribs_core: pytest --basetemp={envtmpdir} tests/core
     ribs_extras: pytest --basetemp={envtmpdir} tests/extras
-    ribs_coverage: NUMBA_DISABLE_JIT=1 pytest --basetemp={envtmpdir} -c pytest_no_benchmark.ini tests
+    ribs_coverage: pytest --basetemp={envtmpdir} -c pytest_no_benchmark.ini tests


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the PR's purpose here. -->

Add step in CI for checking test coverage, which requires disabling numba so that functions can be inspected. Found a bug with GridArchive not working when numba is disabled, so fixed that too.

## Changelog Description

<!-- Please provide a one-line description we can use in the changelog. -->

Fixed a bug where GridArchive failed for float32 due to a small epsilon

## TODO

<!-- Notable points that this PR has either accomplished or will accomplish. -->

## Questions

<!-- Any concerns or points of confusion? -->

## Status

- [x] I have read the guidelines in
      [CONTRIBUTING.md](https://github.com/icaros-usc/pyribs/blob/master/CONTRIBUTING.md).
- [x] I have formatted my code using `yapf`
- [x] I have tested my code by running `pytest` (`tox` is run in CI/CD)
- [x] I have linted my code with `pylint`
- [x] This PR is ready to go
