### PR TITLE
Update rest of repo to remove 'all' extra

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,7 +48,6 @@ Ready to contribute? Here's how to set up pyribs for local development.
    cd pyribs
    conda create --prefix ./env python=3.7 # 3.7 is the minimum version pyribs supports.
    conda activate ./env
-   pip install -e .[all]
    pip install -e .[dev]
    ```
 
@@ -151,8 +150,8 @@ Tutorials are created in Jupyter notebooks that are stored under
 `examples/tutorials` in the repo. To create a tutorial:
 
 1. Write the notebook and save it under `examples/tutorials`.
-1. Use cell magic (e.g. `%pip install ribs[all]`) to install `ribs` or
-   `ribs[all]` and any other packages.
+1. Use cell magic (e.g. `%pip install ribs`) to install pyribs and other
+   dependencies.
    - Installation cells tend to produce a lot of output. Make sure to clear this
      output in Jupyter lab so that it does not clutter the documentation.
 1. Before the main loop of the QD algorithm, include a line like

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -12,7 +12,7 @@
 
 - Drop Python 3.6 and add Python 3.10 support (#181)
 - Add procedure for updating changelog (#182)
-- Add 'visualize' extra and remove 'all' extra (#183)
+- Add 'visualize' extra and remove 'all' extra (#183,#184)
 
 ## 0.4.0 (2021-07-19)
 

--- a/README.md
+++ b/README.md
@@ -143,61 +143,18 @@ For more information, refer to the [documentation](https://docs.pyribs.org/).
 ## Installation
 
 pyribs supports Python 3.7-3.10. Earlier Python versions may work but are not
-officially supported.
+officially supported. To find the installation command for your system
+(including for installing from source), visit the
+[installation selector](https://pyribs.org/#installation) on our website.
 
-To install from PyPI, run
-
-```bash
-pip install ribs
-```
-
-This command only installs dependencies for the core of pyribs. To install
-support tools like `ribs.visualize`, run
-
-```bash
-pip install ribs[all]
-```
-
-Equivalently, you can install the base version (equivalent to `ribs`) from Conda
-with
-
-```bash
-conda install -c conda-forge pyribs-base
-```
-
-The full version (equivalent to `ribs[all]`) can be installed with
-
-```bash
-conda install -c conda-forge pyribs
-```
-
-To test your installation, import it and print the version with:
+To test your installation, import pyribs and print the version with this
+command:
 
 ```bash
 python -c "import ribs; print(ribs.__version__)"
 ```
 
-You should see a version number like `0.2.0` in the output.
-
-### From Source
-
-To install a version from source, clone the repo
-
-```bash
-git clone https://github.com/icaros-usc/pyribs
-```
-
-Then `cd` into it
-
-```bash
-cd pyribs
-```
-
-And run
-
-```bash
-pip install -e .[all]
-```
+You should see a version number in the output.
 
 ## Documentation
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -5,5 +5,4 @@ several micro-benchmarks in our tests. This directory contains benchmarks that
 are too large to run as part of CI/CD.
 
 To run these benchmarks, install the dev dependencies for ribs
-(`pip install ribs[dev]` or `pip install -e .[dev]`). Also install the full
-version of ribs (`pip install -e ribs[all]` or `pip install -e .[all]`).
+(`pip install ribs[dev]` or `pip install -e .[dev]`).

--- a/examples/tutorials/arm_repertoire.ipynb
+++ b/examples/tutorials/arm_repertoire.ipynb
@@ -28,7 +28,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%pip install ribs[all]"
+    "%pip install ribs[visualize]"
    ]
   },
   {

--- a/examples/tutorials/lunar_lander.ipynb
+++ b/examples/tutorials/lunar_lander.ipynb
@@ -38,7 +38,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%pip install ribs[all] gym~=0.17.0 Box2D~=2.3.10 tqdm"
+    "%pip install ribs[visualize] gym~=0.17.0 Box2D~=2.3.10 tqdm"
    ]
   },
   {

--- a/ribs/visualize.py
+++ b/ribs/visualize.py
@@ -8,9 +8,9 @@ After plotting, functions like :func:`~matplotlib.pyplot.xlabel` and
 Alternatively, if using maplotlib's object-oriented API, pass the `ax` parameter
 to these functions.
 
-.. note:: This module only works with ``ribs[all]`` installed. As such, it is
-    not imported with ``import ribs``, and it must be explicitly imported with
-    ``import ribs.visualize``.
+.. note:: This module only works with ``ribs[visualize]`` installed. As such, it
+    is not imported with ``import ribs``, and it must be explicitly imported
+    with ``import ribs.visualize``.
 
 .. autosummary::
     :toctree:

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ install_requires = [
 extras_require = {
     "visualize": ["matplotlib>=3.0.0",],
     # Dependencies for examples (NOT tutorials -- tutorial notebooks should
-    # install deps with cell magic and only depend on ribs and ribs[all]).
+    # install deps with cell magic and only depend on ribs and ribs[visualize]).
     "examples": [
         "matplotlib>=3.0.0",
         "gym~=0.17.0",  # Strict since different gym may give different results.

--- a/tests/examples.sh
+++ b/tests/examples.sh
@@ -4,7 +4,7 @@
 # run.
 #
 # Usage:
-#   pip install .[all] .[examples]
+#   pip install .[visualize,examples]
 #   bash tests/examples.sh
 
 set -e  # Exit if any of the commands fail.

--- a/tests/tutorials.sh
+++ b/tests/tutorials.sh
@@ -5,7 +5,7 @@
 # notebook can be tested by passing in the name of the notebook.
 #
 # Usage:
-#   pip install .[all] jupyter nbconvert
+#   pip install .[visualize] jupyter nbconvert
 #   bash tests/tutorials.sh  # Test all tutorials.
 #   bash tests/tutorials.sh NOTEBOOK.ipynb  # Test a single notebook.
 


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the PR's purpose here. -->

Several files still referred to the `ribs[all]` extra. This PR removes those references.

## TODO

<!-- Notable points that this PR has either accomplished or will accomplish. -->

## Questions

<!-- Any concerns or points of confusion? -->

## Status

- [x] I have read the guidelines in
      [CONTRIBUTING.md](https://github.com/icaros-usc/pyribs/blob/master/CONTRIBUTING.md).
- [x] I have formatted my code using `yapf`
- [x] I have tested my code by running `pytest`
- [x] I have linted my code with `pylint`
- [x] I have added a one-line description of my change to the changelog in
      `HISTORY.md`
- [x] This PR is ready to go
