### PR TITLE
Add index to get_random_elite() and elite_with_behavior() in archives

### DIFF
--- a/examples/tutorials/arm_repertoire.ipynb
+++ b/examples/tutorials/arm_repertoire.ipynb
@@ -429,8 +429,8 @@
     "fig, ax = plt.subplots(2, 2, figsize=(8, 8))\n",
     "ax = ax.ravel()\n",
     "for i in range(len(ax)):\n",
-    "    solution, objective, behavior, _ = archive.get_random_elite()\n",
-    "    visualize(solution, link_lengths, objective, ax[i])"
+    "    sol, obj, *_ = archive.get_random_elite()\n",
+    "    visualize(sol, link_lengths, obj, ax[i])"
    ]
   },
   {
@@ -459,7 +459,7 @@
     }
    ],
    "source": [
-    "sol, obj, beh, _ = archive.elite_with_behavior([0, 0])\n",
+    "sol, obj, *_ = archive.elite_with_behavior([0, 0])\n",
     "_, ax = plt.subplots()\n",
     "if sol is not None:\n",
     "    visualize(sol, link_lengths, obj, ax)"

--- a/examples/tutorials/lunar_lander.ipynb
+++ b/examples/tutorials/lunar_lander.ipynb
@@ -496,7 +496,7 @@
     }
    ],
    "source": [
-    "sol, obj, beh, _ = archive.elite_with_behavior([-0.4, -0.10])\n",
+    "sol, *_ = archive.elite_with_behavior([-0.4, -0.10])\n",
     "if sol is not None:\n",
     "    display_video(sol)"
    ]
@@ -530,7 +530,7 @@
     }
    ],
    "source": [
-    "sol, obj, beh, _ = archive.elite_with_behavior([0.4, -0.10])\n",
+    "sol, *_ = archive.elite_with_behavior([0.4, -0.10])\n",
     "if sol is not None:\n",
     "    display_video(sol)"
    ]
@@ -564,7 +564,7 @@
     }
    ],
    "source": [
-    "sol, obj, beh, _ = archive.elite_with_behavior([0.0, -0.10])\n",
+    "sol, *_ = archive.elite_with_behavior([0.0, -0.10])\n",
     "if sol is not None:\n",
     "    display_video(sol)"
    ]

--- a/ribs/archives/_cvt_archive.py
+++ b/ribs/archives/_cvt_archive.py
@@ -254,6 +254,6 @@ class CVTArchive(ArchiveBase):
             int: Centroid index.
         """
         if self._use_kd_tree:
-            return self._centroid_kd_tree.query(behavior_values)[1]
+            return int(self._centroid_kd_tree.query(behavior_values)[1])
 
-        return self._brute_force_nn_numba(behavior_values, self._centroids)
+        return int(self._brute_force_nn_numba(behavior_values, self._centroids))

--- a/ribs/archives/_cvt_archive.py
+++ b/ribs/archives/_cvt_archive.py
@@ -253,6 +253,7 @@ class CVTArchive(ArchiveBase):
         Returns:
             int: Centroid index.
         """
+        # We use int() here since these methods may return a numpy integer.
         if self._use_kd_tree:
             return int(self._centroid_kd_tree.query(behavior_values)[1])
 

--- a/tests/archives/archive_base_test.py
+++ b/tests/archives/archive_base_test.py
@@ -114,7 +114,11 @@ def test_elite_with_behavior_gets_correct_elite(data):
     assert (sol == data.solution).all()
     assert obj == data.objective_value
     assert (beh == data.behavior_values).all()
-    assert isinstance(idx, (int, tuple))  # Exact value depends on archive.
+    assert isinstance(idx, (
+        int,
+        np.integer,
+        tuple,
+    ))  # Exact value depends on archive.
     assert meta == data.metadata
 
 
@@ -133,7 +137,11 @@ def test_random_elite_gets_single_elite(data):
     assert np.all(sol == data.solution)
     assert obj == data.objective_value
     assert np.all(beh == data.behavior_values)
