### PR TITLE
Move archive statistics to namedtuple attribute

### DIFF
--- a/ribs/archives/__init__.py
+++ b/ribs/archives/__init__.py
@@ -13,9 +13,11 @@
     ribs.archives.ArchiveBase
     ribs.archives.AddStatus
     ribs.archives.Elite
+    ribs.archives.ArchiveStats
 """
 from ribs.archives._add_status import AddStatus
 from ribs.archives._archive_base import ArchiveBase
+from ribs.archives._archive_stats import ArchiveStats
 from ribs.archives._cvt_archive import CVTArchive
 from ribs.archives._elite import Elite
 from ribs.archives._grid_archive import GridArchive
@@ -28,4 +30,5 @@ __all__ = [
     "ArchiveBase",
     "AddStatus",
     "Elite",
+    "ArchiveStats",
 ]

--- a/ribs/archives/_archive_base.py
+++ b/ribs/archives/_archive_base.py
@@ -397,8 +397,7 @@ class ArchiveBase(
     @property
     @require_init
     def coverage(self):
-        """:attr:`dtype`: Proportion of bins in the archive that are currently
-        occupied.
+        """:attr:`dtype`: Proportion of bins in the archive that have an elite.
 
         This will be a value in the range :math:`[0,1]`
         """
@@ -407,19 +406,19 @@ class ArchiveBase(
     @property
     @require_init
     def qd_score(self):
-        """:attr:`dtype`: QD score, i.e. sum of objective values
-        of all elites in the archive.
+        """:attr:`dtype`: QD score, i.e. sum of objective values of all elites
+        in the archive.
 
-        Note that this score only makes sense if objective values are all
-        non-negative.
+        .. note::
+
+            This score only makes sense if objective values are non-negative.
         """
         return self._qd_score
 
     @property
     @require_init
     def obj_max(self):
-        """:attr:`dtype`: Maximum objective value of the elites currently in the
-        archive.
+        """:attr:`dtype`: Maximum objective value of the elites in the archive.
 
         This value is None if there are no elites in the archive.
         """
@@ -428,8 +427,7 @@ class ArchiveBase(
     @property
     @require_init
     def obj_mean(self):
-        """:attr:`dtype`: mean objective value of the elites currently in the
-        archive.
+        """:attr:`dtype`: mean objective value of the elites in the archive.
 
         This value is None if there are no elites in the archive.
         """

--- a/ribs/archives/_archive_base.py
+++ b/ribs/archives/_archive_base.py
@@ -422,7 +422,7 @@ class ArchiveBase(ABC):  # pylint: disable = too-many-instance-attributes
     def _stats_update(self, old_obj, new_obj):
         """Updates the archive stats when old_obj is replaced by new_obj.
 
-        A new object is created so that stats which have been collected
+        A new namedtuple is created so that stats which have been collected
         previously do not change.
         """
         new_qd_score = self._stats.qd_score + new_obj - old_obj

--- a/ribs/archives/_archive_stats.py
+++ b/ribs/archives/_archive_stats.py
@@ -5,7 +5,11 @@ import numpy as np
 
 
 class ArchiveStats(NamedTuple):
-    """Holds statistics about an archive."""
+    """Holds statistics about an archive.
+
+    Attributes of type :class:`~numpy.floating` will match the
+    :attr:`~ArchiveBase.dtype` of their archive.
+    """
 
     #: Number of elites in the archive.
     elites: int

--- a/ribs/archives/_archive_stats.py
+++ b/ribs/archives/_archive_stats.py
@@ -1,0 +1,27 @@
+"""Provides ArchiveStats."""
+from typing import NamedTuple
+
+import numpy as np
+
+
+class ArchiveStats(NamedTuple):
+    """Holds statistics about an archive."""
+
+    #: Number of elites in the archive.
+    elites: int
+
+    #: Proportion of bins in the archive that have an elite - always in the
+    #: range :math:`[0,1]`.
+    coverage: np.floating
+
+    #: QD score, i.e. sum of objective values of all elites in the archive.
+    #: **This score only makes sense if objective values are non-negative.**
+    qd_score: np.floating
+
+    #: Maximum objective value of the elites in the archive. None if there are
+    #: no elites in the archive.
+    obj_max: np.floating
+
+    #: Mean objective value of the elites in the archive. None if there are no
+    #: elites in the archive.
+    obj_mean: np.floating

--- a/tests/archives/archive_base_test.py
+++ b/tests/archives/archive_base_test.py
@@ -155,6 +155,7 @@ def test_clear_and_add_during_iteration():
                          ids=["float64", "float32"])
 def test_stats_dtype(dtype):
     data = get_archive_data("GridArchive", dtype=dtype)
+    assert isinstance(data.archive_with_elite.stats.elites, int)
     assert isinstance(data.archive_with_elite.stats.coverage, dtype)
     assert isinstance(data.archive_with_elite.stats.qd_score, dtype)
     assert isinstance(data.archive_with_elite.stats.obj_max, dtype)

--- a/tests/archives/archive_base_test.py
+++ b/tests/archives/archive_base_test.py
@@ -155,11 +155,10 @@ def test_clear_and_add_during_iteration():
                          ids=["float64", "float32"])
 def test_stats_dtype(dtype):
     data = get_archive_data("GridArchive", dtype=dtype)
-    assert isinstance(data.archive_with_elite.coverage, dtype)
-    assert isinstance(data.archive_with_elite.qd_score, dtype)
-    assert isinstance(data.archive_with_elite.obj_max, dtype)
-    print(type(data.archive_with_elite.obj_mean))
-    assert isinstance(data.archive_with_elite.obj_mean, dtype)
+    assert isinstance(data.archive_with_elite.stats.coverage, dtype)
+    assert isinstance(data.archive_with_elite.stats.qd_score, dtype)
+    assert isinstance(data.archive_with_elite.stats.obj_max, dtype)
+    assert isinstance(data.archive_with_elite.stats.obj_mean, dtype)
 
 
 def test_stats_multiple_add():
@@ -169,10 +168,11 @@ def test_stats_multiple_add():
     archive.add([1, 2, 3], 2.0, [0.25, 0.25])
     archive.add([1, 2, 3], 3.0, [-0.25, -0.25])
 
-    assert np.isclose(archive.coverage, 3 / 200)
-    assert np.isclose(archive.qd_score, 6.0)
-    assert np.isclose(archive.obj_max, 3.0)
-    assert np.isclose(archive.obj_mean, 2.0)
+    assert archive.stats.elites == 3
+    assert np.isclose(archive.stats.coverage, 3 / 200)
+    assert np.isclose(archive.stats.qd_score, 6.0)
+    assert np.isclose(archive.stats.obj_max, 3.0)
+    assert np.isclose(archive.stats.obj_mean, 2.0)
 
 
 def test_stats_add_and_overwrite():
@@ -183,10 +183,11 @@ def test_stats_add_and_overwrite():
     archive.add([1, 2, 3], 3.0, [-0.25, -0.25])
     archive.add([1, 2, 3], 5.0, [0.25, 0.25])  # Overwrites the second add().
 
-    assert np.isclose(archive.coverage, 3 / 200)
-    assert np.isclose(archive.qd_score, 9.0)
-    assert np.isclose(archive.obj_max, 5.0)
-    assert np.isclose(archive.obj_mean, 3.0)
+    assert archive.stats.elites == 3
+    assert np.isclose(archive.stats.coverage, 3 / 200)
+    assert np.isclose(archive.stats.qd_score, 9.0)
+    assert np.isclose(archive.stats.obj_max, 5.0)
+    assert np.isclose(archive.stats.obj_mean, 3.0)
 
 
 #
@@ -236,15 +237,17 @@ def test_solution_dim_correct(data):
 
 
 def test_basic_stats(data):
-    assert data.archive.coverage == 0.0
-    assert data.archive.qd_score == 0.0
-    assert data.archive.obj_max is None
-    assert data.archive.obj_mean is None
+    assert data.archive.stats.elites == 0
+    assert data.archive.stats.coverage == 0.0
+    assert data.archive.stats.qd_score == 0.0
+    assert data.archive.stats.obj_max is None
+    assert data.archive.stats.obj_mean is None
 
-    assert data.archive_with_elite.coverage == 1 / data.bins
-    assert data.archive_with_elite.qd_score == data.objective_value
-    assert data.archive_with_elite.obj_max == data.objective_value
-    assert data.archive_with_elite.obj_mean == data.objective_value
+    assert data.archive_with_elite.stats.elites == 1
+    assert data.archive_with_elite.stats.coverage == 1 / data.bins
+    assert data.archive_with_elite.stats.qd_score == data.objective_value
+    assert data.archive_with_elite.stats.obj_max == data.objective_value
+    assert data.archive_with_elite.stats.obj_mean == data.objective_value
 
 
 def test_elite_with_behavior_gets_correct_elite(data):


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the PR's purpose here. -->

To separate the statistics from the archive and cut down on the number of archive attributes, this PR moves the statistics to an ArchiveStats namedtuple.

A note on performance: The following benchmark code showed 3.89e-7 sec to construct one ArchiveStats on my computer:

```python
import timeit

from ribs.archives import ArchiveStats

n = 1000000
print(timeit.timeit(lambda: ArchiveStats(0, 1.0, 2.0, 3.0, 4.0), number=n) / n)
``` 

## Changelog Description

<!-- Please provide a one-line description we can use in the changelog. -->

Add statistics to archives (#100, #155)

## TODO

<!-- Notable points that this PR has either accomplished or will accomplish. -->

- [x] Add namedtuple
- [x] Move stats to namedtuple
- [x] Fix current usages

## Questions

<!-- Any concerns or points of confusion? -->

## Status

- [x] I have read the guidelines in
      [CONTRIBUTING.md](https://github.com/icaros-usc/pyribs/blob/master/CONTRIBUTING.md).
- [x] I have formatted my code using `yapf`
- [x] I have tested my code by running `pytest`
- [x] I have linted my code with `pylint`
- [ ] This PR is ready to go
