### PR TITLE
Replace get_random_elite() with batched sample_elites() method

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,6 +6,8 @@
 
 #### API
 
+- **Backwards-incompatible:** Replace `get_random_elite()` with batched
+  `sample_elites()` method (#192)
 - **Backwards-incompatible:** Add EliteBatch and rename fields in Elite (#191)
 - **Backwards-incompatible:** Rename bins to cells for consistency with
   literature (#189)

--- a/ribs/archives/_archive_base.py
+++ b/ribs/archives/_archive_base.py
@@ -39,42 +39,6 @@ def readonly(arr):
     return arr
 
 
-class RandomBuffer:
-    """An internal class that stores a buffer of random numbers.
-
-    Generating random indices in get_random_elite() takes a lot of time if done
-    individually. As such, this class generates many random numbers at once and
-    slowly dispenses them. Since the calls in get_random_elite() vary in their
-    range, this class does not store random integers; it stores random floats in
-    the range [0,1) that can be multiplied to get a number in the range [0, x).
-
-    Args:
-        seed (int): Value to seed the random number generator. Set to None to
-            avoid a fixed seed.
-        buf_size (int): How many random floats to store at once in the buffer.
-    """
-
-    def __init__(self, seed=None, buf_size=10):
-        assert buf_size > 0, "buf_size must be at least 1"
-
-        self._rng = np.random.default_rng(seed)
-        self._buf_size = buf_size
-        self._buffer = self._rng.random(buf_size)
-        self._buf_idx = 0
-
-    def get(self, max_val):
-        """Returns a random int in the range [0, max_val)."""
-        val = int(self._buffer[self._buf_idx] * max_val)
-        self._buf_idx += 1
-
-        # Reset the buffer if necessary.
-        if self._buf_idx >= self._buf_size:
-            self._buf_idx = 0
-            self._buffer = self._rng.random(self._buf_size)
-
-        return val
-
-
 class ArchiveIterator:
     """An iterator for an archive's elites."""
 
@@ -343,7 +307,6 @@ class ArchiveBase(ABC):  # pylint: disable = too-many-instance-attributes
             raise RuntimeError("Cannot re-initialize an archive")
         self._initialized = True
 
-        self._rand_buf = RandomBuffer(self._seed)
         self._solution_dim = solution_dim
         self._occupied = np.zeros(self._cells, dtype=bool)
         self._solutions = np.empty((self._cells, solution_dim),
@@ -532,6 +495,7 @@ class ArchiveBase(ABC):  # pylint: disable = too-many-instance-attributes
             )
         return Elite(None, None, None, None, None)
 
+    # TODO: Rename to sample_elites
     @require_init
     def get_random_elite(self):
         """Selects an elite uniformly at random from one of the archive's cells.

--- a/ribs/archives/_archive_base.py
+++ b/ribs/archives/_archive_base.py
@@ -531,10 +531,10 @@ class ArchiveBase(ABC):  # pylint: disable = too-many-instance-attributes
 
         return EliteBatch(
             readonly(self._solutions[selected_indices]),
-            self._objective_values[selected_indices],
+            readonly(self._objective_values[selected_indices]),
             readonly(self._behavior_values[selected_indices]),
-            selected_indices,
-            self._metadata[selected_indices],
+            readonly(selected_indices),
+            readonly(self._metadata[selected_indices]),
         )
 
     def as_pandas(self, include_solutions=True, include_metadata=False):

--- a/ribs/emitters/_gaussian_emitter.py
+++ b/ribs/emitters/_gaussian_emitter.py
@@ -96,18 +96,13 @@ class GaussianEmitter(EmitterBase):
             ``(batch_size, solution_dim)`` array -- contains ``batch_size`` new
             solutions to evaluate.
         """
-        if self.archive.empty:
-            parents = np.expand_dims(self._x0, axis=0)
-        else:
-            parents = [
-                self.archive.get_random_elite().solution
-                for _ in range(self._batch_size)
-            ]
+        parents = (np.expand_dims(self._x0, axis=0) if self.archive.empty else
+                   self.archive.sample_elites(self._batch_size).solution_batch)
 
         noise = self._rng.normal(
             scale=self._sigma0,
             size=(self._batch_size, self.solution_dim),
         ).astype(self.archive.dtype)
 
-        return self._ask_clip_helper(np.asarray(parents), noise,
-                                     self.lower_bounds, self.upper_bounds)
+        return self._ask_clip_helper(parents, noise, self.lower_bounds,
+                                     self.upper_bounds)

--- a/ribs/emitters/_improvement_emitter.py
+++ b/ribs/emitters/_improvement_emitter.py
@@ -169,6 +169,6 @@ class ImprovementEmitter(EmitterBase):
         # Check for reset.
         if (self.opt.check_stop([value for status, value, i in ranking_data]) or
                 self._check_restart(new_sols)):
-            new_x0 = self.archive.get_random_elite().solution
+            new_x0 = self.archive.sample_elites(1).solution_batch[0]
             self.opt.reset(new_x0)
             self._restarts += 1

--- a/ribs/emitters/_iso_line_emitter.py
+++ b/ribs/emitters/_iso_line_emitter.py
@@ -119,14 +119,11 @@ class IsoLineEmitter(EmitterBase):
         if self.archive.empty:
             solutions = np.expand_dims(self._x0, axis=0) + iso_gaussian
         else:
-            parents = [
-                self.archive.get_random_elite().solution
-                for _ in range(self._batch_size)
-            ]
-            directions = [
-                (self.archive.get_random_elite().solution - parents[i])
-                for i in range(self._batch_size)
-            ]
+            parents = self.archive.sample_elites(
+                self._batch_size).solution_batch
+            directions = (
+                self.archive.sample_elites(self._batch_size).solution_batch -
+                parents)
             line_gaussian = self._rng.normal(
                 scale=self._line_sigma,
                 size=(self._batch_size, 1),

--- a/ribs/emitters/_optimizing_emitter.py
+++ b/ribs/emitters/_optimizing_emitter.py
@@ -173,6 +173,6 @@ class OptimizingEmitter(EmitterBase):
         # Check for reset.
         if (self.opt.check_stop([obj for status, obj, i in ranking_data]) or
                 self._check_restart(new_sols)):
-            new_x0 = self.archive.get_random_elite().solution
+            new_x0 = self.archive.sample_elites(1).solution_batch[0]
             self.opt.reset(new_x0)
             self._restarts += 1

--- a/ribs/emitters/_random_direction_emitter.py
+++ b/ribs/emitters/_random_direction_emitter.py
@@ -193,7 +193,7 @@ class RandomDirectionEmitter(EmitterBase):
         if (self.opt.check_stop(
             [projection for status, projection, i in ranking_data]) or
                 self._check_restart(new_sols)):
-            new_x0 = self.archive.get_random_elite().solution
+            new_x0 = self.archive.sample_elites(1).solution_batch[0]
             self.opt.reset(new_x0)
             self._target_behavior_dir = self._generate_random_direction()
             self._restarts += 1

--- a/tests/archives/archive_base_test.py
+++ b/tests/archives/archive_base_test.py
@@ -217,18 +217,18 @@ def test_elite_with_behavior_returns_none(data):
     assert elite.metadata is None
 
 
-def test_random_elite_gets_single_elite(data):
-    elite = data.archive_with_elite.get_random_elite()
-    assert np.all(elite.solution == data.solution)
-    assert elite.objective == data.objective_value
-    assert np.all(elite.measures == data.behavior_values)
+def test_sample_elites_gets_single_elite(data):
+    elite_batch = data.archive_with_elite.sample_elites(2)
+    assert np.all(elite_batch.solution_batch == data.solution)
+    assert np.all(elite_batch.objective_batch == data.objective_value)
+    assert np.all(elite_batch.measures_batch == data.behavior_values)
     # Avoid checking elite.idx since the meaning varies by archive.
-    assert elite.metadata == data.metadata
+    assert np.all(elite_batch.metadata_batch == data.metadata)
 
 
-def test_random_elite_fails_when_empty(data):
+def test_sample_elites_fails_when_empty(data):
     with pytest.raises(IndexError):
-        data.archive.get_random_elite()
+        data.archive.sample_elites(1)
 
 
 @pytest.mark.parametrize("name", ARCHIVE_NAMES)

--- a/tests/archives/archive_base_test.py
+++ b/tests/archives/archive_base_test.py
@@ -3,37 +3,10 @@ import numpy as np
 import pytest
 
 from ribs.archives import GridArchive
-from ribs.archives._archive_base import RandomBuffer
 
 from .conftest import ARCHIVE_NAMES, get_archive_data
 
 # pylint: disable = redefined-outer-name
-
-#
-# RandomBuffer tests -- note this is an internal class.
-#
-
-
-def test_random_buffer_in_range():
-    buffer = RandomBuffer(buf_size=10)
-    for _ in range(10):
-        assert buffer.get(1) == 0
-    for _ in range(10):
-        assert buffer.get(2) in [0, 1]
-
-
-def test_random_buffer_not_repeating():
-    buf_size = 100
-    buffer = RandomBuffer(buf_size=buf_size)
-
-    # Both lists contain random integers in the range [0,100), and we triggered
-    # a reset by retrieving more than buf_size integers. It should be nearly
-    # impossible for the lists to be equal unless something is wrong.
-    x1 = [buffer.get(100) for _ in range(buf_size)]
-    x2 = [buffer.get(100) for _ in range(buf_size)]
-
-    assert x1 != x2
-
 
 #
 # Tests for the require_init decorator. Just need to make sure it works on a few

--- a/tests/archives/cvt_archive_benchmark.py
+++ b/tests/archives/cvt_archive_benchmark.py
@@ -37,21 +37,6 @@ def benchmark_add_10k(use_kd_tree, benchmark, benchmark_data_10k):
     benchmark.pedantic(add_10k, setup=setup, rounds=5, iterations=1)
 
 
-def benchmark_get_10k_random_elites(use_kd_tree, benchmark, benchmark_data_10k):
-    n, solutions, objective_values, behavior_values = benchmark_data_10k
-    archive = CVTArchive(1000, [(-1, 1), (-1, 1)],
-                         samples=20_000,
-                         use_kd_tree=use_kd_tree)
-    archive.initialize(solutions.shape[1])
-    for i in range(n):
-        archive.add(solutions[i], objective_values[i], behavior_values[i])
-
-    def get_elites():
-        archive.sample_elites(n)
-
-    benchmark(get_elites)
-
-
 def benchmark_as_pandas_2000_items(benchmark):
     cells = 2000
     archive = CVTArchive(cells, [(-1, 1), (-1, 1)],

--- a/tests/archives/cvt_archive_benchmark.py
+++ b/tests/archives/cvt_archive_benchmark.py
@@ -47,8 +47,7 @@ def benchmark_get_10k_random_elites(use_kd_tree, benchmark, benchmark_data_10k):
         archive.add(solutions[i], objective_values[i], behavior_values[i])
 
     def get_elites():
-        for _ in range(n):
-            archive.get_random_elite()
+        archive.sample_elites(n)
 
     benchmark(get_elites)
 

--- a/tests/archives/grid_archive_benchmark.py
+++ b/tests/archives/grid_archive_benchmark.py
@@ -31,8 +31,7 @@ def benchmark_get_10k_random_elites(benchmark, benchmark_data_10k):
         archive.add(solutions[i], objective_values[i], behavior_values[i])
 
     def get_elites():
-        for _ in range(n):
-            archive.get_random_elite()
+        archive.sample_elites(n)
 
     benchmark(get_elites)
 

--- a/tests/archives/grid_archive_benchmark.py
+++ b/tests/archives/grid_archive_benchmark.py
@@ -23,19 +23,6 @@ def benchmark_add_10k(benchmark, benchmark_data_10k):
     benchmark.pedantic(add_10k, setup=setup, rounds=5, iterations=1)
 
 
-def benchmark_get_10k_random_elites(benchmark, benchmark_data_10k):
-    n, solutions, objective_values, behavior_values = benchmark_data_10k
-    archive = GridArchive((64, 64), [(-1, 1), (-1, 1)])
-    archive.initialize(solutions.shape[1])
-    for i in range(n):
-        archive.add(solutions[i], objective_values[i], behavior_values[i])
-
-    def get_elites():
-        archive.sample_elites(n)
-
-    benchmark(get_elites)
-
-
 def benchmark_as_pandas_2025_items(benchmark):
     dim = 45
     archive = GridArchive((dim, dim), [(-1, 1), (-1, 1)])

--- a/tests/archives/sliding_boundaries_archive_benchmark.py
+++ b/tests/archives/sliding_boundaries_archive_benchmark.py
@@ -25,22 +25,6 @@ def benchmark_add_10k(benchmark, benchmark_data_10k):
     benchmark.pedantic(add_10k, setup=setup, rounds=5, iterations=1)
 
 
-def benchmark_get_10k_random_elites(benchmark, benchmark_data_10k):
-    n, solutions, objective_values, behavior_values = benchmark_data_10k
-    archive = SlidingBoundariesArchive([10, 20], [(-1, 1), (-2, 2)],
-                                       remap_frequency=100,
-                                       buffer_capacity=1000)
-    archive.initialize(solutions.shape[1])
-
-    for i in range(n):
-        archive.add(solutions[i], objective_values[i], behavior_values[i])
-
-    def get_elites():
-        archive.sample_elites(n)
-
-    benchmark(get_elites)
-
-
 def benchmark_as_pandas_2048_elements(benchmark):
     # TODO (btjanaka): Make this size smaller so that we do a remap.
     archive = SlidingBoundariesArchive([32, 64], [(-1, 1), (-2, 2)],

--- a/tests/archives/sliding_boundaries_archive_benchmark.py
+++ b/tests/archives/sliding_boundaries_archive_benchmark.py
@@ -36,8 +36,7 @@ def benchmark_get_10k_random_elites(benchmark, benchmark_data_10k):
         archive.add(solutions[i], objective_values[i], behavior_values[i])
 
     def get_elites():
-        for _ in range(n):
-            archive.get_random_elite()
+        archive.sample_elites(n)
 
     benchmark(get_elites)
 

--- a/tests/emitters/conftest.py
+++ b/tests/emitters/conftest.py
@@ -33,13 +33,6 @@ class FakeArchive(ArchiveBase):
             behavior_dim=behavior_dim,
         )
 
-    def get_random_elite(self):
-        return (
-            self._solutions[0],
-            self._objective_values[0],
-            self._behavior_values[0],
-        )
-
     def add(self, solution, objective_value, behavior_values, metadata=None):
         return True
 


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the PR's purpose here. -->

This PR replaces `get_random_elite` with a `sample_elites` method which samples an entire batch of elites from the archive rather than just a single elite. This allows the emitter to operate more quickly since they do not have to call `get_random_elite` one at a time. We have decided to rename the method so that we are guaranteed to break people who still use get_random_elite().

## TODO

<!-- Notable points that this PR has either accomplished or will accomplish. -->

- [x] Implement `sample_elites`
- [x] Remove `get_random_elite` benchmarks (since `sample_elites` is batched, it is much faster)
- [x] Test `sample_elites`
- [x] Fix emitters
- [x] Fix tests

## Questions

<!-- Any concerns or points of confusion? -->

## Status

- [x] I have read the guidelines in [CONTRIBUTING.md](https://github.com/icaros-usc/pyribs/blob/master/CONTRIBUTING.md).
- [x] I have formatted my code using `yapf`
- [x] I have tested my code by running `pytest`
- [x] I have linted my code with `pylint`
- [x] I have added a one-line description of my change to the changelog in `HISTORY.md`.
- [x] This PR is ready to go
