### PR TITLE
Minimize numba usage

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,6 +6,7 @@
 
 #### API
 
+- Minimize numba usage (#232)
 - **Backwards-incompatible:** Implement batch addition in archives (#221)
   - `add` now adds a batch of solutions to the archive
   - `add_single` adds a single solution

--- a/ribs/archives/_sliding_boundaries_archive.py
+++ b/ribs/archives/_sliding_boundaries_archive.py
@@ -2,6 +2,7 @@
 
 from collections import deque
 
+# TODO: Remove numba.
 import numba as nb
 import numpy as np
 from sortedcontainers import SortedList

--- a/ribs/emitters/_gaussian_emitter.py
+++ b/ribs/emitters/_gaussian_emitter.py
@@ -1,6 +1,5 @@
 """Provides the GaussianEmitter."""
 import numpy as np
-from numba import jit
 
 from ribs.emitters._emitter_base import EmitterBase
 
@@ -92,13 +91,6 @@ class GaussianEmitter(EmitterBase):
         """int: Number of solutions to return in :meth:`ask`."""
         return self._batch_size
 
-    @staticmethod
-    @jit(nopython=True)
-    def _ask_clip_helper(parents, noise, lower_bounds, upper_bounds):
-        """Numba equivalent of np.clip."""
-        return np.minimum(np.maximum(parents + noise, lower_bounds),
-                          upper_bounds)
-
     def ask(self):
         """Creates solutions by adding Gaussian noise to elites in the archive.
 
@@ -125,8 +117,7 @@ class GaussianEmitter(EmitterBase):
             size=(self._batch_size, self.solution_dim),
         ).astype(self.archive.dtype)
 
-        return self._ask_clip_helper(parents, noise, self.lower_bounds,
-                                     self.upper_bounds)
+        return np.clip(parents + noise, self.lower_bounds, self.upper_bounds)
 
     def tell(self,
              solution_batch,


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the PR's purpose here. -->

Batching the archive operations resulted in massive speedups for the library. Since numba tends to overcomplicate the implementation, we have decided to remove as much of it as we can. This does result in ~5s slowdown on the sphere example (e.g. with `cma_me_imp`, `cma_me_imp_mu`, and `map_elites`) but the total runtime is still much lower than before, and we gain much in code readability and hackability.

Note that we will continue to depend on numba (1) since numpy_groupies depends on it and (2) in case we need to speed up any other bottlenecks in the future.

## TODO

<!-- Notable points that this PR has either accomplished or will accomplish. -->

- [x] Merge #221 (this PR depends on it)

## Questions

<!-- Any concerns or points of confusion? -->

## Status

- [x] I have read the guidelines in [CONTRIBUTING.md](https://github.com/icaros-usc/pyribs/blob/master/CONTRIBUTING.md)
- [x] I have formatted my code using `yapf`
- [x] I have tested my code by running `pytest`
- [x] I have linted my code with `pylint`
- [x] I have added a one-line description of my change to the changelog in `HISTORY.md`
- [x] This PR is ready to go
