### PR TITLE
Raise ValueError for incorrect array shapes in archive methods

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,6 +6,7 @@
 
 #### API
 
+- Raise ValueError for incorrect array shapes in archive methods (#219)
 - Add elites_with_measures_single method for getting elite for a single
   solution's measures (#215)
 - Introduced the Ranker object, which is responsible for ranking the solutions

--- a/ribs/_utils.py
+++ b/ribs/_utils.py
@@ -15,13 +15,13 @@ def check_measures_batch_shape(measures_batch,
                          f"(batch_size, measure_dim)) but it had shape {shape}")
 
 
-def check_measures_shape(measures, measure_dim):
+def check_measures_shape(measures, measure_dim, name="measures"):
     """Checks the shape of a 1D vector of measures.
 
     `measures` must be a numpy array.
     """
     shape = measures.shape
     if len(shape) != 1 or shape[0] != measure_dim:
-        raise ValueError("Expected measures to be a 1D array with shape "
+        raise ValueError(f"Expected {name} to be a 1D array with shape "
                          f"({measure_dim},) (i.e. shape (measure_dim,)) "
                          f"but it had shape {shape}")

--- a/ribs/_utils.py
+++ b/ribs/_utils.py
@@ -1,0 +1,15 @@
+"""Miscellaneous internal utilities."""
+
+
+def check_measures_batch_shape(measures_batch, measure_dim):
+    """Checks the shape of a batch of measures."""
+    shape = measures_batch.shape
+    if len(shape) != 2 or shape[1] != measure_dim:
+        raise ValueError(
+            "Expected measures_batch to be a 2D array with shape "
+            f"(batch_size, measure_dim) (i.e. (batch_size, {measure_dim})) "
+            f"but it had shape {shape}")
+
+
+def check_measures_shape(measures, measure_dim):
+    pass

--- a/ribs/_utils.py
+++ b/ribs/_utils.py
@@ -1,17 +1,18 @@
 """Miscellaneous internal utilities."""
 
 
-def check_measures_batch_shape(measures_batch, measure_dim):
+def check_measures_batch_shape(measures_batch,
+                               measure_dim,
+                               name="measures_batch"):
     """Checks the shape of a batch of measures.
 
     `measures_batch` must be a numpy array.
     """
     shape = measures_batch.shape
     if len(shape) != 2 or shape[1] != measure_dim:
-        raise ValueError(
-            "Expected measures_batch to be a 2D array with shape "
-            f"(batch_size, measure_dim) (i.e. (batch_size, {measure_dim})) "
-            f"but it had shape {shape}")
+        raise ValueError(f"Expected {name} to be a 2D array with shape "
+                         f"(batch_size, {measure_dim}) (i.e. shape "
+                         f"(batch_size, measure_dim)) but it had shape {shape}")
 
 
 def check_measures_shape(measures, measure_dim):
@@ -22,5 +23,5 @@ def check_measures_shape(measures, measure_dim):
     shape = measures.shape
     if len(shape) != 1 or shape[0] != measure_dim:
         raise ValueError("Expected measures to be a 1D array with shape "
-                         f"(measure_dim,) (i.e. ({measure_dim},)) "
+                         f"({measure_dim},) (i.e. shape (measure_dim,)) "
                          f"but it had shape {shape}")

--- a/ribs/_utils.py
+++ b/ribs/_utils.py
@@ -2,7 +2,10 @@
 
 
 def check_measures_batch_shape(measures_batch, measure_dim):
-    """Checks the shape of a batch of measures."""
+    """Checks the shape of a batch of measures.
+
+    `measures_batch` must be a numpy array.
+    """
     shape = measures_batch.shape
     if len(shape) != 2 or shape[1] != measure_dim:
         raise ValueError(
@@ -12,4 +15,12 @@ def check_measures_batch_shape(measures_batch, measure_dim):
 
 
 def check_measures_shape(measures, measure_dim):
-    pass
+    """Checks the shape of a 1D vector of measures.
+
+    `measures` must be a numpy array.
+    """
+    shape = measures.shape
+    if len(shape) != 1 or shape[0] != measure_dim:
+        raise ValueError("Expected measures to be a 1D array with shape "
+                         f"(measure_dim,) (i.e. ({measure_dim},)) "
+                         f"but it had shape {shape}")

--- a/ribs/archives/_archive_base.py
+++ b/ribs/archives/_archive_base.py
@@ -4,7 +4,7 @@ from collections import OrderedDict
 
 import numba as nb
 import numpy as np
-
+from ribs._utils import check_measures_batch_shape
 from ribs.archives._add_status import AddStatus
 from ribs.archives._archive_data_frame import ArchiveDataFrame
 from ribs.archives._archive_stats import ArchiveStats
@@ -453,7 +453,10 @@ class ArchiveBase(ABC):  # pylint: disable = too-many-instance-attributes
         Returns:
             EliteBatch: See above.
         """
-        index_batch = self.index_of(np.asarray(measures_batch))
+        measures_batch = np.asarray(measures_batch)
+        check_measures_batch_shape(measures_batch, self.behavior_dim)
+
+        index_batch = self.index_of(measures_batch)
         occupied_batch = self._occupied[index_batch]
         expanded_occupied_batch = occupied_batch[:, None]
 

--- a/ribs/archives/_archive_base.py
+++ b/ribs/archives/_archive_base.py
@@ -4,7 +4,8 @@ from collections import OrderedDict
 
 import numba as nb
 import numpy as np
-from ribs._utils import check_measures_batch_shape
+
+from ribs._utils import check_measures_batch_shape, check_measures_shape
 from ribs.archives._add_status import AddStatus
 from ribs.archives._archive_data_frame import ArchiveDataFrame
 from ribs.archives._archive_stats import ArchiveStats
@@ -303,7 +304,9 @@ class ArchiveBase(ABC):  # pylint: disable = too-many-instance-attributes
             int or numpy.integer: Integer index of the measures in the archive's
             storage arrays.
         """
-        return self.index_of(np.asarray(measures)[None])[0]
+        measures = np.asarray(measures)
+        check_measures_shape(measures, self.behavior_dim)
+        return self.index_of(measures[None])[0]
 
     @staticmethod
     @nb.jit(locals={"already_occupied": nb.types.b1}, nopython=True)
@@ -518,7 +521,10 @@ class ArchiveBase(ABC):  # pylint: disable = too-many-instance-attributes
             returns an :namedtuple:`Elite` filled with the same "empty" values
             described in :meth:`elites_with_measures`.
         """
-        elite_batch = self.elites_with_measures([measures])
+        measures = np.asarray(measures)
+        check_measures_shape(measures, self.behavior_dim)
+
+        elite_batch = self.elites_with_measures(measures[None])
         return Elite(
             elite_batch.solution_batch[0],
             elite_batch.objective_batch[0],

--- a/ribs/archives/_archive_base.py
+++ b/ribs/archives/_archive_base.py
@@ -303,6 +303,8 @@ class ArchiveBase(ABC):  # pylint: disable = too-many-instance-attributes
         Returns:
             int or numpy.integer: Integer index of the measures in the archive's
             storage arrays.
+        Raises:
+            ValueError: ``measures`` is not of shape (:attr:`behavior_dim`,).
         """
         measures = np.asarray(measures)
         check_measures_shape(measures, self.behavior_dim)
@@ -455,6 +457,9 @@ class ArchiveBase(ABC):  # pylint: disable = too-many-instance-attributes
                 array of coordinates in measure space.
         Returns:
             EliteBatch: See above.
+        Raises:
+            ValueError: ``measures_batch`` is not of shape (batch_size,
+                :attr:`behavior_dim`).
         """
         measures_batch = np.asarray(measures_batch)
         check_measures_batch_shape(measures_batch, self.behavior_dim)
@@ -520,6 +525,8 @@ class ArchiveBase(ABC):  # pylint: disable = too-many-instance-attributes
             the fields hold the info of that elite. Otherwise, this method
             returns an :namedtuple:`Elite` filled with the same "empty" values
             described in :meth:`elites_with_measures`.
+        Raises:
+            ValueError: ``measures`` is not of shape (:attr:`behavior_dim`,).
         """
         measures = np.asarray(measures)
         check_measures_shape(measures, self.behavior_dim)

--- a/ribs/archives/_cvt_archive.py
+++ b/ribs/archives/_cvt_archive.py
@@ -4,6 +4,7 @@ from numba import jit
 from scipy.spatial import cKDTree  # pylint: disable=no-name-in-module
 from sklearn.cluster import k_means
 
+from ribs._utils import check_measures_batch_shape
 from ribs.archives._archive_base import ArchiveBase
 
 
@@ -240,6 +241,7 @@ class CVTArchive(ArchiveBase):
             corresponding to each measure space coordinate.
         """
         measures_batch = np.asarray(measures_batch)
+        check_measures_batch_shape(measures_batch, self.behavior_dim)
 
         if self._use_kd_tree:
             return np.asarray(

--- a/ribs/archives/_cvt_archive.py
+++ b/ribs/archives/_cvt_archive.py
@@ -239,6 +239,9 @@ class CVTArchive(ArchiveBase):
         Returns:
             numpy.ndarray: (batch_size,) array of centroid indices
             corresponding to each measure space coordinate.
+        Raises:
+            ValueError: ``measures_batch`` is not of shape (batch_size,
+                :attr:`behavior_dim`).
         """
         measures_batch = np.asarray(measures_batch)
         check_measures_batch_shape(measures_batch, self.behavior_dim)

--- a/ribs/archives/_grid_archive.py
+++ b/ribs/archives/_grid_archive.py
@@ -161,6 +161,9 @@ class GridArchive(ArchiveBase):
         Returns:
             numpy.ndarray: (batch_size,) array of integer indices representing
             the flattened grid coordinates.
+        Raises:
+            ValueError: ``measures_batch`` is not of shape (batch_size,
+                :attr:`behavior_dim`).
         """
         measures_batch = np.asarray(measures_batch)
         check_measures_batch_shape(measures_batch, self.behavior_dim)
@@ -184,8 +187,16 @@ class GridArchive(ArchiveBase):
                 array of indices in the archive grid.
         Returns:
             numpy.ndarray: (batch_size,) array of integer indices.
+        Raises:
+            ValueError: ``grid_index_batch`` is not of shape (batch_size,
+                :attr:`behavior_dim`)
         """
-        return np.ravel_multi_index(np.asarray(grid_index_batch).T,
+        grid_index_batch = np.asarray(grid_index_batch)
+        check_measures_batch_shape(grid_index_batch,
+                                   self.behavior_dim,
+                                   name="grid_index_batch")
+
+        return np.ravel_multi_index(grid_index_batch.T,
                                     self._dims).astype(np.int32)
 
     def int_to_grid_index(self, int_index_batch):
@@ -199,9 +210,15 @@ class GridArchive(ArchiveBase):
         Returns:
             numpy.ndarray: (batch_size, :attr:`behavior_dim`) array of indices
             in the archive grid.
+        Raises:
+            ValueError: ``int_index_batch`` is not of shape (batch_size,).
         """
-        return np.asarray(
-            np.unravel_index(
-                np.asarray(int_index_batch),
-                self._dims,
-            )).T.astype(np.int32)
+        int_index_batch = np.asarray(int_index_batch)
+        if len(int_index_batch.shape) != 1:
+            raise ValueError("Expected int_index_batch to be a 1D array "
+                             f"but it had shape {int_index_batch.shape}")
+
+        return np.asarray(np.unravel_index(
+            int_index_batch,
+            self._dims,
+        )).T.astype(np.int32)

--- a/ribs/archives/_grid_archive.py
+++ b/ribs/archives/_grid_archive.py
@@ -2,6 +2,7 @@
 import numpy as np
 from numba import jit
 
+from ribs._utils import check_measures_batch_shape
 from ribs.archives._archive_base import ArchiveBase
 
 _EPSILON = 1e-6
@@ -161,9 +162,12 @@ class GridArchive(ArchiveBase):
             numpy.ndarray: (batch_size,) array of integer indices representing
             the flattened grid coordinates.
         """
+        measures_batch = np.asarray(measures_batch)
+        check_measures_batch_shape(measures_batch, self.behavior_dim)
+
         return self.grid_to_int_index(
             self._index_of_numba(
-                np.asarray(measures_batch),
+                measures_batch,
                 self._upper_bounds,
                 self._lower_bounds,
                 self._interval_size,

--- a/ribs/archives/_sliding_boundaries_archive.py
+++ b/ribs/archives/_sliding_boundaries_archive.py
@@ -283,6 +283,9 @@ class SlidingBoundariesArchive(ArchiveBase):
         Returns:
             numpy.ndarray: (batch_size,) array of integer indices representing
             the flattened grid coordinates.
+        Raises:
+            ValueError: ``measures_batch`` is not of shape (batch_size,
+                :attr:`behavior_dim`).
         """
         measures_batch = np.asarray(measures_batch)
         check_measures_batch_shape(measures_batch, self.behavior_dim)

--- a/ribs/archives/_sliding_boundaries_archive.py
+++ b/ribs/archives/_sliding_boundaries_archive.py
@@ -6,6 +6,7 @@ import numba as nb
 import numpy as np
 from sortedcontainers import SortedList
 
+from ribs._utils import check_measures_batch_shape
 from ribs.archives._archive_base import ArchiveBase
 from ribs.archives._grid_archive import GridArchive
 
@@ -283,8 +284,11 @@ class SlidingBoundariesArchive(ArchiveBase):
             numpy.ndarray: (batch_size,) array of integer indices representing
             the flattened grid coordinates.
         """
+        measures_batch = np.asarray(measures_batch)
+        check_measures_batch_shape(measures_batch, self.behavior_dim)
+
         index_cols = SlidingBoundariesArchive._index_of_numba(
-            np.asarray(measures_batch),
+            measures_batch,
             self.upper_bounds,
             self.lower_bounds,
             self._boundaries,

--- a/tests/archives/archive_base_test.py
+++ b/tests/archives/archive_base_test.py
@@ -290,3 +290,28 @@ def test_as_pandas(name, with_elite, include_solutions, include_metadata,
         if include_metadata:
             expected_data.append(data.metadata)
         assert (df.loc[0, "behavior_0":] == expected_data).all()
+
+
+#
+# Check that incorrect input shapes are detected by these methods.
+#
+
+
+def test_elites_with_measures_wrong_shape(data):
+    with pytest.raises(ValueError):
+        data.archive.elites_with_measures([data.behavior_values[:-1]])
+
+
+def test_elites_with_measures_single_wrong_shape(data):
+    with pytest.raises(ValueError):
+        data.archive.elites_with_measures_single(data.behavior_values[:-1])
+
+
+def test_index_of_wrong_shape(data):
+    with pytest.raises(ValueError):
+        data.archive.index_of([data.behavior_values[:-1]])
+
+
+def test_index_of_single_wrong_shape(data):
+    with pytest.raises(ValueError):
+        data.archive.elites_with_measures_single(data.behavior_values[:-1])

--- a/tests/archives/archive_base_test.py
+++ b/tests/archives/archive_base_test.py
@@ -120,13 +120,24 @@ def test_stats_add_and_overwrite():
 
 
 #
-# index_of_single() tests -- on GridArchive only.
+# index_of() and index_of_single() tests
 #
 
 
+def test_index_of_wrong_shape(data):
+    with pytest.raises(ValueError):
+        data.archive.index_of([data.behavior_values[:-1]])
+
+
+# Only test on GridArchive.
 def test_index_of_single():
     data = get_archive_data("GridArchive")
     assert data.archive.index_of_single(data.behavior_values) == data.int_index
+
+
+def test_index_of_single_wrong_shape(data):
+    with pytest.raises(ValueError):
+        data.archive.elites_with_measures_single(data.behavior_values[:-1])
 
 
 #
@@ -203,6 +214,11 @@ def test_elites_with_measures_empty_values(data):
     assert elite_batch.metadata_batch[0] is None
 
 
+def test_elites_with_measures_wrong_shape(data):
+    with pytest.raises(ValueError):
+        data.archive.elites_with_measures([data.behavior_values[:-1]])
+
+
 def test_elites_with_measures_single_gets_correct_elite(data):
     elite = data.archive_with_elite.elites_with_measures_single(
         data.behavior_values)
@@ -220,6 +236,11 @@ def test_elites_with_measures_single_empty_values(data):
     assert np.all(np.isnan(elite.measures))
     assert elite.index == -1
     assert elite.metadata is None
+
+
+def test_elites_with_measures_single_wrong_shape(data):
+    with pytest.raises(ValueError):
+        data.archive.elites_with_measures_single(data.behavior_values[:-1])
 
 
 def test_sample_elites_gets_single_elite(data):
@@ -290,28 +311,3 @@ def test_as_pandas(name, with_elite, include_solutions, include_metadata,
         if include_metadata:
             expected_data.append(data.metadata)
         assert (df.loc[0, "behavior_0":] == expected_data).all()
-
-
-#
-# Check that incorrect input shapes are detected by these methods.
-#
-
-
-def test_elites_with_measures_wrong_shape(data):
-    with pytest.raises(ValueError):
-        data.archive.elites_with_measures([data.behavior_values[:-1]])
-
-
-def test_elites_with_measures_single_wrong_shape(data):
-    with pytest.raises(ValueError):
-        data.archive.elites_with_measures_single(data.behavior_values[:-1])
-
-
-def test_index_of_wrong_shape(data):
-    with pytest.raises(ValueError):
-        data.archive.index_of([data.behavior_values[:-1]])
-
-
-def test_index_of_single_wrong_shape(data):
-    with pytest.raises(ValueError):
-        data.archive.elites_with_measures_single(data.behavior_values[:-1])

--- a/tests/archives/grid_archive_test.py
+++ b/tests/archives/grid_archive_test.py
@@ -23,7 +23,7 @@ def assert_archive_elite(archive, solution, objective, measures, grid_indices,
     assert np.isclose(elite.solution, solution).all()
     assert np.isclose(elite.objective, objective).all()
     assert np.isclose(elite.measures, measures).all()
-    assert elite.index == archive.grid_to_int_index(grid_indices)
+    assert elite.index == archive.grid_to_int_index([grid_indices])
     assert elite.metadata == metadata
 
 

--- a/tests/archives/grid_archive_test.py
+++ b/tests/archives/grid_archive_test.py
@@ -125,7 +125,17 @@ def test_grid_to_int_index(data):
                                            ])[0] == data.int_index)
 
 
+def test_grid_to_int_index_wrong_shape(data):
+    with pytest.raises(ValueError):
+        data.archive.grid_to_int_index([data.grid_indices[:-1]])
+
+
 def test_int_to_grid_index(data):
     assert np.all(
         data.archive.int_to_grid_index([data.int_index])[0] ==
         data.grid_indices)
+
+
+def test_int_to_grid_index_wrong_shape(data):
+    with pytest.raises(ValueError):
+        data.archive.int_to_grid_index(data.int_index)

--- a/tests/emitters/rankers_test.py
+++ b/tests/emitters/rankers_test.py
@@ -4,10 +4,10 @@ import numpy as np
 
 from ribs.archives import GridArchive
 from ribs.emitters import GaussianEmitter
-from ribs.emitters.rankers import (TwoStageImprovementRanker,
-                                   RandomDirectionRanker,
-                                   TwoStageRandomDirectionRanker,
-                                   ObjectiveRanker, TwoStageObjectiveRanker)
+from ribs.emitters.rankers import (ObjectiveRanker, RandomDirectionRanker,
+                                   TwoStageImprovementRanker,
+                                   TwoStageObjectiveRanker,
+                                   TwoStageRandomDirectionRanker)
 
 
 def test_two_stage_improvement_ranker(archive_fixture):
@@ -18,7 +18,7 @@ def test_two_stage_improvement_ranker(archive_fixture):
     # objective_values and behavior_values.
     solutions = emitter.ask()
     objective_values = [0, 1, 3, 6]
-    behavior_values = [[0], [0], [0], [0]]
+    behavior_values = [[0, 0], [0, 0], [0, 0], [0, 0]]
     metadata = []
     statuses = []
     values = []
@@ -108,7 +108,7 @@ def test_objective_ranker(archive_fixture):
 
     solutions = emitter.ask()
     objective_values = [0, 3, 2, 1]
-    behavior_values = [[0], [0], [1], [1]]
+    behavior_values = [[0, 0], [0, 0], [1, 1], [1, 1]]
     metadata = []
     statuses = []
     values = []
@@ -131,12 +131,7 @@ def test_two_stage_objective_ranker(archive_fixture):
 
     solutions = emitter.ask()
     objective_values = [0, 3, 1, 2]
-    behavior_values = [
-        [0],
-        [0],
-        [1],
-        [1],
-    ]
+    behavior_values = [[0, 0], [0, 0], [1, 1], [1, 1]]
     metadata = []
     statuses = []
     values = []


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the PR's purpose here. -->

## TODO

<!-- Notable points that this PR has either accomplished or will accomplish. -->

- [x] Add checking utils to all methods
  - [x] index_of / index_of_single
  - [x] elites_with_measures / elites_with_measures_single
  - [x] int_to_grid_index / grid_to_int_index
- [x] Test that errors are raised
- [x] Fix any errors we discover along the way

## Questions

<!-- Any concerns or points of confusion? -->

## Status

- [x] I have read the guidelines in [CONTRIBUTING.md](https://github.com/icaros-usc/pyribs/blob/master/CONTRIBUTING.md).
- [x] I have formatted my code using `yapf`
- [x] I have tested my code by running `pytest`
- [x] I have linted my code with `pylint`
- [x] I have added a one-line description of my change to the changelog in `HISTORY.md`.
- [x] This PR is ready to go
