### PR TITLE
Make get_index() public in archives to emphasize each index's meaning

### DIFF
--- a/ribs/archives/_archive_base.py
+++ b/ribs/archives/_archive_base.py
@@ -94,7 +94,7 @@ class ArchiveBase(ABC):  # pylint: disable = too-many-instance-attributes
 
     - :meth:`__init__`: child classes must invoke this class's :meth:`__init__`
       with the appropriate arguments
-    - :meth:`_get_index`: this method returns an index into the arrays above
+    - :meth:`get_index`: this method returns an index into the arrays above
       when given the behavior values of a solution
     - :meth:`initialize`: since this method sets up the arrays described, child
       classes should invoke this in their own implementation -- however, child
@@ -250,7 +250,7 @@ class ArchiveBase(ABC):  # pylint: disable = too-many-instance-attributes
             [] for _ in range(len(self._storage_dims)))
 
     @abstractmethod
-    def _get_index(self, behavior_values):
+    def get_index(self, behavior_values):
         """Returns archive indices for the given behavior values.
 
         Indices must be either an int or a tuple of int.
@@ -341,7 +341,7 @@ class ArchiveBase(ABC):  # pylint: disable = too-many-instance-attributes
         solution = np.asarray(solution)
         behavior_values = np.asarray(behavior_values)
 
-        index = self._get_index(behavior_values)
+        index = self.get_index(behavior_values)
         old_objective = self._objective_values[index]
         was_inserted, already_occupied = self._add_numba(
             index, solution, objective_value, behavior_values, self._occupied,
@@ -388,7 +388,7 @@ class ArchiveBase(ABC):  # pylint: disable = too-many-instance-attributes
             ``sol, obj, beh, meta = archive.elite_with_behavior(...)`` still
             works).
         """
-        index = self._get_index(np.asarray(behavior_values))
+        index = self.get_index(np.asarray(behavior_values))
         if self._occupied[index]:
             return (self._solutions[index], self._objective_values[index],
                     self._behavior_values[index], self._metadata[index])

--- a/ribs/archives/_archive_base.py
+++ b/ribs/archives/_archive_base.py
@@ -260,7 +260,7 @@ class ArchiveBase(ABC):  # pylint: disable = too-many-instance-attributes
 
         Args:
             behavior_values (numpy.ndarray): (:attr:`behavior_dim`,) array of
-                behavior values for a solution.
+                coordinates in behavior space.
         Returns:
             int or tuple of int: Indices of the entry in the archive's storage
             arrays.

--- a/ribs/archives/_archive_base.py
+++ b/ribs/archives/_archive_base.py
@@ -131,7 +131,7 @@ class ArchiveBase(ABC):  # pylint: disable = too-many-instance-attributes
             value of each solution. This attribute is None until
             :meth:`initialize` is called.
         _behavior_values (numpy.ndarray): Float array storing the behavior
-            values of each solution. This attribute is None until
+            space coordinates of each solution. This attribute is None until
             :meth:`initialize` is called.
         _metadata (numpy.ndarray): Object array storing the metadata associated
             with each solution. This attribute is None until :meth:`initialize`

--- a/ribs/archives/_archive_base.py
+++ b/ribs/archives/_archive_base.py
@@ -86,19 +86,21 @@ class ArchiveBase(ABC):  # pylint: disable = too-many-instance-attributes
     | ``_metadata``          |  ``(*storage_dims)``               |
     +------------------------+------------------------------------+
 
-    All of these arrays are accessed by a common index. If we have index ``i``,
+    All of these arrays are accessed via a common index. If we have index ``i``,
     we access its solution at ``_solutions[i]``, its behavior values at
     ``_behavior_values[i]``, etc.
 
-    Thus, child classes typically override at least the following methods:
+    Thus, child classes typically override the following methods:
 
