### PR TITLE
Add selectors (`FilterSelector` and `MuSelector`) which determines how many solutions to use as evolution parents

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,6 +6,8 @@
 
 #### API
 
+- Add selectors (FilterSelector and MuSelector), which determines how many
+  solutions to use as evolution parents (#217)
 - Add elites_with_measures_single method for getting elite for a single
   solution's measures (#215)
 - Introduced the Ranker object, which is responsible for ranking the solutions

--- a/ribs/emitters/rankers.py
+++ b/ribs/emitters/rankers.py
@@ -76,14 +76,13 @@ class RankerBase(ABC):
 
     Child classes are only required to override :meth:`rank`.
     """
+    # pylint: disable=missing-function-docstring
 
     @abstractmethod
     def rank(self, emitter, archive, rng, solution_batch, objective_batch,
              measures_batch, metadata, add_statuses, add_values):
-        # pylint: disable=missing-function-docstring
         pass
 
-    # Generates the docstring for rank
     rank.__doc__ = f"""
 Generates a batch of indices that represents an ordering of ``solution_batch``.
 
@@ -91,7 +90,6 @@ Generates a batch of indices that represents an ordering of ``solution_batch``.
     """
 
     def reset(self, emitter, archive, rng):
-        # pylint: disable=missing-function-docstring
         pass
 
     reset.__doc__ = f"""
@@ -181,7 +179,6 @@ Ranks the soutions based on projection onto a direction in measure space.
         unscaled_dir = rng.standard_normal(measure_dim)
         self._target_measure_dir = unscaled_dir * ranges
 
-    # Generates the docstring for reset
     reset.__doc__ = f"""
 Generates a random direction in the archive space.
 

--- a/ribs/emitters/selectors.py
+++ b/ribs/emitters/selectors.py
@@ -1,0 +1,113 @@
+"""Selectors for use across emitters.
+
+The selectors implemented in this file are intended to be used with emitters.
+The ``Selector`` object will define the :meth:`select` method which returns the
+num of top-performing candidates that should be taken as parents for the
+evolution strategy. It will also define a :meth:`reset` method which resets
+the internal state of the object.
+
+.. autosummary::
+    :toctree:
+
+    ribs.emitters.selectors.MuSelector
+    ribs.emitters.selectors.FilterSelector
+    ribs.emitters.selectors.SelectorBase
+"""
+from abc import ABC, abstractmethod
+
+from ribs._docstrings import DocstringComponents, core_args
+
+__all__ = [
+    "MuSelector",
+    "FilterSelector",
+    "SelectorBase",
+]
+
+_select_args = f"""
+Args:
+{core_args.emitter}
+{core_args.archive}
+{core_args.solutions}
+{core_args.objective_values}
+{core_args.behavior_values}
+{core_args.metadata}
+{core_args.add_statuses}
+{core_args.add_values}
+
+Returns:
+    The number of top-performing solutions to select as parents.
+"""
+
+_reset_args = f"""
+Args:
+{core_args.emitter}
+{core_args.archive}
+"""
+
+
+class SelectorBase(ABC):
+    """Base class for selectors.
+
+    Every selector has a :meth:`select` method that returns the number of
+    top-performing parents to select from the ranking and a :meth:`reset`
+    method that resets the internal state of the selector.
+
+    Child classes are only required to override :meth:`select`.
+    """
+    # pylint: disable=missing-function-docstring
+
+    @abstractmethod
+    def select(self, emitter, archive, solutions, objective_values,
+               behavior_values, metadata, add_statuses, add_values):
+        pass
+
+    select.__doc__ = f"""
+Selects the number of parents that will be used for the evolution strategy.
+
+{_select_args}
+    """
+
+    def reset(self, emitter, archive):
+        pass
+
+    reset.__doc__ = f"""
+Resets the internal state of the selector.
+
+{_reset_args}
+   """
+
+
+class MuSelector(SelectorBase):
+    """Implementation of MuSelector.
+
+    This selector will select the top :math:`\\mu` solutions
+    as parents.
+    """
+
+    def select(self, emitter, archive, solutions, objective_values,
+               behavior_values, metadata, add_statuses, add_values):
+        return emitter.batch_size // 2
+
+    select.__doc__ = f"""
+Selects the top :math:`\\mu` solutions.
+
+{_select_args}
+    """
+
+
+class FilterSelector(SelectorBase):
+    """Implementation of FilterSelector.
+
+    This selector will select all the *added* and *improved* solutions
+    as parents.
+    """
+
+    def select(self, emitter, archive, solutions, objective_values,
+               behavior_values, metadata, add_statuses, add_values):
+        return add_statuses.astype(bool).sum()
+
+    select.__doc__ = f"""
+Selects all the added solutions and the improved solutions.
+
+{_select_args}
+    """

--- a/ribs/emitters/selectors.py
+++ b/ribs/emitters/selectors.py
@@ -15,6 +15,8 @@ the internal state of the object.
 """
 from abc import ABC, abstractmethod
 
+import numpy as np
+
 from ribs._docstrings import DocstringComponents, core_args
 
 __all__ = [
@@ -106,7 +108,7 @@ class FilterSelector(SelectorBase):
 
     def select(self, emitter, archive, rng, solution_batch, objective_batch,
                measures_batch, metadata, add_statuses, add_values):
-        return add_statuses.astype(bool).sum()
+        return np.array(add_statuses).astype(bool).sum()
 
     select.__doc__ = f"""
 Selects all the added and improved solutions.

--- a/ribs/emitters/selectors.py
+++ b/ribs/emitters/selectors.py
@@ -23,16 +23,18 @@ __all__ = [
     "SelectorBase",
 ]
 
+_args = DocstringComponents(core_args)
+
 _select_args = f"""
 Args:
-{core_args.emitter}
-{core_args.archive}
-{core_args.solutions}
-{core_args.objective_values}
-{core_args.behavior_values}
-{core_args.metadata}
-{core_args.add_statuses}
-{core_args.add_values}
+{_args.emitter}
+{_args.archive}
+{_args.solution_batch}
+{_args.objective_batch}
+{_args.measures_batch}
+{_args.metadata}
+{_args.add_statuses}
+{_args.add_values}
 
 Returns:
     The number of top-performing solutions to select as parents.
@@ -40,8 +42,8 @@ Returns:
 
 _reset_args = f"""
 Args:
-{core_args.emitter}
-{core_args.archive}
+{_args.emitter}
+{_args.archive}
 """
 
 
@@ -57,8 +59,8 @@ class SelectorBase(ABC):
     # pylint: disable=missing-function-docstring
 
     @abstractmethod
-    def select(self, emitter, archive, solutions, objective_values,
-               behavior_values, metadata, add_statuses, add_values):
+    def select(self, emitter, archive, rng, solution_batch, objective_batch,
+               measures_batch, metadata, add_statuses, add_values):
         pass
 
     select.__doc__ = f"""
@@ -67,7 +69,7 @@ Selects the number of parents that will be used for the evolution strategy.
 {_select_args}
     """
 
-    def reset(self, emitter, archive):
+    def reset(self, emitter, archive, rng):
         pass
 
     reset.__doc__ = f"""
@@ -84,8 +86,8 @@ class MuSelector(SelectorBase):
     as parents.
     """
 
-    def select(self, emitter, archive, solutions, objective_values,
-               behavior_values, metadata, add_statuses, add_values):
+    def select(self, emitter, archive, rng, solution_batch, objective_batch,
+               measures_batch, metadata, add_statuses, add_values):
         return emitter.batch_size // 2
 
     select.__doc__ = f"""
@@ -102,12 +104,12 @@ class FilterSelector(SelectorBase):
     as parents.
     """
 
-    def select(self, emitter, archive, solutions, objective_values,
-               behavior_values, metadata, add_statuses, add_values):
+    def select(self, emitter, archive, rng, solution_batch, objective_batch,
+               measures_batch, metadata, add_statuses, add_values):
         return add_statuses.astype(bool).sum()
 
     select.__doc__ = f"""
-Selects all the added solutions and the improved solutions.
+Selects all the added and improved solutions.
 
 {_select_args}
     """

--- a/tests/emitters/rankers_test.py
+++ b/tests/emitters/rankers_test.py
@@ -104,7 +104,7 @@ def test_two_stage_random_direction():
 
 def test_objective_ranker(archive_fixture):
     archive, x0 = archive_fixture
-    emitter = GaussianEmitter(archive, x0, 1, batch_size=2)
+    emitter = GaussianEmitter(archive, x0, 1, batch_size=4)
 
     solutions = emitter.ask()
     objective_values = [0, 3, 2, 1]

--- a/tests/emitters/selectors_test.py
+++ b/tests/emitters/selectors_test.py
@@ -1,0 +1,52 @@
+"""Tests for the rankers."""
+
+from ribs.emitters import GaussianEmitter
+from ribs.emitters.selectors import FilterSelector, MuSelector
+
+
+def test_filter_selector(archive_fixture):
+    archive, x0 = archive_fixture
+    emitter = GaussianEmitter(archive, x0, 1, batch_size=4)
+
+    solutions = emitter.ask()
+    objective_values = [0, 3, 2, 1]
+    behavior_values = [[0], [0], [1], [1]]
+    metadata = []
+    statuses = []
+    values = []
+    for (sol, obj, beh) in zip(solutions, objective_values, behavior_values):
+        status, value = archive.add(sol, obj, beh)
+        statuses.append(status)
+        values.append(value)
+
+    selector = FilterSelector()
+
+    num_parents = selector.select(emitter, archive, None, solutions,
+                                  objective_values, behavior_values, metadata,
+                                  statuses, values)
+    print(statuses)
+    assert num_parents == 3
+
+
+def test_mu_selector(archive_fixture):
+    archive, x0 = archive_fixture
+    emitter = GaussianEmitter(archive, x0, 1, batch_size=4)
+
+    solutions = emitter.ask()
+    objective_values = [0, 1, 2, 3]
+    behavior_values = [[0], [0], [1], [1]]
+    metadata = []
+    statuses = []
+    values = []
+    for (sol, obj, beh) in zip(solutions, objective_values, behavior_values):
+        status, value = archive.add(sol, obj, beh)
+        statuses.append(status)
+        values.append(value)
+
+    selector = MuSelector()
+
+    num_parents = selector.select(emitter, archive, None, solutions,
+                                objective_values, behavior_values, metadata,
+                                statuses, values)
+
+    assert num_parents == 2


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the PR's purpose here. -->
*This PR is a split from #207*

This PR introduces major API changes for the Emitter class. Emitter class now requires a Ranker object and a Selector object.

The Ranker object will define a rank function which returns the index of the solutions in the descending order that they should be in. It will also define a reset function which resets the internal states of the object.

RandomDirectionEmitter, OptimizingEmitter, and ImprovementEmitter are now all combined into EvolutionStrategyEmitter, which can be configured to use different Ranker's.

**We also introduce FilterSelector and MuSelector objects which defines a select() function that decides how many parents to select from the potential parents.**

EvolutionStrategyEmitter(x0, sigma0, ranker=Ranker, string, selector, ES, restart_rule, bounds, batch_size, seed)
If ranker=str, then we create the object for you


## TODO

<!-- Notable points that this PR has either accomplished or will accomplish. -->

- [x] MuSelector
- [x] FilterSelector
- [x] Documentation
- [x] Testing

## Questions
- [ ] Clarify how `MuSelector` is supposed to work

## Status

- [x] I have read the guidelines in [CONTRIBUTING.md](https://github.com/icaros-usc/pyribs/blob/master/CONTRIBUTING.md).
- [x] I have formatted my code using `yapf`
- [x] I have tested my code by running `pytest`
- [x] I have linted my code with `pylint`
- [x] I have added a one-line description of my change to the changelog in `HISTORY.md`.
- [ ] This PR is ready to go
