### PR TITLE
Fix readthedocs extras config

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -15,5 +15,5 @@ python:
     - method: pip
       path: .
       extra_requirements:
-        - all
+        - visualize
         - dev


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the PR's purpose here. -->

readthedocs was failing to build since it still used the `all` extra instead of `visualize`

Exclude from changelog.

## TODO

<!-- Notable points that this PR has either accomplished or will accomplish. -->

- [x] Test on ReadTheDocs

## Questions

<!-- Any concerns or points of confusion? -->

## Status

- [x] I have read the guidelines in [CONTRIBUTING.md](https://github.com/icaros-usc/pyribs/blob/master/CONTRIBUTING.md).
- [x] I have formatted my code using `yapf`
- [x] I have tested my code by running `pytest`
- [x] I have linted my code with `pylint`
- [x] I have added a one-line description of my change to the changelog in `HISTORY.md`.
- [x] This PR is ready to go