-    - :meth:`__init__`: child classes must invoke this class's :meth:`__init__`
-      with the appropriate arguments
-    - :meth:`get_index`: this method returns an index into the arrays above
-      when given the behavior values of a solution
-    - :meth:`initialize`: since this method sets up the arrays described, child
-      classes should invoke this in their own implementation -- however, child
-      classes may not need to override this method at all
+    - :meth:`__init__`: Child classes must invoke this class's :meth:`__init__`
+      with the appropriate arguments.
+    - :meth:`get_index`: Returns an index into the arrays above when given the
+      behavior values of a solution. Usually, the index has a meaning, e.g. in
+      :class:`~ribs.archives.CVTArchive` it is the index of a centroid. This
+      method should include an explanation of what the index means.
+    - :meth:`initialize`: By default, this method sets up the arrays described,
+      so child classes should invoke the parent implementation if they are
+      overriding it.
 
     .. note:: Attributes beginning with an underscore are only intended to be
         accessed by child classes (i.e. they are "protected" attributes).
@@ -126,7 +128,7 @@ class ArchiveBase(ABC):  # pylint: disable = too-many-instance-attributes
             themselves. This attribute is None until :meth:`initialize` is
             called.
         _objective_values (numpy.ndarray): Float array storing the objective
-            values of each solution. This attribute is None until
+            value of each solution. This attribute is None until
             :meth:`initialize` is called.
         _behavior_values (numpy.ndarray): Float array storing the behavior
             values of each solution. This attribute is None until
@@ -253,9 +255,15 @@ class ArchiveBase(ABC):  # pylint: disable = too-many-instance-attributes
     def get_index(self, behavior_values):
         """Returns archive indices for the given behavior values.
 
-        Indices must be either an int or a tuple of int.
+        See the main :class:`~ribs.archives.ArchiveBase` docstring for more
+        info.
 
-        :meta public:
+        Args:
+            behavior_values (numpy.ndarray): (:attr:`behavior_dim`,) array of
+                behavior values for a solution.
+        Returns:
+            int or tuple of int: Indices of the entry in the archive's storage
+            arrays.
         """
 
     @staticmethod
@@ -465,7 +473,8 @@ class ArchiveBase(ABC):  # pylint: disable = too-many-instance-attributes
 
                 **all_indices** (:class:`list` -- shape (n_entries,)): Index of
                 all entries in the archive. As each index can be either an int
-                or a tuple, this is a Python list.
+                or a tuple, this is a Python list. See :meth:`get_index` for
+                more info.
 
                 **all_metadata** (:class:`numpy.ndarray` -- shape (n_entries,)):
                 Object array with metadata of all entries.
@@ -484,10 +493,8 @@ class ArchiveBase(ABC):  # pylint: disable = too-many-instance-attributes
         - ``len(self._storage_dims)`` columns for the index, named
           ``index_0, index_1, ...`` In :class:`~ribs.archives.GridArchive` and
           :class:`~ribs.archives.SlidingBoundariesArchive`, there are
-          :attr:`behavior_dim` columns, and the indices correspond to the bins
-          of the entries. In :class:`~ribs.archives.CVTArchive`,
-          there is just one column, and the index is the index of the entry's
-          centroid in :attr:`~ribs.archives.CVTArchive.centroids`.
+          :attr:`behavior_dim` columns. In :class:`~ribs.archives.CVTArchive`,
+          there is just one column. See :meth:`get_index` for more info.
         - ``self._behavior_dim`` columns for the behavior characteristics, named
           ``behavior_0, behavior_1, ...``
         - 1 column for the objective values, named ``objective``

