### PR TITLE
Add index_of_single method for getting index of measures for one solution

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,6 +6,8 @@
 
 #### API
 
+- Add index_of_single method for getting index of measures for one solution
+  (#214)
 - **Backwards-incompatible:** Replace get_index with batched index_of method in
   archives (#208)
   - Also added `grid_to_int_index` and `int_to_grid_index` methods for

--- a/ribs/archives/_archive_base.py
+++ b/ribs/archives/_archive_base.py
@@ -288,6 +288,21 @@ class ArchiveBase(ABC):  # pylint: disable = too-many-instance-attributes
             batch of measures in the archive's storage arrays.
         """
 
+    def index_of_single(self, measures):
+        """Returns index of measures for one solution.
+
+        This is the unbatched version of :meth:`index_of`. As long as you
+        implement :meth:`index_of` correctly, this method should work out of the
+        box.
+
+        Args:
+            measures (array-like): (:attr:`behavior_dim`,) array of measures for
+                a single solution.
+        Returns:
+            integer: Index of the measures in the archive's storage arrays.
+        """
+        return self.index_of(np.asarray(measures)[None])[0]
+
     @staticmethod
     @nb.jit(locals={"already_occupied": nb.types.b1}, nopython=True)
     def _add_numba(new_index, new_solution, new_objective_value,

--- a/ribs/archives/_archive_base.py
+++ b/ribs/archives/_archive_base.py
@@ -277,8 +277,8 @@ class ArchiveBase(ABC):  # pylint: disable = too-many-instance-attributes
     def index_of(self, measures_batch):
         """Returns archive indices for the given batch of measures.
 
-        See the :class:`~ribs.archives.ArchiveBase` class docstring for more
-        info.
+        If you need to retrieve the index of the measures for a *single*
+        solution, consider using :meth:`index_of_single`.
 
         Args:
             measures_batch (array-like): (batch_size, :attr:`behavior_dim`)
@@ -292,14 +292,16 @@ class ArchiveBase(ABC):  # pylint: disable = too-many-instance-attributes
         """Returns the index of the measures for one solution.
 
         While :meth:`index_of` takes in a *batch* of measures, this method takes
-        in the measures for only *one* solution. As long as :meth:`index_of` is
-        implemented correctly, this method should work out of the box.
+        in the measures for only *one* solution. If :meth:`index_of` is
+        implemented correctly, this method should work immediately (i.e. `"out
+        of the box" <https://idioms.thefreedictionary.com/Out-of-the-Box>`_).
 
         Args:
             measures (array-like): (:attr:`behavior_dim`,) array of measures for
                 a single solution.
         Returns:
-            integer: Index of the measures in the archive's storage arrays.
+            int or numpy.integer: Integer index of the measures in the archive's
+            storage arrays.
         """
         return self.index_of(np.asarray(measures)[None])[0]
 

--- a/ribs/archives/_archive_base.py
+++ b/ribs/archives/_archive_base.py
@@ -289,7 +289,7 @@ class ArchiveBase(ABC):  # pylint: disable = too-many-instance-attributes
         """
 
     def index_of_single(self, measures):
-        """Returns index of measures for one solution.
+        """Returns the index of the measures for one solution.
 
         This is the unbatched version of :meth:`index_of`. As long as you
         implement :meth:`index_of` correctly, this method should work out of the

--- a/ribs/archives/_archive_base.py
+++ b/ribs/archives/_archive_base.py
@@ -291,9 +291,9 @@ class ArchiveBase(ABC):  # pylint: disable = too-many-instance-attributes
     def index_of_single(self, measures):
         """Returns the index of the measures for one solution.
 
-        This is the unbatched version of :meth:`index_of`. As long as you
-        implement :meth:`index_of` correctly, this method should work out of the
-        box.
+        While :meth:`index_of` takes in a *batch* of measures, this method takes
+        in the measures for only *one* solution. As long as :meth:`index_of` is
+        implemented correctly, this method should work out of the box.
 
         Args:
             measures (array-like): (:attr:`behavior_dim`,) array of measures for

--- a/tests/archives/archive_base_test.py
+++ b/tests/archives/archive_base_test.py
@@ -120,6 +120,16 @@ def test_stats_add_and_overwrite():
 
 
 #
+# index_of_single() tests -- on GridArchive only.
+#
+
+
+def test_index_of_single():
+    data = get_archive_data("GridArchive")
+    assert data.archive.index_of_single(data.behavior_values) == data.int_index
+
+
+#
 # General tests -- should work for all archive classes.
 #
 


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the PR's purpose here. -->

Adds an `index_of_single` method for retrieving the index of measures for a single solution.

An alternative is to allow `index_of` to take in a 1D array of measures, but this complicates the implementation for users who wish to implement their own archives. By adding this extra method, users get `index_of_single` for free if they implement `index_of` correctly.

Furthermore, `index_of_single` makes it clear that users are choosing a method that is slow.

## TODO

<!-- Notable points that this PR has either accomplished or will accomplish. -->

- [x] Implement
- [x] Document
- [x] Test

## Questions

<!-- Any concerns or points of confusion? -->

## Status

- [x] I have read the guidelines in [CONTRIBUTING.md](https://github.com/icaros-usc/pyribs/blob/master/CONTRIBUTING.md).
- [x] I have formatted my code using `yapf`
- [x] I have tested my code by running `pytest`
- [x] I have linted my code with `pylint`
- [x] I have added a one-line description of my change to the changelog in `HISTORY.md`.
- [x] This PR is ready to go
