### PR TITLE
Allow unlimited max args in pylint

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -336,7 +336,7 @@ exclude-protected=_asdict,_fields,_replace,_source,_make
 [DESIGN]
 
 # Maximum number of arguments for function / method
-max-args=10
+max-args=9999
 
 # Argument names that match this expression will be ignored. Default to name
 # with leading underscore


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the PR's purpose here. -->

Allow unlimited max-args in pylint since our classes may require many parameters. In the future, we may force users to only provide kwargs like scikit-learn does, so that the parameters are more readable.

## TODO

<!-- Notable points that this PR has either accomplished or will accomplish. -->

## Questions

<!-- Any concerns or points of confusion? -->

## Status

- [x] I have read the guidelines in [CONTRIBUTING.md](https://github.com/icaros-usc/pyribs/blob/master/CONTRIBUTING.md).
- [x] I have formatted my code using `yapf`
- [x] I have tested my code by running `pytest`
- [x] I have linted my code with `pylint`
- [x] I have added a one-line description of my change to the changelog in `HISTORY.md`.
- [x] This PR is ready to go