--- a/ribs/archives/_cvt_archive.py
+++ b/ribs/archives/_cvt_archive.py
@@ -241,8 +241,8 @@ class CVTArchive(ArchiveBase):
         """Finds the index of the centroid closest to the behavior values.
 
         If ``idx`` is the index returned by this method for some behavior values
-        ``beh``, then ``archive.centroids[idx]`` (see :attr:`centroids`) is the
-        coordinates of the centroid closest to ``beh``.
+        ``beh``, then ``archive.centroids[idx]`` holds the coordinates of the
+        centroid closest to ``beh``. See :attr:`centroids` for more info.
 
         The centroid index is located using either the k-D tree or brute force,
         depending on the value of ``use_kd_tree`` in the constructor.

--- a/ribs/archives/_cvt_archive.py
+++ b/ribs/archives/_cvt_archive.py
@@ -237,11 +237,8 @@ class CVTArchive(ArchiveBase):
         distances = np.sum(np.square(distances), axis=1)
         return np.argmin(distances)
 
-    def _get_index(self, behavior_values):
-        """Finds the centroid index using either the k-D tree or brute force.
-
-        :meta private:
-        """
+    def get_index(self, behavior_values):
+        """Finds the centroid index using either the k-D tree or brute force."""
         if self._use_kd_tree:
             return self._centroid_kd_tree.query(behavior_values)[1]
 

--- a/ribs/archives/_cvt_archive.py
+++ b/ribs/archives/_cvt_archive.py
@@ -43,10 +43,10 @@ class CVTArchive(ArchiveBase):
     Finally, if running multiple experiments, it may be beneficial to use the
     same centroids across each experiment. Doing so can keep experiments
     consistent and reduce execution time. To do this, either 1) construct custom
-    centroids centroids and pass them in via the ``custom_centroids`` argument,
-    or 2) access the centroids created in the first archive with
-    :attr:`centroids` and pass them into ``custom_centroids`` when constructing
-    archives for subsequent experiments.
+    centroids and pass them in via the ``custom_centroids`` argument, or 2)
+    access the centroids created in the first archive with :attr:`centroids` and
+    pass them into ``custom_centroids`` when constructing archives for
+    subsequent experiments.
 
     Args:
         bins (int): The number of bins to use in the archive, equivalent to the
@@ -82,8 +82,8 @@ class CVTArchive(ArchiveBase):
         ckdtree_kwargs (dict): kwargs for :class:`~scipy.spatial.cKDTree`. By
             default, we do not pass in any kwargs.
     Raises:
-        ValueError: The ``samples`` array or the ``custom_centroids`` array is
-            of the wrong dimensionality.
+        ValueError: The ``samples`` array or the ``custom_centroids`` array has
+            the wrong shape.
     """
 
     def __init__(self,
@@ -176,8 +176,8 @@ class CVTArchive(ArchiveBase):
     @property
     @require_init
     def centroids(self):
-        """(num_centroids, behavior_dim) numpy.ndarray: The centroids used in
-        the CVT.
+        """(n_centroids, :attr:`behavior_dim`) numpy.ndarray: The centroids used
+        in the CVT.
 
         None until :meth:`initialize` is called.
         """
@@ -238,7 +238,21 @@ class CVTArchive(ArchiveBase):
         return np.argmin(distances)
 
     def get_index(self, behavior_values):
-        """Finds the centroid index using either the k-D tree or brute force."""
+        """Finds the index of the centroid closest to the behavior values.
+
+        If ``idx`` is the index returned by this method for some behavior values
+        ``beh``, then ``archive.centroids[idx]`` (see :attr:`centroids`) is the
+        coordinates of the centroid closest to ``beh``.
+
+        The centroid index is located using either the k-D tree or brute force,
+        depending on the value of ``use_kd_tree`` in the constructor.
+
+        Args:
+            behavior_values (numpy.ndarray): (:attr:`behavior_dim`,) array of
+                coordinates in behavior space.
+        Returns:
+            int: Centroid index.
+        """
         if self._use_kd_tree:
             return self._centroid_kd_tree.query(behavior_values)[1]
 

--- a/ribs/archives/_grid_archive.py
+++ b/ribs/archives/_grid_archive.py
@@ -121,9 +121,27 @@ class GridArchive(ArchiveBase):
         return index.astype(np.int32)
 
     def get_index(self, behavior_values):
-        """Retrieves grid indices.
+        """Returns indices of the entry within the archive's grid.
 
-        Clips behavior values to behavior bounds.
+        First, values are clipped to the bounds of the behavior space. Then, the
+        values are mapped to bins; e.g. bin 5 along dimension 0 and bin 3 along
+        dimension 1.
+
+        One use of the indices is for determining boundaries of a behavior
+        value's bin. For example, the following retrieves the lower and upper
+        bounds of the bin along dimension 0::
+
+            idx = archive.get_index(...)  # Other methods also return indices.
+            lower = archive.boundaries[0][idx[0]]
+            upper = archive.boundaries[0][idx[0] + 1]
+
+        See :attr:`boundaries` for more info.
+
+        Args:
+            behavior_values (numpy.ndarray): (:attr:`behavior_dim`,) array of
+                coordinates in behavior space.
+        Returns:
+            tuple of int: The grid indices.
         """
         index = GridArchive._get_index_numba(behavior_values,
                                              self._upper_bounds,

--- a/ribs/archives/_grid_archive.py
+++ b/ribs/archives/_grid_archive.py
@@ -105,9 +105,9 @@ class GridArchive(ArchiveBase):
     @jit(nopython=True)
     def _get_index_numba(behavior_values, upper_bounds, lower_bounds,
                          interval_size, dims):
-        """Numba helper for _get_index().
+        """Numba helper for get_index().
 
-        See _get_index() for usage.
+        See get_index() for usage.
         """
         # Adding epsilon to behavior values accounts for floating point
         # precision errors from transforming behavior values. Subtracting
@@ -120,10 +120,10 @@ class GridArchive(ArchiveBase):
         index = (behavior_values - lower_bounds) / interval_size * dims
         return index.astype(np.int32)
 
-    def _get_index(self, behavior_values):
-        """Retrieves grid indices. Clips behavior values to behavior bounds.
+    def get_index(self, behavior_values):
+        """Retrieves grid indices.
 
-        :meta private:
+        Clips behavior values to behavior bounds.
         """
         index = GridArchive._get_index_numba(behavior_values,
                                              self._upper_bounds,

--- a/ribs/archives/_grid_archive.py
+++ b/ribs/archives/_grid_archive.py
@@ -127,9 +127,9 @@ class GridArchive(ArchiveBase):
         values are mapped to bins; e.g. bin 5 along dimension 0 and bin 3 along
         dimension 1.
 
-        One use of the indices is for determining boundaries of a behavior
-        value's bin. For example, the following retrieves the lower and upper
-        bounds of the bin along dimension 0::
+        The indices can be used to access boundaries of a behavior value's bin.
+        For example, the following retrieves the lower and upper bounds of the
+        bin along dimension 0::
 
             idx = archive.get_index(...)  # Other methods also return indices.
             lower = archive.boundaries[0][idx[0]]

--- a/ribs/archives/_sliding_boundaries_archive.py
+++ b/ribs/archives/_sliding_boundaries_archive.py
@@ -243,7 +243,28 @@ class SlidingBoundariesArchive(ArchiveBase):
         return index
 
     def get_index(self, behavior_values):
-        """Index is determined based on sliding boundaries."""
+        """Returns indices of the entry within the archive's grid.
+
+        First, values are clipped to the bounds of the behavior space. The
+        values are mapped to bins via a binary search along the boundaries in
+        each dimension.
+
+        The indices can be used to access boundaries of a behavior value's bin.
+        For example, the following retrieves the lower and upper bounds of the
+        bin along dimension 0::
+
+            idx = archive.get_index(...)  # Other methods also return indices.
+            lower = archive.boundaries[0][idx[0]]
+            upper = archive.boundaries[0][idx[0] + 1]
+
+        See :attr:`boundaries` for more info.
+
+        Args:
+            behavior_values (numpy.ndarray): (:attr:`behavior_dim`,) array of
+                coordinates in behavior space.
+        Returns:
+            tuple of int: The grid indices.
+        """
         index = SlidingBoundariesArchive._get_index_numba(
             behavior_values, self.upper_bounds, self.lower_bounds,
             self._boundaries, self._dims)
@@ -298,11 +319,10 @@ class SlidingBoundariesArchive(ArchiveBase):
                                                      self._behavior_dim,
                                                      self.dims)
 
-        index_columns = tuple(map(list, zip(*self._occupied_indices)))
-        old_sols = self._solutions[index_columns].copy()
-        old_objs = self._objective_values[index_columns].copy()
-        old_behs = self._behavior_values[index_columns].copy()
-        old_metas = self._metadata[index_columns].copy()
+        old_sols = self._solutions[self._occupied_indices_cols].copy()
+        old_objs = self._objective_values[self._occupied_indices_cols].copy()
+        old_behs = self._behavior_values[self._occupied_indices_cols].copy()
+        old_metas = self._metadata[self._occupied_indices_cols].copy()
 
         self._reset_archive()
         for sol, obj, beh, meta in zip(old_sols, old_objs, old_behs, old_metas):

--- a/ribs/archives/_sliding_boundaries_archive.py
+++ b/ribs/archives/_sliding_boundaries_archive.py
@@ -229,9 +229,9 @@ class SlidingBoundariesArchive(ArchiveBase):
     @nb.jit(nopython=True)
     def _get_index_numba(behavior_values, upper_bounds, lower_bounds,
                          boundaries, dims):
-        """Numba helper for _get_index().
+        """Numba helper for get_index().
 
-        See _get_index() for usage.
+        See get_index() for usage.
         """
         behavior_values = np.minimum(
             np.maximum(behavior_values + _EPSILON, lower_bounds),
@@ -242,11 +242,8 @@ class SlidingBoundariesArchive(ArchiveBase):
             index.append(max(0, idx - 1))
         return index
 
-    def _get_index(self, behavior_values):
-        """Index is determined based on sliding boundaries.
-
-        :meta private:
-        """
+    def get_index(self, behavior_values):
+        """Index is determined based on sliding boundaries."""
         index = SlidingBoundariesArchive._get_index_numba(
             behavior_values, self.upper_bounds, self.lower_bounds,
             self._boundaries, self._dims)

--- a/ribs/archives/_sliding_boundaries_archive.py
+++ b/ribs/archives/_sliding_boundaries_archive.py
@@ -245,7 +245,7 @@ class SlidingBoundariesArchive(ArchiveBase):
     def get_index(self, behavior_values):
         """Returns indices of the entry within the archive's grid.
 
-        First, values are clipped to the bounds of the behavior space. The
+        First, values are clipped to the bounds of the behavior space. Then, the
         values are mapped to bins via a binary search along the boundaries in
         each dimension.
 

--- a/tests/emitters/conftest.py
+++ b/tests/emitters/conftest.py
@@ -19,12 +19,9 @@ def archive_fixture():
 class FakeArchive(ArchiveBase):
     """Bare-bones archive solely for emitter benchmarking.
 
-    Because this archive is used in emitter benchmarking, we want to
-    spend as little time in this archive as possible. Thus, the archive
-    functions are optimized for speed and not for any meaningful
-    functionality. That's why this is a "fake" archive.
-
-    Note that the get_index() method may not ever actually be called.
+    This archive is used in emitter benchmarking, so each method does as little
+    as possible. Since the methods have no meaningful functionality, this
+    archive is "fake."
     """
 
     def __init__(self, dims):

--- a/tests/emitters/conftest.py
+++ b/tests/emitters/conftest.py
@@ -24,7 +24,7 @@ class FakeArchive(ArchiveBase):
     functions are optimized for speed and not for any meaningful
     functionality. That's why this is a "fake" archive.
 
-    Note that the _get_index() method may not ever actually be called.
+    Note that the get_index() method may not ever actually be called.
     """
 
     def __init__(self, dims):
@@ -48,7 +48,7 @@ class FakeArchive(ArchiveBase):
         return True
 
     @jit(nopython=True)
-    def _get_index(self, behavior_values):
+    def get_index(self, behavior_values):
         return np.full_like(behavior_values, 0)
 
     def as_pandas(self):


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the PR's purpose here. -->

By making get_index() public, we have a method that we can link to when we say "this is what the index for this archive means." Furthermore, it will be less awkward for users to override `get_index`, as they will not be overriding a private method.

## Changelog Description

<!-- Please provide a one-line description we can use in the changelog. -->

Make get_index() public in archives to emphasize each index's meaning (#128)

## TODO

<!-- Notable points that this PR has either accomplished or will accomplish. -->

- [x] Rename `_get_index` to `get_index`
- [x] Explain meaning of each index
- [x] Refer to `get_index` in docstrings (read thru all archive docstrings)

## Questions

<!-- Any concerns or points of confusion? -->

## Status

- [x] I have read the guidelines in
      [CONTRIBUTING.md](https://github.com/icaros-usc/pyribs/blob/master/CONTRIBUTING.md).
- [x] I have formatted my code using `yapf`
- [x] I have tested my code by running `pytest` (`tox` is run in CI/CD)
- [x] I have linted my code with `pylint`
- [x] This PR is ready to go
