### PR TITLE
Rename bins to cells for consistency with literature

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,7 +6,8 @@
 
 #### API
 
-- **Backwards-incompatible:** Rename bins to cells.
+- **Backwards-incompatible:** Rename bins to cells for consistency with
+  literature.
   - `ArchiveBase`
     - Rename `bins` property to `cells`
 - **Backwards-incompatible:** Only use integer indices in archives (#185)

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,6 +6,9 @@
 
 #### API
 
+- **Backwards-incompatible:** Rename bins to cells.
+  - `ArchiveBase`
+    - Rename `bins` property to `cells`
 - **Backwards-incompatible:** Only use integer indices in archives (#185)
   - `ArchiveBase`
     - Replaced `storage_dims` (tuple of int) with `storage_dim` (int)

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -8,8 +8,8 @@
 
 - **Backwards-incompatible:** Rename bins to cells for consistency with
   literature.
-  - `ArchiveBase`
-    - Rename `bins` property to `cells`
+  - Archive constructors now take in `cells` argument instead of `bins`
+  - Archive now have a `cells` property rather than a `bins` property
 - **Backwards-incompatible:** Only use integer indices in archives (#185)
   - `ArchiveBase`
     - Replaced `storage_dims` (tuple of int) with `storage_dim` (int)

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ If you use the CMA-ME algorithm, please also cite
 Here we show an example application of CMA-ME in pyribs. To initialize the
 algorithm, we first create:
 
-- A 2D **GridArchive** where each dimension contains 20 bins across the range
+- A 2D **GridArchive** where each dimension contains 20 cells across the range
   [-1, 1].
 - An **ImprovementEmitter**, which starts from the search point **0** in 10
   dimensional space and a Gaussian sampling distribution with standard deviation

--- a/benchmarks/cvt_add.py
+++ b/benchmarks/cvt_add.py
@@ -1,15 +1,15 @@
 """Compare performance of adding to the CVTArchive with and without k-D tree.
 
-In CVTArchive, we use a k-D tree to identify the bin by finding the nearest
+In CVTArchive, we use a k-D tree to identify the cell by finding the nearest
 centroid to a solution in behavior space. Though a k-D tree is theoretically
 more efficient than brute force, constant factors mean that brute force can be
-faster than k-D tree for smaller numbers of centroids / bins. In this script, we
-want to increase the number of bins in the archive and see when the k-D tree
+faster than k-D tree for smaller numbers of centroids / cells. In this script, we
+want to increase the number of cells in the archive and see when the k-D tree
 becomes faster than brute force.
 
 In this experiment, we construct archives with 10, 50, 100, 500, 1k, 5k, 10k,
-100k bins in the behavior space of [(-1, 1), (-1, 1)] and 100k samples (except
-for 10k bins, where we use 200k samples so that the CVT generation does not drop
+100k cells in the behavior space of [(-1, 1), (-1, 1)] and 100k samples (except
+for 10k cells, where we use 200k samples so that the CVT generation does not drop
 a cluster). In each archive, we then time how long it takes to add 100k random
 solutions sampled u.a.r. from the behavior space. We run each experiment with
 brute force and with the k-D tree, 5 times each, and take the minimum runtime
@@ -20,7 +20,7 @@ Usage:
 
 This script will run for a while (~30 min) and produce two outputs. The first is
 cvt_add_times.json, which holds the raw times. The second is cvt_add_plot.png,
-which is a plot of the times with respect to number of bins.
+which is a plot of the times with respect to number of cells.
 
 To re-plot the results without re-running the benchmarks, modify plot_times and
 run:
@@ -38,12 +38,15 @@ import numpy as np
 from ribs.archives import CVTArchive
 
 
-def save_times(n_bins, brute_force_t, kd_tree_t, filename="cvt_add_times.json"):
+def save_times(n_cells,
+               brute_force_t,
+               kd_tree_t,
+               filename="cvt_add_times.json"):
     """Saves a dict of the results to the given file."""
     with open(filename, "w") as file:
         json.dump(
             {
-                "n_bins": n_bins,
+                "n_cells": n_cells,
                 "brute_force_t": brute_force_t,
                 "kd_tree_t": kd_tree_t,
             }, file)
@@ -53,19 +56,19 @@ def load_times(filename="cvt_add_times.json"):
     """Loads the results from the given file."""
     with open(filename, "r") as file:
         data = json.load(file)
-        return data["n_bins"], data["brute_force_t"], data["kd_tree_t"]
+        return data["n_cells"], data["brute_force_t"], data["kd_tree_t"]
 
 
-def plot_times(n_bins, brute_force_t, kd_tree_t, filename="cvt_add_plot.png"):
+def plot_times(n_cells, brute_force_t, kd_tree_t, filename="cvt_add_plot.png"):
     """Plots the results to the given file."""
     fig, ax = plt.subplots(figsize=(4, 4))
     fig.tight_layout()
     ax.set_title("Runtime to insert 100k 2D entries into CVTArchive")
-    ax.set_xlabel("Archive bins")
+    ax.set_xlabel("Archive cells")
     ax.set_ylabel("Time (s)")
     ax.set_yscale("log")
-    ax.semilogx(n_bins, brute_force_t, "-o", label="Brute Force", c="#304FFE")
-    ax.semilogx(n_bins, kd_tree_t, "-o", label="k-D Tree", c="#e62020")
+    ax.semilogx(n_cells, brute_force_t, "-o", label="Brute Force", c="#304FFE")
+    ax.semilogx(n_cells, kd_tree_t, "-o", label="k-D Tree", c="#e62020")
     ax.grid(True, which="major", linestyle="--", linewidth=1)
     ax.legend(loc="upper left")
     fig.savefig(filename, bbox_inches="tight", dpi=120)
@@ -74,7 +77,7 @@ def plot_times(n_bins, brute_force_t, kd_tree_t, filename="cvt_add_plot.png"):
 def main():
     """Creates archives, times insertion into them, and plots results."""
     archive = None
-    n_bins = [10, 50, 100, 500, 1_000, 5_000, 10_000, 100_000]
+    n_cells = [10, 50, 100, 500, 1_000, 5_000, 10_000, 100_000]
 
     # Pre-made solutions to insert.
     n_vals = 100_000
@@ -83,23 +86,23 @@ def main():
     behavior_values = np.random.uniform(-1, 1, (n_vals, 2))
 
     # Set up these archives so we can use the same centroids across all
-    # experiments for a certain number of bins (and also save time).
+    # experiments for a certain number of cells (and also save time).
     ref_archives = {
-        bins: CVTArchive(
-            bins,
+        cells: CVTArchive(
+            cells,
             [(-1, 1), (-1, 1)],
-            # Use 200k bins to avoid dropping clusters.
-            samples=n_vals if bins != 10_000 else 200_000,
-            use_kd_tree=False) for bins in n_bins
+            # Use 200k cells to avoid dropping clusters.
+            samples=n_vals if cells != 10_000 else 200_000,
+            use_kd_tree=False) for cells in n_cells
     }
-    for bins, archive in ref_archives.items():
-        print(f"Setting up archive with {bins} bins")
+    for cells, archive in ref_archives.items():
+        print(f"Setting up archive with {cells} cells")
         archive.initialize(solutions.shape[1])
 
-    def setup(bins, use_kd_tree):
+    def setup(cells, use_kd_tree):
         nonlocal archive
-        archive = CVTArchive(bins, [(-1, 1), (-1, 1)],
-                             custom_centroids=ref_archives[bins].centroids,
+        archive = CVTArchive(cells, [(-1, 1), (-1, 1)],
+                             custom_centroids=ref_archives[cells].centroids,
                              use_kd_tree=use_kd_tree)
         archive.initialize(solutions.shape[1])
 
@@ -111,12 +114,12 @@ def main():
     # Run the timing.
     brute_force_t = []
     kd_tree_t = []
-    for bins in n_bins:
+    for cells in n_cells:
         for use_kd_tree in (False, True):
             print(f"--------------\n"
-                  f"Bins: {bins}\n"
+                  f"Cells: {cells}\n"
                   f"Method: {'k-D Tree' if use_kd_tree else 'Brute Force'}")
-            setup_func = partial(setup, bins, use_kd_tree)
+            setup_func = partial(setup, cells, use_kd_tree)
             res_t = min(
                 timeit.repeat(add_100k_entries, setup_func, repeat=5, number=1))
             print(f"Time: {res_t} s")
@@ -125,11 +128,11 @@ def main():
                 kd_tree_t.append(res_t)
             else:
                 brute_force_t.append(res_t)
-        save_times(n_bins, brute_force_t, kd_tree_t, "cvt_add_times.json")
+        save_times(n_cells, brute_force_t, kd_tree_t, "cvt_add_times.json")
 
     # Save the results.
-    plot_times(n_bins, brute_force_t, kd_tree_t)
-    save_times(n_bins, brute_force_t, kd_tree_t)
+    plot_times(n_cells, brute_force_t, kd_tree_t)
+    save_times(n_cells, brute_force_t, kd_tree_t)
 
 
 if __name__ == "__main__":

--- a/examples/lunar_lander.py
+++ b/examples/lunar_lander.py
@@ -147,7 +147,7 @@ def create_optimizer(seed, n_emitters, sigma0, batch_size):
     obs_dim = env.observation_space.shape[0]
 
     archive = GridArchive(
-        [50, 50],  # 50 bins in each dimension.
+        [50, 50],  # 50 cells in each dimension.
         [(-1.0, 1.0), (-3.0, 0.0)],  # (-1, 1) for x-pos and (-3, 0) for y-vel.
         seed=seed,
     )
@@ -284,7 +284,7 @@ def save_ccdf(archive, filename):
     https://en.wikipedia.org/wiki/Cumulative_distribution_function#Complementary_cumulative_distribution_function_(tail_distribution)).
     The CCDF plotted here is not normalized to the range (0,1). This may help
     when comparing CCDF's among archives with different amounts of coverage
-    (i.e. when one archive has more bins filled).
+    (i.e. when one archive has more cells filled).
 
     Args:
         archive (GridArchive): Archive with results from an experiment.
@@ -293,7 +293,7 @@ def save_ccdf(archive, filename):
     fig, ax = plt.subplots()
     ax.hist(
         archive.as_pandas(include_solutions=False)["objective"],
-        50,  # Number of bins.
+        50,  # Number of cells.
         histtype="step",
         density=False,
         cumulative=-1)  # CCDF rather than CDF.

--- a/examples/sphere.py
+++ b/examples/sphere.py
@@ -28,7 +28,7 @@ The supported algorithms are:
 All algorithms use 15 emitters, each with a batch size of 37. Each one runs for
 4500 iterations for a total of 15 * 37 * 4500 ~= 2.5M evaluations.
 
-Note that the CVTArchive in this example uses 10,000 bins, as opposed to the
+Note that the CVTArchive in this example uses 10,000 cells, as opposed to the
 250,000 (500x500) in the GridArchive, so it is not fair to directly compare
 `cvt_map_elites` and `line_cvt_map_elites` to the other algorithms. However, the
 other algorithms may be fairly compared because they use the same archive.

--- a/ribs/archives/_archive_base.py
+++ b/ribs/archives/_archive_base.py
@@ -114,29 +114,29 @@ class ArchiveIterator:
 class ArchiveBase(ABC):  # pylint: disable = too-many-instance-attributes
     """Base class for archives.
 
-    This class assumes all archives use a fixed-size container with bins that
-    hold (1) information about whether the bin is occupied (bool), (2) a
+    This class assumes all archives use a fixed-size container with cells that
+    hold (1) information about whether the cell is occupied (bool), (2) a
     solution (1D array), (3) objective function evaluation of the solution
     (float), (4) behavior space coordinates of the solution (1D array), and (5)
     any additional metadata associated with the solution (object). In this
     class, the container is implemented with separate numpy arrays that share
-    common dimensions. Using the ``storage_dim`` and ``behavior_dim`` arguments
-    in ``__init__`` and the ``solution_dim`` argument in ``initialize``, these
+    common dimensions. Using the ``cells`` and ``behavior_dim`` arguments in
+    ``__init__`` and the ``solution_dim`` argument in ``initialize``, these
     arrays are as follows:
 
-    +------------------------+----------------------------------+
-    | Name                   |  Shape                           |
-    +========================+==================================+
-    | ``_occupied``          |  ``(storage_dim)``               |
-    +------------------------+----------------------------------+
-    | ``_solutions``         |  ``(storage_dim, solution_dim)`` |
-    +------------------------+----------------------------------+
-    | ``_objective_values``  |  ``(storage_dim)``               |
-    +------------------------+----------------------------------+
-    | ``_behavior_values``   |  ``(storage_dim, behavior_dim)`` |
-    +------------------------+----------------------------------+
-    | ``_metadata``          |  ``(storage_dim)``               |
-    +------------------------+----------------------------------+
+    +------------------------+----------------------------+
+    | Name                   |  Shape                     |
+    +========================+============================+
+    | ``_occupied``          |  ``(cells)``               |
+    +------------------------+----------------------------+
+    | ``_solutions``         |  ``(cells, solution_dim)`` |
+    +------------------------+----------------------------+
+    | ``_objective_values``  |  ``(cells)``               |
+    +------------------------+----------------------------+
+    | ``_behavior_values``   |  ``(cells, behavior_dim)`` |
+    +------------------------+----------------------------+
+    | ``_metadata``          |  ``(cells)``               |
+    +------------------------+----------------------------+
 
     All of these arrays are accessed via a common integer index. If we have
     index ``i``, we access its solution at ``_solutions[i]``, its behavior
@@ -158,8 +158,8 @@ class ArchiveBase(ABC):  # pylint: disable = too-many-instance-attributes
         accessed by child classes (i.e. they are "protected" attributes).
 
     Args:
-        storage_dim (int): Primary dimension of the archive storage. This is
-            used to create the numpy arrays described above.
+        cells (int): Number of cells in the archive. This is used to create the
+            numpy arrays described above for storing archive info.
         behavior_dim (int): The dimension of the behavior space.
         seed (int): Value to seed the random number generator. Set to None to
             avoid a fixed seed.
@@ -169,11 +169,11 @@ class ArchiveBase(ABC):  # pylint: disable = too-many-instance-attributes
     Attributes:
         _rng (numpy.random.Generator): Random number generator, used in
             particular for generating random elites.
-        _storage_dim (int): See ``storage_dim`` arg.
+        _cells (int): See ``cells`` arg.
         _behavior_dim (int): See ``behavior_dim`` arg.
         _solution_dim (int): Dimension of the solution space, passed in with
             :meth:`initialize`.
-        _occupied (numpy.ndarray): Bool array storing whether each bin in the
+        _occupied (numpy.ndarray): Bool array storing whether each cell in the
             archive is occupied. This attribute is None until :meth:`initialize`
             is called.
         _solutions (numpy.ndarray): Float array storing the solutions
@@ -188,7 +188,7 @@ class ArchiveBase(ABC):  # pylint: disable = too-many-instance-attributes
         _metadata (numpy.ndarray): Object array storing the metadata associated
             with each solution. This attribute is None until :meth:`initialize`
             is called.
-        _occupied_indices (numpy.ndarray): A ``(storage_dim,)`` array of integer
+        _occupied_indices (numpy.ndarray): A ``(cells,)`` array of integer
             (``np.int32``) indices that are occupied in the archive. This could
             be a list, but for efficiency, we make it a fixed-size array, with
             only the first ``_num_occupied`` entries will be valid. This
@@ -197,12 +197,12 @@ class ArchiveBase(ABC):  # pylint: disable = too-many-instance-attributes
             used to index into ``_occupied_indices``.
     """
 
-    def __init__(self, storage_dim, behavior_dim, seed=None, dtype=np.float64):
+    def __init__(self, cells, behavior_dim, seed=None, dtype=np.float64):
 
         ## Intended to be accessed by child classes. ##
 
         self._rng = np.random.default_rng(seed)
-        self._storage_dim = storage_dim
+        self._cells = cells
         self._behavior_dim = behavior_dim
         self._solution_dim = None
         self._occupied = None
@@ -218,7 +218,6 @@ class ArchiveBase(ABC):  # pylint: disable = too-many-instance-attributes
         self._rand_buf = None
         self._seed = seed
         self._initialized = False
-        self._bins = self._storage_dim
         self._stats = None
 
         # Tracks archive modifications by counting calls to clear() and add().
@@ -254,9 +253,9 @@ class ArchiveBase(ABC):  # pylint: disable = too-many-instance-attributes
         return self._initialized
 
     @property
-    def bins(self):
-        """int: Total number of bins in the archive."""
-        return self._bins
+    def cells(self):
+        """int: Total number of cells in the archive."""
+        return self._cells
 
     @property
     def empty(self):
@@ -322,7 +321,7 @@ class ArchiveBase(ABC):  # pylint: disable = too-many-instance-attributes
         new_qd_score = self._stats.qd_score + new_obj - old_obj
         self._stats = ArchiveStats(
             num_elites=len(self),
-            coverage=self.dtype(len(self) / self.bins),
+            coverage=self.dtype(len(self) / self.cells),
             qd_score=new_qd_score,
             obj_max=new_obj if self._stats.obj_max is None else max(
                 self._stats.obj_max, new_obj),
@@ -346,14 +345,14 @@ class ArchiveBase(ABC):  # pylint: disable = too-many-instance-attributes
 
         self._rand_buf = RandomBuffer(self._seed)
         self._solution_dim = solution_dim
-        self._occupied = np.zeros(self._storage_dim, dtype=bool)
-        self._solutions = np.empty((self._storage_dim, solution_dim),
+        self._occupied = np.zeros(self._cells, dtype=bool)
+        self._solutions = np.empty((self._cells, solution_dim),
                                    dtype=self.dtype)
-        self._objective_values = np.empty(self._storage_dim, dtype=self.dtype)
-        self._behavior_values = np.empty(
-            (self._storage_dim, self._behavior_dim), dtype=self.dtype)
-        self._metadata = np.empty(self._storage_dim, dtype=object)
-        self._occupied_indices = np.empty(self._storage_dim, dtype=np.int32)
+        self._objective_values = np.empty(self._cells, dtype=self.dtype)
+        self._behavior_values = np.empty((self._cells, self._behavior_dim),
+                                         dtype=self.dtype)
+        self._metadata = np.empty(self._cells, dtype=object)
+        self._occupied_indices = np.empty(self._cells, dtype=np.int32)
 
         self._stats_reset()
         self._state = {"clear": 0, "add": 0}
@@ -365,7 +364,7 @@ class ArchiveBase(ABC):  # pylint: disable = too-many-instance-attributes
         After this method is called, the archive will be :attr:`empty`.
         """
         # Only ``self._occupied_indices`` and ``self._occupied`` are cleared, as
-        # a bin can have arbitrary values when its index is marked as
+        # a cell can have arbitrary values when its index is marked as
         # unoccupied.
         self._num_occupied = 0
         self._occupied.fill(False)
@@ -432,7 +431,7 @@ class ArchiveBase(ABC):  # pylint: disable = too-many-instance-attributes
         """Attempts to insert a new solution into the archive.
 
         The solution is only inserted if it has a higher ``objective_value``
-        than the elite previously in the corresponding bin.
+        than the elite previously in the corresponding cell.
 
         Args:
             solution (array-like): Parameters of the solution.
@@ -492,7 +491,8 @@ class ArchiveBase(ABC):  # pylint: disable = too-many-instance-attributes
 
     @require_init
     def elite_with_behavior(self, behavior_values):
-        """Gets the elite with behavior vals in the same bin as those specified.
+        """Gets the elite with behavior vals in the same cell as those
+        specified.
 
         Since :namedtuple:`Elite` is a namedtuple, the result can be unpacked
         (here we show how to ignore some of the fields)::
@@ -510,11 +510,11 @@ class ArchiveBase(ABC):  # pylint: disable = too-many-instance-attributes
             behavior_values (array-like): Coordinates in behavior space.
         Returns:
             Elite:
-              * If there is an elite with behavior values in the same bin as
+              * If there is an elite with behavior values in the same cell as
                 those specified, this :namedtuple:`Elite` holds the info for
                 that elite. In that case, ``beh`` (the behavior values) may not
                 be exactly the same as the behavior values specified since the
-                elite is only guaranteed to be in the same archive bin.
+                elite is only guaranteed to be in the same archive cell.
               * If no such elite exists, then all fields of the
                 :namedtuple:`Elite` are set to None. This way, tuple unpacking
                 (e.g.
@@ -534,7 +534,7 @@ class ArchiveBase(ABC):  # pylint: disable = too-many-instance-attributes
 
     @require_init
     def get_random_elite(self):
-        """Selects an elite uniformly at random from one of the archive's bins.
+        """Selects an elite uniformly at random from one of the archive's cells.
 
         Since :namedtuple:`Elite` is a namedtuple, the result can be unpacked
         (here we show how to ignore some of the fields)::

--- a/ribs/archives/_archive_base.py
+++ b/ribs/archives/_archive_base.py
@@ -127,15 +127,15 @@ class ArchiveBase(ABC):  # pylint: disable = too-many-instance-attributes
     +------------------------+----------------------------+
     | Name                   |  Shape                     |
     +========================+============================+
-    | ``_occupied``          |  ``(cells)``               |
+    | ``_occupied``          |  ``(cells,)``              |
     +------------------------+----------------------------+
     | ``_solutions``         |  ``(cells, solution_dim)`` |
     +------------------------+----------------------------+
-    | ``_objective_values``  |  ``(cells)``               |
+    | ``_objective_values``  |  ``(cells,)``              |
     +------------------------+----------------------------+
     | ``_behavior_values``   |  ``(cells, behavior_dim)`` |
     +------------------------+----------------------------+
-    | ``_metadata``          |  ``(cells)``               |
+    | ``_metadata``          |  ``(cells,)``              |
     +------------------------+----------------------------+
 
     All of these arrays are accessed via a common integer index. If we have

--- a/ribs/archives/_archive_stats.py
+++ b/ribs/archives/_archive_stats.py
@@ -14,7 +14,7 @@ class ArchiveStats(NamedTuple):
     #: Number of elites in the archive.
     num_elites: int
 
-    #: Proportion of bins in the archive that have an elite - always in the
+    #: Proportion of cells in the archive that have an elite - always in the
     #: range :math:`[0,1]`.
     coverage: np.floating
 

--- a/ribs/archives/_grid_archive.py
+++ b/ribs/archives/_grid_archive.py
@@ -8,19 +8,19 @@ _EPSILON = 1e-6
 
 
 class GridArchive(ArchiveBase):
-    """An archive that divides each dimension into uniformly-sized bins.
+    """An archive that divides each dimension into uniformly-sized cells.
 
     This archive is the container described in `Mouret 2015
     <https://arxiv.org/pdf/1504.04909.pdf>`_. It can be visualized as an
     n-dimensional grid in the behavior space that is divided into a certain
-    number of bins in each dimension. Each bin contains an elite, i.e. a
+    number of cells in each dimension. Each cell contains an elite, i.e. a
     solution that `maximizes` the objective function for the behavior values in
-    that bin.
+    that cell.
 
     Args:
-        dims (array-like of int): Number of bins in each dimension of the
+        dims (array-like of int): Number of cells in each dimension of the
             behavior space, e.g. ``[20, 30, 40]`` indicates there should be 3
-            dimensions with 20, 30, and 40 bins. (The number of dimensions is
+            dimensions with 20, 30, and 40 cells. (The number of dimensions is
             implicitly defined in the length of this argument).
         ranges (array-like of (float, float)): Upper and lower bound of each
             dimension of the behavior space, e.g. ``[(-1, 1), (-2, 2)]``
@@ -45,7 +45,7 @@ class GridArchive(ArchiveBase):
 
         ArchiveBase.__init__(
             self,
-            storage_dim=np.product(self._dims),
+            cells=np.product(self._dims),
             behavior_dim=len(self._dims),
             seed=seed,
             dtype=dtype,
@@ -64,7 +64,7 @@ class GridArchive(ArchiveBase):
 
     @property
     def dims(self):
-        """(behavior_dim,) numpy.ndarray: Number of bins in each dimension."""
+        """(behavior_dim,) numpy.ndarray: Number of cells in each dimension."""
         return self._dims
 
     @property
@@ -85,18 +85,18 @@ class GridArchive(ArchiveBase):
 
     @property
     def boundaries(self):
-        """list of numpy.ndarray: The boundaries of the bins in each dimension.
+        """list of numpy.ndarray: The boundaries of the cells in each dimension.
 
         Entry ``i`` in this list is an array that contains the boundaries of the
-        bins in dimension ``i``. The array contains ``self.dims[i] + 1`` entries
-        laid out like this::
+        cells in dimension ``i``. The array contains ``self.dims[i] + 1``
+        entries laid out like this::
 
-            Archive bins:   | 0 | 1 |   ...   |    self.dims[i]    |
+            Archive cells:  | 0 | 1 |   ...   |    self.dims[i]    |
             boundaries[i]:  0   1   2   self.dims[i] - 1     self.dims[i]
 
         Thus, ``boundaries[i][j]`` and ``boundaries[i][j + 1]`` are the lower
-        and upper bounds of bin ``j`` in dimension ``i``. To access the lower
-        bounds of all the bins in dimension ``i``, use ``boundaries[i][:-1]``,
+        and upper bounds of cell ``j`` in dimension ``i``. To access the lower
+        bounds of all the cells in dimension ``i``, use ``boundaries[i][:-1]``,
         and to access all the upper bounds, use ``boundaries[i][1:]``.
         """
         return self._boundaries
@@ -125,12 +125,12 @@ class GridArchive(ArchiveBase):
         """Returns indices of the behavior values within the archive's grid.
 
         First, values are clipped to the bounds of the behavior space. Then, the
-        values are mapped to bins; e.g. bin 5 along dimension 0 and bin 3 along
-        dimension 1.
+        values are mapped to cells; e.g. cell 5 along dimension 0 and cell 3
+        along dimension 1.
 
-        The indices can be used to access boundaries of a behavior value's bin.
+        The indices can be used to access boundaries of a behavior value's cell.
         For example, the following retrieves the lower and upper bounds of the
-        bin along dimension 0::
+        cell along dimension 0::
 
             idx = archive.get_index(...)  # Other methods also return indices.
             lower = archive.boundaries[0][idx[0]]

--- a/ribs/archives/_sliding_boundaries_archive.py
+++ b/ribs/archives/_sliding_boundaries_archive.py
@@ -88,7 +88,7 @@ class SlidingBoundariesArchive(ArchiveBase):
     <https://arxiv.org/abs/1904.10656>`_. Just like the
     :class:`~ribs.archives.GridArchive`, it can be visualized as an
     n-dimensional grid in the behavior space that is divided into a certain
-    number of bins in each dimension. Internally, this archive stores a buffer
+    number of cells in each dimension. Internally, this archive stores a buffer
     with the ``buffer_capacity`` most recent solutions and uses them to
     determine the boundaries of the behavior characteristics along each
     dimension. After every ``remap_frequency`` solutions are inserted, the
@@ -96,16 +96,16 @@ class SlidingBoundariesArchive(ArchiveBase):
 
     Initially, the archive has no solutions, so it cannot automatically
     calculate the boundaries. Thus, until the first remap, this archive divides
-    the behavior space defined by ``ranges`` into equally sized bins.
+    the behavior space defined by ``ranges`` into equally sized cells.
 
     Overall, this archive attempts to make the distribution of the space
     illuminated by the archive more accurately match the true distribution of
     the behavior characteristics when they are not uniformly distributed.
 
     Args:
-        dims (array-like): Number of bins in each dimension of the behavior
+        dims (array-like): Number of cells in each dimension of the behavior
             space, e.g. ``[20, 30, 40]`` indicates there should be 3 dimensions
-            with 20, 30, and 40 bins. (The number of dimensions is implicitly
+            with 20, 30, and 40 cells. (The number of dimensions is implicitly
             defined in the length of this argument).
         ranges (array-like of (float, float)): `Initial` upper and lower bound
             of each dimension of the behavior space, e.g. ``[(-1, 1), (-2, 2)]``
@@ -139,7 +139,7 @@ class SlidingBoundariesArchive(ArchiveBase):
 
         ArchiveBase.__init__(
             self,
-            storage_dim=np.product(self._dims),
+            cells=np.product(self._dims),
             behavior_dim=len(self._dims),
             seed=seed,
             dtype=dtype,
@@ -173,7 +173,7 @@ class SlidingBoundariesArchive(ArchiveBase):
 
     @property
     def dims(self):
-        """(behavior_dim,) numpy.ndarray: Number of bins in each dimension."""
+        """(behavior_dim,) numpy.ndarray: Number of cells in each dimension."""
         return self._dims
 
     @property
@@ -206,19 +206,19 @@ class SlidingBoundariesArchive(ArchiveBase):
 
     @property
     def boundaries(self):
-        """list of numpy.ndarray: The dynamic boundaries of the bins in each
+        """list of numpy.ndarray: The dynamic boundaries of the cells in each
         dimension.
 
         Entry ``i`` in this list is an array that contains the boundaries of the
-        bins in dimension ``i``. The array contains ``self.dims[i] + 1`` entries
-        laid out like this::
+        cells in dimension ``i``. The array contains ``self.dims[i] + 1``
+        entries laid out like this::
 
-            Archive bins:   | 0 | 1 |   ...   |    self.dims[i]    |
+            Archive cells:  | 0 | 1 |   ...   |    self.dims[i]    |
             boundaries[i]:  0   1   2   self.dims[i] - 1     self.dims[i]
 
         Thus, ``boundaries[i][j]`` and ``boundaries[i][j + 1]`` are the lower
-        and upper bounds of bin ``j`` in dimension ``i``. To access the lower
-        bounds of all the bins in dimension ``i``, use ``boundaries[i][:-1]``,
+        and upper bounds of cell ``j`` in dimension ``i``. To access the lower
+        bounds of all the cells in dimension ``i``, use ``boundaries[i][:-1]``,
         and to access all the upper bounds, use ``boundaries[i][1:]``.
         """
         return [
@@ -246,12 +246,12 @@ class SlidingBoundariesArchive(ArchiveBase):
         """Returns indices of the behavior values within the archive's grid.
 
         First, values are clipped to the bounds of the behavior space. Then, the
-        values are mapped to bins via a binary search along the boundaries in
+        values are mapped to cells via a binary search along the boundaries in
         each dimension.
 
-        The indices can be used to access boundaries of a behavior value's bin.
+        The indices can be used to access boundaries of a behavior value's cell.
         For example, the following retrieves the lower and upper bounds of the
-        bin along dimension 0::
+        cell along dimension 0::
 
             idx = archive.get_index(...)  # Other methods also return indices.
             lower = archive.boundaries[0][idx[0]]

--- a/ribs/visualize.py
+++ b/ribs/visualize.py
@@ -180,8 +180,8 @@ def cvt_archive_heatmap(archive,
     Essentially, we create a Voronoi diagram and shade in each cell with a
     color corresponding to the objective value of that cell's elite.
 
-    Depending on how many bins are in the archive, ``ms`` and ``lw`` may need to
-    be tuned. If there are too many bins, the Voronoi diagram and centroid
+    Depending on how many cells are in the archive, ``ms`` and ``lw`` may need
+    to be tuned. If there are too many cells, the Voronoi diagram and centroid
     markers will make the entire image appear black. In that case, try turning
     off the centroids with ``plot_centroids=False`` or even removing the lines
     completely with ``lw=0``.

--- a/tests/archives/archive_base_test.py
+++ b/tests/archives/archive_base_test.py
@@ -200,8 +200,8 @@ def test_archive_is_empty_after_clear(data):
     assert data.archive_with_elite.empty
 
 
-def test_bins_correct(data):
-    assert data.archive.bins == data.bins
+def test_cells_correct(data):
+    assert data.archive.cells == data.cells
 
 
 def test_behavior_dim_correct(data):
@@ -220,7 +220,7 @@ def test_basic_stats(data):
     assert data.archive.stats.obj_mean is None
 
     assert data.archive_with_elite.stats.num_elites == 1
-    assert data.archive_with_elite.stats.coverage == 1 / data.bins
+    assert data.archive_with_elite.stats.coverage == 1 / data.cells
     assert data.archive_with_elite.stats.qd_score == data.objective_value
     assert data.archive_with_elite.stats.obj_max == data.objective_value
     assert data.archive_with_elite.stats.obj_mean == data.objective_value

--- a/tests/archives/conftest.py
+++ b/tests/archives/conftest.py
@@ -46,7 +46,7 @@ ArchiveFixtureData = namedtuple(
         "metadata",  # Metadata object for the solution.
         "grid_indices",  # Index for GridArchive and SlidingBoundariesArchive.
         "centroid",  # Centroid coordinates for CVTArchive.
-        "bins",  # Total number of bins in the archive.
+        "cells",  # Total number of cells in the archive.
     ],
 )
 
@@ -78,9 +78,9 @@ def get_archive_data(name, dtype=np.float64):
     centroid = None
 
     if name == "GridArchive":
-        # Grid archive with 10 bins and range (-1, 1) in first dim, and 20 bins
-        # and range (-2, 2) in second dim.
-        bins = 10 * 20
+        # Grid archive with 10 cells and range (-1, 1) in first dim, and 20
+        # cells and range (-2, 2) in second dim.
+        cells = 10 * 20
         archive = GridArchive([10, 20], [(-1, 1), (-2, 2)], dtype=dtype)
         archive.initialize(len(solution))
 
@@ -92,7 +92,7 @@ def get_archive_data(name, dtype=np.float64):
         # CVT archive with bounds (-1,1) and (-1,1), and 4 centroids at (0.5,
         # 0.5), (-0.5, 0.5), (-0.5, -0.5), and (0.5, -0.5). The elite in
         # archive_with_elite should match with centroid (0.5, 0.5).
-        bins = 4
+        cells = 4
         kd_tree = name == "CVTArchive-kd_tree"
         samples = [[0.5, 0.5], [-0.5, 0.5], [-0.5, -0.5], [0.5, -0.5]]
         centroid = [0.5, 0.5]
@@ -109,9 +109,9 @@ def get_archive_data(name, dtype=np.float64):
                                         dtype=dtype)
         archive_with_elite.initialize(len(solution))
     elif name == "SlidingBoundariesArchive":
-        # Sliding boundary archive with 10 bins and range (-1, 1) in first dim,
-        # and 20 bins and range (-2, 2) in second dim.
-        bins = 10 * 20
+        # Sliding boundary archive with 10 cells and range (-1, 1) in first dim,
+        # and 20 cells and range (-2, 2) in second dim.
+        cells = 10 * 20
         archive = SlidingBoundariesArchive([10, 20], [(-1, 1), (-2, 2)],
                                            remap_frequency=100,
                                            buffer_capacity=1000,
@@ -136,5 +136,5 @@ def get_archive_data(name, dtype=np.float64):
         metadata,
         grid_indices,
         centroid,
-        bins,
+        cells,
     )

--- a/tests/archives/cvt_archive_benchmark.py
+++ b/tests/archives/cvt_archive_benchmark.py
@@ -54,8 +54,8 @@ def benchmark_get_10k_random_elites(use_kd_tree, benchmark, benchmark_data_10k):
 
 
 def benchmark_as_pandas_2000_items(benchmark):
-    bins = 2000
-    archive = CVTArchive(bins, [(-1, 1), (-1, 1)],
+    cells = 2000
+    archive = CVTArchive(cells, [(-1, 1), (-1, 1)],
                          use_kd_tree=True,
                          samples=50_000)
     archive.initialize(10)
@@ -67,6 +67,6 @@ def benchmark_as_pandas_2000_items(benchmark):
         archive.add(sol, 1.0, np.array([x, y]))
 
     # Archive should be full.
-    assert len(archive) == bins
+    assert len(archive) == cells
 
     benchmark(archive.as_pandas)

--- a/tests/emitters/conftest.py
+++ b/tests/emitters/conftest.py
@@ -29,7 +29,7 @@ class FakeArchive(ArchiveBase):
         behavior_dim = len(self._dims)
         ArchiveBase.__init__(
             self,
-            storage_dim=np.product(self._dims),
+            cells=np.product(self._dims),
             behavior_dim=behavior_dim,
         )
 


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the PR's purpose here. -->

Papers such as [PGA-MAP-Elites](https://github.com/ollenilsson19/PGA-MAP-Elites), [MAP-Elites](https://arxiv.org/abs/1504.04909), [CMA-ME](https://arxiv.org/abs/1912.02400), [DQD](https://arxiv.org/abs/2106.03894), [DQD-RL](https://dqd-rl.github.io) all refer to the archive as consisting of _cells_ rather than _bins_. This PR replaces occurrences of bins with cells for consistency.

This does introduce breaking changes -- archives now take in `cells` rather than `bins`, and they have a `cells` property rather than a `bins` property.

## TODO

<!-- Notable points that this PR has either accomplished or will accomplish. -->

## Questions

<!-- Any concerns or points of confusion? -->

## Status

- [x] I have read the guidelines in [CONTRIBUTING.md](https://github.com/icaros-usc/pyribs/blob/master/CONTRIBUTING.md).
- [x] I have formatted my code using `yapf`
- [x] I have tested my code by running `pytest`
- [x] I have linted my code with `pylint`
- [x] I have added a one-line description of my change to the changelog in `HISTORY.md`.
- [x] This PR is ready to go
