### PR TITLE
Fix documentation rendering issues on ReadTheDocs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -10,6 +10,7 @@ sphinx:
 
 # Set the version of Python and requirements required to build the docs.
 python:
+  os: ubuntu-20.04
   version: 3.9
   install:
     - method: pip

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -10,7 +10,7 @@ sphinx:
 
 # Set the version of Python and requirements required to build the docs.
 python:
-  version: 3.7
+  version: 3.9
   install:
     - method: pip
       path: .

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -10,8 +10,7 @@ sphinx:
 
 # Set the version of Python and requirements required to build the docs.
 python:
-  os: ubuntu-20.04
-  version: 3.9
+  version: 3.8
   install:
     - method: pip
       path: .

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -31,6 +31,7 @@
 
 #### Documentation
 
+- Fix documentation rendering issues on ReadTheDocs (#205)
 - Fix typos and formatting in docstrings of `ribs/visualize.py` (#203)
 - Add in-comment type hint rich linking (#204)
 - Upgrade Sphinx dependencies (#202)


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the PR's purpose here. -->

The linking introduced in #204 was not showing up in the rendered docs on ReadTheDocs. Bumping the Python version to 3.8 seems to solve this.

## TODO

<!-- Notable points that this PR has either accomplished or will accomplish. -->

## Questions

<!-- Any concerns or points of confusion? -->

## Status

- [x] I have read the guidelines in [CONTRIBUTING.md](https://github.com/icaros-usc/pyribs/blob/master/CONTRIBUTING.md).
- [x] I have formatted my code using `yapf`
- [x] I have tested my code by running `pytest`
- [x] I have linted my code with `pylint`
- [x] I have added a one-line description of my change to the changelog in `HISTORY.md`.
- [x] This PR is ready to go
