### PR TITLE
Add len and iter methods to archives

### DIFF
--- a/docs/_templates/autosummary/class.rst
+++ b/docs/_templates/autosummary/class.rst
@@ -1,0 +1,39 @@
+{# Adapted from https://stackoverflow.com/questions/62142793/autosummary-generated-documentation-missing-all-dunder-methods-except-for-ini #}
+
+{{ fullname | escape | underline}}
+
+.. currentmodule:: {{ module }}
+
+.. autoclass:: {{ objname }}
+
+   {% block methods %}
+
+   {% if methods %}
+   .. rubric:: {{ _('Methods') }}
+
+   .. autosummary::
+   {% for item in all_methods %}
+      {%- if not item.startswith('_') or item in ['__len__',
+                                                  '__call__',
+                                                  '__next__',
+                                                  '__iter__',
+                                                  '__getitem__',
+                                                  '__setitem__',
+                                                  '__delitem__',
+                                                  ] %}
+      ~{{ name }}.{{ item }}
+      {%- endif -%}
+   {%- endfor %}
+   {% endif %}
+   {% endblock %}
+
+   {% block attributes %}
+   {% if attributes %}
+   .. rubric:: {{ _('Attributes') }}
+
+   .. autosummary::
+   {% for item in attributes %}
+      ~{{ name }}.{{ item }}
+   {%- endfor %}
+   {% endif %}
+   {% endblock %}

--- a/docs/_templates/autosummary/class.rst
+++ b/docs/_templates/autosummary/class.rst
@@ -1,4 +1,9 @@
-{# Adapted from https://stackoverflow.com/questions/62142793/autosummary-generated-documentation-missing-all-dunder-methods-except-for-ini #}
+{#
+  Adapted from
+  https://github.com/sphinx-doc/sphinx/blob/v3.2.1/sphinx/ext/autosummary/templates/autosummary/class.rst
+  and
+  https://stackoverflow.com/questions/62142793/autosummary-generated-documentation-missing-all-dunder-methods-except-for-ini
+#}
 
 {{ fullname | escape | underline}}
 

--- a/ribs/archives/_archive_base.py
+++ b/ribs/archives/_archive_base.py
@@ -282,7 +282,17 @@ class ArchiveBase(ABC):  # pylint: disable = too-many-instance-attributes
         return len(self._occupied_indices)
 
     def __iter__(self):
-        """Creates an iterator over the elites in the archive."""
+        """Creates an iterator over the :class:`Elite`'s in the archive.
+
+        Example:
+
+            ::
+
+                for elite in archive:
+                    elite.sol
+                    elite.obj
+                    ...
+        """
         require_init_inline(self)
         return ArchiveIterator(self)
 

--- a/ribs/archives/_archive_base.py
+++ b/ribs/archives/_archive_base.py
@@ -121,8 +121,8 @@ class ArchiveBase(ABC):  # pylint: disable = too-many-instance-attributes
     any additional metadata associated with the solution (object). In this
     class, the container is implemented with separate numpy arrays that share
     common dimensions. Using the ``storage_dims`` and ``behavior_dim`` arguments
-    in :meth:`__init__` and the ``solution_dim`` argument in ``initialize``,
-    these arrays are as follows:
+    in ``__init__`` and the ``solution_dim`` argument in ``initialize``, these
+    arrays are as follows:
 
     +------------------------+------------------------------------+
     | Name                   |  Shape                             |
@@ -144,8 +144,8 @@ class ArchiveBase(ABC):  # pylint: disable = too-many-instance-attributes
 
     Thus, child classes typically override the following methods:
 
-    - :meth:`__init__`: Child classes must invoke this class's :meth:`__init__`
-      with the appropriate arguments.
+    - ``__init__``: Child classes must invoke this class's ``__init__`` with the
+      appropriate arguments.
     - :meth:`get_index`: Returns an index into the arrays above when given the
       behavior values of a solution. Usually, the index has a meaning, e.g. in
       :class:`~ribs.archives.CVTArchive` it is the index of a centroid. This

--- a/tests/archives/archive_base_test.py
+++ b/tests/archives/archive_base_test.py
@@ -94,12 +94,9 @@ def test_iteration():
 
 
 def test_add_during_iteration():
+    # Even with just one entry, adding during iteration should still raise an
+    # error, just like it does in set.
     data = get_archive_data("GridArchive")
-    # Archive needs two elites so it can be interrupted.
-    data.archive_with_elite.add(data.solution, data.objective_value,
-                                -data.behavior_values)
-
-    assert len(data.archive_with_elite) == 2
     with pytest.raises(RuntimeError):
         for _ in data.archive_with_elite:
             data.archive_with_elite.add(data.solution, data.objective_value + 1,
@@ -108,11 +105,6 @@ def test_add_during_iteration():
 
 def test_clear_during_iteration():
     data = get_archive_data("GridArchive")
-    # Archive needs two elites so it can be interrupted.
-    data.archive_with_elite.add(data.solution, data.objective_value,
-                                -data.behavior_values)
-
-    assert len(data.archive_with_elite) == 2
     with pytest.raises(RuntimeError):
         for _ in data.archive_with_elite:
             data.archive_with_elite.clear()

--- a/tests/archives/archive_base_test.py
+++ b/tests/archives/archive_base_test.py
@@ -41,6 +41,12 @@ def test_random_buffer_not_repeating():
 #
 
 
+def test_iter_require_init():
+    archive = GridArchive([20, 20], [(-1, 1)] * 2)
+    with pytest.raises(RuntimeError):
+        iter(archive)
+
+
 def test_add_requires_init():
     archive = GridArchive([20, 20], [(-1, 1)] * 2)
     with pytest.raises(RuntimeError):
@@ -73,7 +79,47 @@ def test_invalid_dtype():
 
 
 #
-# ArchiveBase tests -- should work for all archive classes.
+# Tests for iteration -- only GridArchive for simplicity.
+#
+
+
+def test_iteration():
+    data = get_archive_data("GridArchive")
+    for elite in data.archive_with_elite:
+        assert np.isclose(elite.sol, data.solution).all()
+        assert np.isclose(elite.obj, data.objective_value).all()
+        assert np.isclose(elite.beh, data.behavior_values).all()
+        assert elite.idx == data.grid_indices
+        assert elite.meta == data.metadata
+
+
+def test_add_during_iteration():
+    data = get_archive_data("GridArchive")
+    # Archive needs two elites so it can be interrupted.
+    data.archive_with_elite.add(data.solution, data.objective_value,
+                                -data.behavior_values)
+
+    assert len(data.archive_with_elite) == 2
+    with pytest.raises(RuntimeError):
+        for _ in data.archive_with_elite:
+            data.archive_with_elite.add(data.solution, data.objective_value + 1,
+                                        data.behavior_values)
+
+
+def test_clear_during_iteration():
+    data = get_archive_data("GridArchive")
+    # Archive needs two elites so it can be interrupted.
+    data.archive_with_elite.add(data.solution, data.objective_value,
+                                -data.behavior_values)
+
+    assert len(data.archive_with_elite) == 2
+    with pytest.raises(RuntimeError):
+        for _ in data.archive_with_elite:
+            data.archive_with_elite.clear()
+
+
+#
+# General tests -- should work for all archive classes.
 #
 
 
@@ -81,6 +127,11 @@ def test_invalid_dtype():
 def data(request):
     """Provides data for testing all kinds of archives."""
     return get_archive_data(request.param)
+
+
+def test_length(data):
+    assert len(data.archive) == 0
+    assert len(data.archive_with_elite) == 1
 
 
 def test_archive_cannot_reinit(data):

--- a/tests/archives/sliding_boundaries_archive_test.py
+++ b/tests/archives/sliding_boundaries_archive_test.py
@@ -119,15 +119,13 @@ def test_initial_remap():
             archive.add([x, y], obj, [x, y])
 
     # There are 199 entries because the last entry has not been inserted.
-    # TODO(btjanaka): Use the archive.occupied property when it is available.
-    assert len(archive.as_pandas(include_solutions=False)) == 199
+    assert len(archive) == 199
 
     # Buffer should now have 231 entries; hence it remaps.
     archive.add([-1, -2], 1, [-1, -2])
     expected_bcs.append((-1, -2))
 
-    # TODO(btjanaka): Use the archive.occupied property when it is available.
-    assert len(archive.as_pandas(include_solutions=False)) == 200
+    assert len(archive) == 200
 
     # Since we passed in unique entries generated with linspace, the boundaries
     # should come from linspace.
@@ -174,8 +172,7 @@ def test_adds_solutions_from_old_archive():
         for y in np.linspace(-2, 2, 21):
             archive.add([x, y], 2, [x, y])
 
-    # TODO(btjanaka): Use the archive.occupied property when it is available.
-    assert len(archive.as_pandas(include_solutions=False)) == 200
+    assert len(archive) == 200
 
     # Archive gets remapped again, but it should maintain the same BCs since
     # solutions are the same. All the high-performing solutions should be
@@ -184,8 +181,7 @@ def test_adds_solutions_from_old_archive():
         for y in np.linspace(-2, 2, 21):
             archive.add([x, y], 1, [x, y])
 
-    # TODO(btjanaka): Use the archive.occupied property when it is available.
-    assert len(archive.as_pandas(include_solutions=False)) == 200
+    assert len(archive) == 200
 
     # The objective values from the previous archive should remain because they
     # are higher.


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the PR's purpose here. -->

The iterator goes through all elites in the archive. Given this, it makes sense for len to be the number of elites in the archive. Resolves #124

## Changelog Description

<!-- Please provide a one-line description we can use in the changelog. -->
Add len and iter methods to archives (#151)

## TODO

<!-- Notable points that this PR has either accomplished or will accomplish. -->

- [x] Add and test iter method
- [x] Add and test len method
- [x] Resolve issues with len in SlidingBoundariesArchive test
- [x] Modify docs to show special methods

## Questions

<!-- Any concerns or points of confusion? -->

## Status

- [x] I have read the guidelines in
      [CONTRIBUTING.md](https://github.com/icaros-usc/pyribs/blob/master/CONTRIBUTING.md).
- [x] I have formatted my code using `yapf`
- [x] I have tested my code by running `pytest`
- [x] I have linted my code with `pylint`
- [x] This PR is ready to go