-    assert isinstance(idx, (int, tuple))  # Exact value depends on archive.
+    assert isinstance(idx, (
+        int,
+        np.integer,
+        tuple,
+    ))  # Exact value depends on archive.
     assert meta == data.metadata
 
 

--- a/tests/archives/archive_base_test.py
+++ b/tests/archives/archive_base_test.py
@@ -109,27 +109,31 @@ def test_solution_dim_correct(data):
 
 
 def test_elite_with_behavior_gets_correct_elite(data):
-    sol, obj, beh, meta = data.archive_with_entry.elite_with_behavior(
-        data.behavior_values)
+    (sol, obj, beh, idx,
+     meta) = data.archive_with_entry.elite_with_behavior(data.behavior_values)
     assert (sol == data.solution).all()
     assert obj == data.objective_value
     assert (beh == data.behavior_values).all()
+    assert isinstance(idx, (int, tuple))  # Exact value depends on archive.
     assert meta == data.metadata
 
 
 def test_elite_with_behavior_returns_none(data):
-    sol, obj, beh, meta = data.archive.elite_with_behavior(data.behavior_values)
+    (sol, obj, beh, idx,
+     meta) = data.archive.elite_with_behavior(data.behavior_values)
     assert sol is None
     assert obj is None
     assert beh is None
+    assert idx is None
     assert meta is None
 
 
 def test_random_elite_gets_single_elite(data):
-    sol, obj, beh, meta = data.archive_with_entry.get_random_elite()
+    sol, obj, beh, idx, meta = data.archive_with_entry.get_random_elite()
     assert np.all(sol == data.solution)
     assert obj == data.objective_value
     assert np.all(beh == data.behavior_values)
+    assert isinstance(idx, (int, tuple))  # Exact value depends on archive.
     assert meta == data.metadata
 
 

--- a/tests/archives/archive_base_test.py
+++ b/tests/archives/archive_base_test.py
@@ -114,11 +114,7 @@ def test_elite_with_behavior_gets_correct_elite(data):
     assert (sol == data.solution).all()
     assert obj == data.objective_value
     assert (beh == data.behavior_values).all()
-    assert isinstance(idx, (
-        int,
-        np.integer,
-        tuple,
-    ))  # Exact value depends on archive.
+    assert isinstance(idx, (int, tuple))  # Exact value depends on archive.
     assert meta == data.metadata
 
 
@@ -137,11 +133,7 @@ def test_random_elite_gets_single_elite(data):
     assert np.all(sol == data.solution)
     assert obj == data.objective_value
     assert np.all(beh == data.behavior_values)
-    assert isinstance(idx, (
-        int,
-        np.integer,
-        tuple,
-    ))  # Exact value depends on archive.
+    assert isinstance(idx, (int, tuple))  # Exact value depends on archive.
     assert meta == data.metadata
 
 


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the PR's purpose here. -->

Index can be useful, so this PR adds it to `get_random_elite()` and `elite_with_behavior()` in the archive. This also makes the methods consistent with the `data()` method.

## Changelog Description

<!-- Please provide a one-line description we can use in the changelog. -->

Add index to get_random_elite() and elite_with_behavior() in archives (#129)

## TODO

<!-- Notable points that this PR has either accomplished or will accomplish. -->

- [x] Add index to get_random_elite() and elite_with_behavior()
- [x] Fix calls to these methods in tests
- [x] Fix calls to these methods in examples / tutorials
- [x] Force CVTArchive to return int instead of sometimes returning np.integer

## Questions

<!-- Any concerns or points of confusion? -->

## Status

- [x] I have read the guidelines in
      [CONTRIBUTING.md](https://github.com/icaros-usc/pyribs/blob/master/CONTRIBUTING.md).
- [x] I have formatted my code using `yapf`
- [x] I have tested my code by running `pytest` (`tox` is run in CI/CD)
- [x] I have linted my code with `pylint`
- [x] This PR is ready to go
