### PR TITLE
Fix `sklearn.cluster.KMeans` deprecation warning on Python 3.9

### DIFF
--- a/ribs/archives/_cvt_archive.py
+++ b/ribs/archives/_cvt_archive.py
@@ -129,7 +129,7 @@ class CVTArchive(ArchiveBase):
             # The default, "auto"/"elkan", allocates a huge array.
             if semantic_version.Version(
                     sklearn.__version__) >= semantic_version.Version("1.1.0"):
-                # In the newer version, "full" has been deprecated in favor of "lloyd".
+                # In the newer versions, "full" has been deprecated in favor of "lloyd".
                 self._k_means_kwargs["algorithm"] = "lloyd"
             else:
                 self._k_means_kwargs["algorithm"] = "full"

--- a/ribs/archives/_cvt_archive.py
+++ b/ribs/archives/_cvt_archive.py
@@ -126,12 +126,12 @@ class CVTArchive(ArchiveBase):
             # The default, "k-means++", takes very long to init.
             self._k_means_kwargs["init"] = "random"
         if "algorithm" not in self._k_means_kwargs:
-            # The default, "auto"/"elkan", allocates a huge array.
             if semantic_version.Version(
                     sklearn.__version__) >= semantic_version.Version("1.1.0"):
                 # In the newer versions, "full" has been deprecated in favor of "lloyd".
                 self._k_means_kwargs["algorithm"] = "lloyd"
             else:
+                # The default, "auto"/"elkan", allocates a huge array.
                 self._k_means_kwargs["algorithm"] = "full"
         if "random_state" not in self._k_means_kwargs:
             self._k_means_kwargs["random_state"] = seed

--- a/ribs/archives/_cvt_archive.py
+++ b/ribs/archives/_cvt_archive.py
@@ -1,5 +1,7 @@
 """Contains the CVTArchive class."""
 import numpy as np
+import semantic_version
+import sklearn
 from numba import jit
 from scipy.spatial import cKDTree  # pylint: disable=no-name-in-module
 from sklearn.cluster import k_means
@@ -125,7 +127,12 @@ class CVTArchive(ArchiveBase):
             self._k_means_kwargs["init"] = "random"
         if "algorithm" not in self._k_means_kwargs:
             # The default, "auto"/"elkan", allocates a huge array.
-            self._k_means_kwargs["algorithm"] = "lloyd"
+            if semantic_version.Version(
+                    sklearn.__version__) >= semantic_version.Version("1.1.0"):
+                # In the newer version, "full" has been deprecated in favor of "lloyd".
+                self._k_means_kwargs["algorithm"] = "lloyd"
+            else:
+                self._k_means_kwargs["algorithm"] = "full"
         if "random_state" not in self._k_means_kwargs:
             self._k_means_kwargs["random_state"] = seed
 

--- a/ribs/archives/_cvt_archive.py
+++ b/ribs/archives/_cvt_archive.py
@@ -76,7 +76,7 @@ class CVTArchive(ArchiveBase):
             ``archive.samples`` will be None. This can be useful when one wishes
             to use the same CVT across experiments for fair comparison.
         k_means_kwargs (dict): kwargs for :func:`~sklearn.cluster.k_means`. By
-            default, we pass in `n_init=1`, `init="random"`, `algorithm="full"`,
+            default, we pass in `n_init=1`, `init="random"`, `algorithm="lloyd"`,
             and `random_state=seed`.
         use_kd_tree (bool): If True, use a k-D tree for finding the closest
             centroid when inserting into the archive. This may result in a
@@ -125,7 +125,7 @@ class CVTArchive(ArchiveBase):
             self._k_means_kwargs["init"] = "random"
         if "algorithm" not in self._k_means_kwargs:
             # The default, "auto"/"elkan", allocates a huge array.
-            self._k_means_kwargs["algorithm"] = "full"
+            self._k_means_kwargs["algorithm"] = "lloyd"
         if "random_state" not in self._k_means_kwargs:
             self._k_means_kwargs["random_state"] = seed
 

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ install_requires = [
     "scikit-learn>=0.20.0",  # Primarily used in CVTArchive.
     "scipy>=1.4.0",  # Primarily used in CVTArchive.
     "threadpoolctl>=2.0.0",
+    "semantic-version>=2.10"
 ]
 
 extras_require = {


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the PR's purpose here. -->

On python 3.9, `sklearn.cluster.kmeans` has deprecated `algorithm='full'`. According to the [documentation](https://scikit-learn.org/stable/modules/generated/sklearn.cluster.KMeans.html) for kmeans,
> "auto" and "full" are deprecated and they will be removed in Scikit-Learn 1.3. They are both aliases for "lloyd".

This deprecation has led to a warning for some users, and this changes resolves that warning.

## TODO

<!-- Notable points that this PR has either accomplished or will accomplish. -->

- [x] Change `algorithm='full'` to `algorithm='lloyd'`

## Status

- [x] I have read the guidelines in [CONTRIBUTING.md](https://github.com/icaros-usc/pyribs/blob/master/CONTRIBUTING.md).
- [x] I have formatted my code using `yapf`
- [x] I have tested my code by running `pytest`
- [x] I have linted my code with `pylint`
- [x] I have added a one-line description of my change to the changelog in `HISTORY.md`.
  - Exclude this from history
- [x] This PR is ready to go
