### PR TITLE
Detect more complicated changes in archive during iteration

### DIFF
--- a/tests/archives/archive_base_test.py
+++ b/tests/archives/archive_base_test.py
@@ -110,6 +110,15 @@ def test_clear_during_iteration():
             data.archive_with_elite.clear()
 
 
+def test_clear_and_add_during_iteration():
+    data = get_archive_data("GridArchive")
+    with pytest.raises(RuntimeError):
+        for _ in data.archive_with_elite:
+            data.archive_with_elite.clear()
+            data.archive_with_elite.add(data.solution, data.objective_value + 1,
+                                        data.behavior_values)
+
+
 #
 # General tests -- should work for all archive classes.
 #


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the PR's purpose here. -->

Previously, I only counted calls to add() -- but it is possible to clear() and then add() again, which would change the archive. This PR detects that by having the state count calls to both clear() and add().

## Changelog Description

<!-- Please provide a one-line description we can use in the changelog. -->

(followup to #151)

## TODO

<!-- Notable points that this PR has either accomplished or will accomplish. -->

## Questions

<!-- Any concerns or points of confusion? -->

## Status

- [x] I have read the guidelines in
      [CONTRIBUTING.md](https://github.com/icaros-usc/pyribs/blob/master/CONTRIBUTING.md).
- [x] I have formatted my code using `yapf`
- [x] I have tested my code by running `pytest`
- [x] I have linted my code with `pylint`
- [x] This PR is ready to go
