### PR TITLE
Add clearer error messages for archives

### DIFF
--- a/ribs/archives/_cvt_archive.py
+++ b/ribs/archives/_cvt_archive.py
@@ -139,7 +139,7 @@ class CVTArchive(ArchiveBase):
                 if samples.shape[1] != self._behavior_dim:
                     raise ValueError(
                         f"Samples has shape {samples.shape} but must be of "
-                        f"shape (n_samples, {self._behavior_dim})")
+                        f"shape (n_samples, len(ranges)={self._behavior_dim})")
             self._samples = samples
             self._centroids = None
         else:
@@ -148,7 +148,8 @@ class CVTArchive(ArchiveBase):
             if custom_centroids.shape != (bins, self._behavior_dim):
                 raise ValueError(
                     f"custom_centroids has shape {custom_centroids.shape} but "
-                    f"must be of shape ({bins}, {self._behavior_dim})")
+                    f"must be of shape (bins={bins}, len(ranges)="
+                    f"{self._behavior_dim})")
             self._centroids = custom_centroids
             self._samples = None
 

--- a/ribs/archives/_grid_archive.py
+++ b/ribs/archives/_grid_archive.py
@@ -33,6 +33,8 @@ class GridArchive(ArchiveBase):
         dtype (str or data-type): Data type of the solutions, objective values,
             and behavior values. We only support ``"f"`` / :class:`np.float32`
             and ``"d"`` / :class:`np.float64`.
+    Raises:
+        ValueError: ``dims`` and ``ranges`` are not the same length.
     """
 
     def __init__(self, dims, ranges, seed=None, dtype=np.float64):
@@ -47,6 +49,9 @@ class GridArchive(ArchiveBase):
         )
 
         ranges = list(zip(*ranges))
+        if len(self._dims) != len(ranges):
+            raise ValueError(f"dims (length {len(self._dims)}) and ranges "
+                             f"(length {len(ranges)}) must be the same length")
         self._lower_bounds = np.array(ranges[0], dtype=self.dtype)
         self._upper_bounds = np.array(ranges[1], dtype=self.dtype)
         self._interval_size = self._upper_bounds - self._lower_bounds

--- a/ribs/archives/_grid_archive.py
+++ b/ribs/archives/_grid_archive.py
@@ -39,19 +39,19 @@ class GridArchive(ArchiveBase):
 
     def __init__(self, dims, ranges, seed=None, dtype=np.float64):
         self._dims = np.array(dims)
-        behavior_dim = len(self._dims)
+        if len(self._dims) != len(ranges):
+            raise ValueError(f"dims (length {len(self._dims)}) and ranges "
+                             f"(length {len(ranges)}) must be the same length")
+
         ArchiveBase.__init__(
             self,
             storage_dims=tuple(self._dims),
-            behavior_dim=behavior_dim,
+            behavior_dim=len(self._dims),
             seed=seed,
             dtype=dtype,
         )
 
         ranges = list(zip(*ranges))
-        if len(self._dims) != len(ranges):
-            raise ValueError(f"dims (length {len(self._dims)}) and ranges "
-                             f"(length {len(ranges)}) must be the same length")
         self._lower_bounds = np.array(ranges[0], dtype=self.dtype)
         self._upper_bounds = np.array(ranges[1], dtype=self.dtype)
         self._interval_size = self._upper_bounds - self._lower_bounds

--- a/tests/core/archives/grid_archive_test.py
+++ b/tests/core/archives/grid_archive_test.py
@@ -2,7 +2,7 @@
 import numpy as np
 import pytest
 
-from ribs.archives import AddStatus
+from ribs.archives import AddStatus, GridArchive
 
 from .conftest import get_archive_data
 
@@ -20,6 +20,14 @@ def _assert_archive_has_entry(archive, indices, behavior_values,
     assert len(archive_df) == 1
     assert (archive_df.iloc[0] == (list(indices) + list(behavior_values) +
                                    [objective_value] + list(solution))).all()
+
+
+def test_fails_on_dim_mismatch():
+    with pytest.raises(ValueError):
+        GridArchive(
+            dims=[10] * 2,  # 2D space here.
+            ranges=[(-1, 1)] * 3,  # But 3D space here.
+        )
 
 
 def test_properties_are_correct(_data):


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the PR's purpose here. -->

## Changelog Description

<!-- Please provide a one-line description we can use in the changelog. -->

Added clearer error messages for archives

## TODO

<!-- Notable points that this PR has either accomplished or will accomplish. -->

- [x] Clearer CVTArchive error messages
- [x] Check for dim mismatch in GridArchive

## Questions

<!-- Any concerns or points of confusion? -->

## Status

- [x] I have read the guidelines in
      [CONTRIBUTING.md](https://github.com/icaros-usc/pyribs/blob/master/CONTRIBUTING.md).
- [x] I have formatted my code using `yapf`
- [x] I have tested my code by running `pytest` (`tox` is run in CI/CD)
- [x] I have linted my code with `pylint`
- [x] This PR is ready to go
