### PR TITLE
Add EliteBatch and rename fields in Elite

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,6 +6,7 @@
 
 #### API
 
+- **Backwards-incompatible:** Add EliteBatch and rename fields in Elite (#191)
 - **Backwards-incompatible:** Rename bins to cells for consistency with
   literature (#189)
   - Archive constructors now take in `cells` argument instead of `bins`

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -7,7 +7,7 @@
 #### API
 
 - **Backwards-incompatible:** Rename bins to cells for consistency with
-  literature.
+  literature (#189)
   - Archive constructors now take in `cells` argument instead of `bins`
   - Archive now have a `cells` property rather than a `bins` property
 - **Backwards-incompatible:** Only use integer indices in archives (#185)

--- a/ribs/archives/__init__.py
+++ b/ribs/archives/__init__.py
@@ -13,6 +13,7 @@
     ribs.archives.ArchiveBase
     ribs.archives.AddStatus
     ribs.archives.Elite
+    ribs.archives.EliteBatch
     ribs.archives.ArchiveDataFrame
     ribs.archives.ArchiveStats
 """
@@ -21,7 +22,7 @@ from ribs.archives._archive_base import ArchiveBase
 from ribs.archives._archive_data_frame import ArchiveDataFrame
 from ribs.archives._archive_stats import ArchiveStats
 from ribs.archives._cvt_archive import CVTArchive
-from ribs.archives._elite import Elite
+from ribs.archives._elite import Elite, EliteBatch
 from ribs.archives._grid_archive import GridArchive
 from ribs.archives._sliding_boundaries_archive import SlidingBoundariesArchive
 

--- a/ribs/archives/_archive_base.py
+++ b/ribs/archives/_archive_base.py
@@ -489,6 +489,7 @@ class ArchiveBase(ABC):  # pylint: disable = too-many-instance-attributes
             value = objective_value - old_objective
         return status, value
 
+    # TODO: Update docstring due to new elite definition.
     @require_init
     def elite_with_behavior(self, behavior_values):
         """Gets the elite with behavior vals in the same cell as those

--- a/ribs/archives/_elite.py
+++ b/ribs/archives/_elite.py
@@ -1,4 +1,4 @@
-"""Provides Elite."""
+"""Provides data structures for storing one or more elites."""
 from typing import NamedTuple
 
 import numpy as np
@@ -12,16 +12,39 @@ class Elite(NamedTuple):
     """
 
     #: Parameters of the elite's solution.
-    sol: np.ndarray
+    solution: np.ndarray
 
     #: Objective value evaluation.
-    obj: float
+    objective: float
 
-    #: Behavior values.
-    beh: np.ndarray
+    #: Measure values.
+    measures: np.ndarray
 
     #: Index of the elite in the archive (see :meth:`ArchiveBase.get_index`).
-    idx: int
+    index: int
 
     #: Metadata object for the elite.
-    meta: object
+    metadata: object
+
+
+class EliteBatch(NamedTuple):
+    """Represents a batch of elites.
+
+    Each field is an array with dimensions ``(batch, ...)``. Refer to
+    :class:`Elite` for the non-batched version of this class.
+    """
+
+    #: Batch of solutions -- shape ``(batch, solution_dim)``
+    solution_batch: np.ndarray
+
+    #: Batch of objectives -- shape ``(batch,)``
+    objective_batch: np.ndarray
+
+    #: Batch of measures -- shape ``(batch, measure_dim)``
+    measures_batch: np.ndarray
+
+    #: Batch of indices -- shape ``(batch,)``
+    index_batch: np.ndarray
+
+    #: Batch of metadata -- shape ``(batch,)``
+    metadata_batch: np.ndarray

--- a/ribs/emitters/_gaussian_emitter.py
+++ b/ribs/emitters/_gaussian_emitter.py
@@ -100,7 +100,7 @@ class GaussianEmitter(EmitterBase):
             parents = np.expand_dims(self._x0, axis=0)
         else:
             parents = [
-                self.archive.get_random_elite().sol
+                self.archive.get_random_elite().solution
                 for _ in range(self._batch_size)
             ]
 

--- a/ribs/emitters/_improvement_emitter.py
+++ b/ribs/emitters/_improvement_emitter.py
@@ -169,6 +169,6 @@ class ImprovementEmitter(EmitterBase):
         # Check for reset.
         if (self.opt.check_stop([value for status, value, i in ranking_data]) or
                 self._check_restart(new_sols)):
-            new_x0 = self.archive.get_random_elite().sol
+            new_x0 = self.archive.get_random_elite().solution
             self.opt.reset(new_x0)
             self._restarts += 1

--- a/ribs/emitters/_iso_line_emitter.py
+++ b/ribs/emitters/_iso_line_emitter.py
@@ -120,11 +120,13 @@ class IsoLineEmitter(EmitterBase):
             solutions = np.expand_dims(self._x0, axis=0) + iso_gaussian
         else:
             parents = [
-                self.archive.get_random_elite().sol
+                self.archive.get_random_elite().solution
                 for _ in range(self._batch_size)
             ]
-            directions = [(self.archive.get_random_elite().sol - parents[i])
-                          for i in range(self._batch_size)]
+            directions = [
+                (self.archive.get_random_elite().solution - parents[i])
+                for i in range(self._batch_size)
+            ]
             line_gaussian = self._rng.normal(
                 scale=self._line_sigma,
                 size=(self._batch_size, 1),

--- a/ribs/emitters/_optimizing_emitter.py
+++ b/ribs/emitters/_optimizing_emitter.py
@@ -173,6 +173,6 @@ class OptimizingEmitter(EmitterBase):
         # Check for reset.
         if (self.opt.check_stop([obj for status, obj, i in ranking_data]) or
                 self._check_restart(new_sols)):
-            new_x0 = self.archive.get_random_elite().sol
+            new_x0 = self.archive.get_random_elite().solution
             self.opt.reset(new_x0)
             self._restarts += 1

--- a/ribs/emitters/_random_direction_emitter.py
+++ b/ribs/emitters/_random_direction_emitter.py
@@ -193,7 +193,7 @@ class RandomDirectionEmitter(EmitterBase):
         if (self.opt.check_stop(
             [projection for status, projection, i in ranking_data]) or
                 self._check_restart(new_sols)):
-            new_x0 = self.archive.get_random_elite().sol
+            new_x0 = self.archive.get_random_elite().solution
             self.opt.reset(new_x0)
             self._target_behavior_dir = self._generate_random_direction()
             self._restarts += 1

--- a/ribs/visualize.py
+++ b/ribs/visualize.py
@@ -127,8 +127,8 @@ def grid_archive_heatmap(archive,
     colors = np.full((y_dim, x_dim), np.nan)
     for elite in archive:
         # TODO: Do not require calling numpy?
-        idx = np.unravel_index(elite.idx, archive.dims)
-        colors[idx[1], idx[0]] = elite.obj
+        idx = np.unravel_index(elite.index, archive.dims)
+        colors[idx[1], idx[0]] = elite.objective
 
     if transpose_bcs:
         # Since the archive is 2D, transpose by swapping the x and y boundaries
@@ -278,7 +278,7 @@ def cvt_archive_heatmap(archive,
     # the region index of each point.
     region_obj = [None] * len(vor.regions)
     min_obj, max_obj = np.inf, -np.inf
-    pt_to_obj = {elite.idx: elite.obj for elite in archive}
+    pt_to_obj = {elite.index: elite.objective for elite in archive}
     for pt_idx, region_idx in enumerate(
             vor.point_region[:-4]):  # Exclude faraway_pts.
         if region_idx != -1 and pt_idx in pt_to_obj:

--- a/tests/archives/archive_base_test.py
+++ b/tests/archives/archive_base_test.py
@@ -92,7 +92,7 @@ def test_iteration():
         # TODO: Avoid having to manually ravel.
         assert elite.index == np.ravel_multi_index(data.grid_indices,
                                                    data.archive_with_elite.dims)
-        assert elite.meta == data.metadata
+        assert elite.metadata == data.metadata
 
 
 def test_add_during_iteration():

--- a/tests/archives/archive_base_test.py
+++ b/tests/archives/archive_base_test.py
@@ -86,12 +86,12 @@ def test_invalid_dtype():
 def test_iteration():
     data = get_archive_data("GridArchive")
     for elite in data.archive_with_elite:
-        assert np.isclose(elite.sol, data.solution).all()
-        assert np.isclose(elite.obj, data.objective_value)
-        assert np.isclose(elite.beh, data.behavior_values).all()
+        assert np.isclose(elite.solution, data.solution).all()
+        assert np.isclose(elite.objective, data.objective_value)
+        assert np.isclose(elite.measures, data.behavior_values).all()
         # TODO: Avoid having to manually ravel.
-        assert elite.idx == np.ravel_multi_index(data.grid_indices,
-                                                 data.archive_with_elite.dims)
+        assert elite.index == np.ravel_multi_index(data.grid_indices,
+                                                   data.archive_with_elite.dims)
         assert elite.meta == data.metadata
 
 
@@ -228,29 +228,29 @@ def test_basic_stats(data):
 
 def test_elite_with_behavior_gets_correct_elite(data):
     elite = data.archive_with_elite.elite_with_behavior(data.behavior_values)
-    assert np.all(elite.sol == data.solution)
-    assert elite.obj == data.objective_value
-    assert np.all(elite.beh == data.behavior_values)
+    assert np.all(elite.solution == data.solution)
+    assert elite.objective == data.objective_value
+    assert np.all(elite.measures == data.behavior_values)
     # Avoid checking elite.idx since the meaning varies by archive.
-    assert elite.meta == data.metadata
+    assert elite.metadata == data.metadata
 
 
 def test_elite_with_behavior_returns_none(data):
     elite = data.archive.elite_with_behavior(data.behavior_values)
-    assert elite.sol is None
-    assert elite.obj is None
-    assert elite.beh is None
-    assert elite.idx is None
-    assert elite.meta is None
+    assert elite.solution is None
+    assert elite.objective is None
+    assert elite.measures is None
+    assert elite.index is None
+    assert elite.metadata is None
 
 
 def test_random_elite_gets_single_elite(data):
     elite = data.archive_with_elite.get_random_elite()
-    assert np.all(elite.sol == data.solution)
-    assert elite.obj == data.objective_value
-    assert np.all(elite.beh == data.behavior_values)
+    assert np.all(elite.solution == data.solution)
+    assert elite.objective == data.objective_value
+    assert np.all(elite.measures == data.behavior_values)
     # Avoid checking elite.idx since the meaning varies by archive.
-    assert elite.meta == data.metadata
+    assert elite.metadata == data.metadata
 
 
 def test_random_elite_fails_when_empty(data):

--- a/tests/archives/archive_data_frame_test.py
+++ b/tests/archives/archive_data_frame_test.py
@@ -32,12 +32,13 @@ def df(data):
 
 
 def test_iterelites(data, df):
-    for elite, (sol, obj, beh, idx, meta) in zip(df.iterelites(), zip(*data)):
-        assert np.isclose(elite.sol, sol).all()
-        assert np.isclose(elite.obj, obj)
-        assert np.isclose(elite.beh, beh).all()
-        assert elite.idx == idx
-        assert elite.meta == meta
+    for elite, (solution, objective, measures, index,
+                metadata) in zip(df.iterelites(), zip(*data)):
+        assert np.isclose(elite.solution, solution).all()
+        assert np.isclose(elite.objective, objective)
+        assert np.isclose(elite.measures, measures).all()
+        assert elite.index == index
+        assert elite.metadata == metadata
 
 
 def test_batch_methods(data, df):

--- a/tests/archives/cvt_archive_test.py
+++ b/tests/archives/cvt_archive_test.py
@@ -18,16 +18,16 @@ def data(use_kd_tree):
             if use_kd_tree else get_archive_data("CVTArchive-brute_force"))
 
 
-def assert_archive_elite(archive, solution, objective_value, behavior_values,
-                         centroid, metadata):
+def assert_archive_elite(archive, solution, objective, measures, centroid,
+                         metadata):
     """Asserts that the archive has one specific elite."""
     assert len(archive) == 1
     elite = list(archive)[0]
-    assert np.isclose(elite.sol, solution).all()
-    assert np.isclose(elite.obj, objective_value).all()
-    assert np.isclose(elite.beh, behavior_values).all()
-    assert np.isclose(archive.centroids[elite.idx], centroid).all()
-    assert elite.meta == metadata
+    assert np.isclose(elite.solution, solution).all()
+    assert np.isclose(elite.objective, objective).all()
+    assert np.isclose(elite.measures, measures).all()
+    assert np.isclose(archive.centroids[elite.index], centroid).all()
+    assert elite.metadata == metadata
 
 
 def test_samples_bad_shape(use_kd_tree):

--- a/tests/archives/grid_archive_test.py
+++ b/tests/archives/grid_archive_test.py
@@ -15,16 +15,16 @@ def data():
     return get_archive_data("GridArchive")
 
 
-def assert_archive_elite(archive, solution, objective_value, behavior_values,
-                         indices, metadata):
+def assert_archive_elite(archive, solution, objective, measures, indices,
+                         metadata):
     """Asserts that the archive has one specific elite."""
     assert len(archive) == 1
     elite = list(archive)[0]
-    assert np.isclose(elite.sol, solution).all()
-    assert np.isclose(elite.obj, objective_value).all()
-    assert np.isclose(elite.beh, behavior_values).all()
-    assert elite.idx == np.ravel_multi_index(indices, archive.dims)
-    assert elite.meta == metadata
+    assert np.isclose(elite.solution, solution).all()
+    assert np.isclose(elite.objective, objective).all()
+    assert np.isclose(elite.measures, measures).all()
+    assert elite.index == np.ravel_multi_index(indices, archive.dims)
+    assert elite.metadata == metadata
 
 
 def test_fails_on_dim_mismatch():


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the PR's purpose here. -->

This PR adds an `EliteBatch` data structure for storing a batch of elites. This is similar to the `Elite` but stores a batch in each field rather than just one entry.

Since we added this new structure, we also renamed `Elite` to use the full word for each field name, and we replaced `behavior_values` with `measures` (we will make this latter change throughout the entire library later on).

Using the full word for each field (e.g. `objective` instead of `obj`) makes it clear what we are referring to -- for instance, we previously used words like `beh` and `meta` that were not necessarily well-known.

One issue to decide is how to name the fields in `EltieBatch`. I decided to go with `XXX_batch` rather than `batch_XXX` since `batch_XXX` would require making `XXX` plural, e.g. `batch_objectives` instead of `objective_batch`. Keeping the word singular helps us align it with `Elite`; for instance, `Elite` has `objective` and `EliteBatch` has `objective_batch`. Using plurals would also have introduced a conflict with `measures`, since `Elite.measures` is already plural.

The main change of this PR is in `_elite.py`. This change caused some existing code and tests to break, so the remaining files repair that.

## TODO

<!-- Notable points that this PR has either accomplished or will accomplish. -->

## Questions

<!-- Any concerns or points of confusion? -->

## Status

- [x] I have read the guidelines in [CONTRIBUTING.md](https://github.com/icaros-usc/pyribs/blob/master/CONTRIBUTING.md).
- [x] I have formatted my code using `yapf`
- [x] I have tested my code by running `pytest`
- [x] I have linted my code with `pylint`
- [x] I have added a one-line description of my change to the changelog in `HISTORY.md`.
- [x] This PR is ready to go
