### PR TITLE
Remove decorator from pinned reqs

### DIFF
--- a/pinned_reqs/install.txt
+++ b/pinned_reqs/install.txt
@@ -5,5 +5,4 @@ toml==0.10.0
 sortedcontainers==2.0.0
 scikit-learn==0.20.0
 scipy==1.4.0
-decorator==4.0.0
 threadpoolctl==2.0.0


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the PR's purpose here. -->

Forgot to remove the `decorator` package from the pinned requirements when we removed it from `setup.py` in #200

## TODO

<!-- Notable points that this PR has either accomplished or will accomplish. -->

## Questions

<!-- Any concerns or points of confusion? -->

## Status

- [x] I have read the guidelines in [CONTRIBUTING.md](https://github.com/icaros-usc/pyribs/blob/master/CONTRIBUTING.md).
- [x] I have formatted my code using `yapf`
- [x] I have tested my code by running `pytest`
- [x] I have linted my code with `pylint`
- [x] I have added a one-line description of my change to the changelog in `HISTORY.md`
  - Exclude
- [x] This PR is ready to go
