### PR TITLE
Allow adding solutions one at a time in optimizer

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,6 +6,7 @@
 
 #### API
 
+- Allow adding solutions one at a time in optimizer (#233)
 - **Backwards-incompatible:** Implement batch addition in archives (#221)
   - `add` now adds a batch of solutions to the archive
   - `add_single` adds a single solution


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the PR's purpose here. -->

Added an `add_mode` parameter to the optimizer that allows adding solutions to the archive either in batch or one at a time. This makes it possible to recover the old pyribs behavior if so desired (although it is not recommended).

## TODO

<!-- Notable points that this PR has either accomplished or will accomplish. -->

- [x] Merge #221 (dependency of this PR)

## Questions

<!-- Any concerns or points of confusion? -->

## Status

- [x] I have read the guidelines in [CONTRIBUTING.md](https://github.com/icaros-usc/pyribs/blob/master/CONTRIBUTING.md)
- [x] I have formatted my code using `yapf`
- [x] I have tested my code by running `pytest`
- [x] I have linted my code with `pylint`
- [x] I have added a one-line description of my change to the changelog in `HISTORY.md`
- [x] This PR is ready to go
