### PR TITLE
Fix video display for lunar lander in Colab

### DIFF
--- a/examples/tutorials/lunar_lander.ipynb
+++ b/examples/tutorials/lunar_lander.ipynb
@@ -432,6 +432,27 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    import google.colab\n",
+    "    print(\"Google Colab detected. Setting up display.\")\n",
+    "\n",
+    "    !apt-get install -y xvfb python-opengl\n",
+    "    %pip install pyvirtualdisplay\n",
+    "    \n",
+    "    from pyvirtualdisplay import Display\n",
+    "\n",
+    "    display = Display(visible=0, size=(400, 300))\n",
+    "    display.start()\n",
+    "except ImportError:\n",
+    "    print(\"Not in Google Colab. Skipping display setup.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": 12,
    "metadata": {},
    "outputs": [],


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the PR's purpose here. -->

Resolves #160. Turns out we need to set up a virtual display for Python. I also added detection for Google Colab (basically, `try` to `import google.colab`) so that this code does not run on local notebooks.

## Changelog Description

<!-- Please provide a one-line description we can use in the changelog. -->

Fix video display for lunar lander in Colab (#163)

## TODO

<!-- Notable points that this PR has either accomplished or will accomplish. -->

- [x] Add display setup
- [x] Only setup display in Colab
- [x] Test on Colab -> https://colab.research.google.com/github/icaros-usc/pyribs/blob/lander-display/examples/tutorials/lunar_lander.ipynb

## Questions

<!-- Any concerns or points of confusion? -->

## Status

- [x] I have read the guidelines in
      [CONTRIBUTING.md](https://github.com/icaros-usc/pyribs/blob/master/CONTRIBUTING.md).
- [x] I have formatted my code using `yapf`
- [x] I have tested my code by running `pytest`
- [x] I have linted my code with `pylint`
- [x] This PR is ready to go
