### PR TITLE
Move threadpoolctl from optimizer to CMA-ES

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -74,6 +74,7 @@
 
 #### Improvements
 
+- Move threadpoolctl from optimizer to CMA-ES (#241)
 - Remove unnecessary emitter benchmarks (#231)
 - Build docs during CI/CD workflow (#211)
 - Drop Python 3.6 and add Python 3.10 support (#181)

--- a/pinned_reqs/install.txt
+++ b/pinned_reqs/install.txt
@@ -4,4 +4,4 @@ pandas==1.0.0
 sortedcontainers==2.0.0
 scikit-learn==0.20.0
 scipy==1.4.0
-threadpoolctl==2.0.0
+threadpoolctl==3.0.0

--- a/ribs/emitters/opt/_cma_es.py
+++ b/ribs/emitters/opt/_cma_es.py
@@ -5,6 +5,7 @@ https://github.com/CMA-ES/pycma/blob/master/cma/purecma.py
 """
 import numba as nb
 import numpy as np
+from threadpoolctl import threadpool_limits
 
 
 class DecompMatrix:
@@ -180,6 +181,7 @@ class CMAEvolutionStrategy:
         )
         return solutions, out_of_bounds
 
+    @threadpool_limits.wrap(limits=1, user_api="blas")
     def ask(self, lower_bounds, upper_bounds):
         """Samples new solutions from the Gaussian distribution.
 
@@ -250,6 +252,7 @@ class CMAEvolutionStrategy:
         return (cov * (1 - c1a - cmu) + rank_one_update * c1 +
                 rank_mu_update * cmu / (sigma**2))
 
+    @threadpool_limits.wrap(limits=1, user_api="blas")
     def tell(self, solutions, num_parents):
         """Passes the solutions back to the optimizer.
 

--- a/ribs/emitters/opt/_cma_es.py
+++ b/ribs/emitters/opt/_cma_es.py
@@ -181,6 +181,8 @@ class CMAEvolutionStrategy:
         )
         return solutions, out_of_bounds
 
+    # Limit OpenBLAS to single thread. This is typically faster than
+    # multithreading because our data is too small.
     @threadpool_limits.wrap(limits=1, user_api="blas")
     def ask(self, lower_bounds, upper_bounds):
         """Samples new solutions from the Gaussian distribution.
@@ -252,6 +254,8 @@ class CMAEvolutionStrategy:
         return (cov * (1 - c1a - cmu) + rank_one_update * c1 +
                 rank_mu_update * cmu / (sigma**2))
 
+    # Limit OpenBLAS to single thread. This is typically faster than
+    # multithreading because our data is too small.
     @threadpool_limits.wrap(limits=1, user_api="blas")
     def tell(self, solutions, num_parents):
         """Passes the solutions back to the optimizer.

--- a/ribs/optimizers/_optimizer.py
+++ b/ribs/optimizers/_optimizer.py
@@ -1,6 +1,5 @@
 """Provides the Optimizer."""
 import numpy as np
-from threadpoolctl import threadpool_limits
 
 
 class Optimizer:
@@ -113,13 +112,10 @@ class Optimizer:
 
         self._solution_batch = []
 
-        # Limit OpenBLAS to single thread. This is typically faster than
-        # multithreading because our data is too small.
-        with threadpool_limits(limits=1, user_api="blas"):
-            for i, emitter in enumerate(self._emitters):
-                emitter_sols = emitter.ask()
-                self._solution_batch.append(emitter_sols)
-                self._num_emitted[i] = len(emitter_sols)
+        for i, emitter in enumerate(self._emitters):
+            emitter_sols = emitter.ask()
+            self._solution_batch.append(emitter_sols)
+            self._num_emitted[i] = len(emitter_sols)
 
         self._solution_batch = np.concatenate(self._solution_batch, axis=0)
         return self._solution_batch
@@ -194,15 +190,12 @@ class Optimizer:
             status_batch = np.asarray(status_batch)
             value_batch = np.asarray(value_batch)
 
-        # Limit OpenBLAS to single thread. This is typically faster than
-        # multithreading because our data is too small.
-        with threadpool_limits(limits=1, user_api="blas"):
-            # Keep track of pos because emitters may have different batch sizes.
-            pos = 0
-            for emitter, n in zip(self._emitters, self._num_emitted):
-                end = pos + n
-                emitter.tell(self._solution_batch[pos:end],
-                             objective_batch[pos:end], measures_batch[pos:end],
-                             status_batch[pos:end], value_batch[pos:end],
-                             metadata_batch[pos:end])
-                pos = end
+        # Keep track of pos because emitters may have different batch sizes.
+        pos = 0
+        for emitter, n in zip(self._emitters, self._num_emitted):
+            end = pos + n
+            emitter.tell(self._solution_batch[pos:end],
+                         objective_batch[pos:end], measures_batch[pos:end],
+                         status_batch[pos:end], value_batch[pos:end],
+                         metadata_batch[pos:end])
+            pos = end

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ install_requires = [
     "sortedcontainers>=2.0.0",  # Primarily used in SlidingBoundariesArchive.
     "scikit-learn>=0.20.0",  # Primarily used in CVTArchive.
     "scipy>=1.4.0",  # Primarily used in CVTArchive.
-    "threadpoolctl>=2.0.0",
+    "threadpoolctl>=3.0.0",
     "semantic-version>=2.10"
 ]
 


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the PR's purpose here. -->

Previously, we placed threadpoolctl in the optimizer in order to force OpenBLAS to run with only one thread in CMA-ES. However, this meant that all emitters would be affected by OpenBLAS, including ones defined by users. This commit moves threadpoolctl out of the optimizer and into CMA-ES, so that we only limit OpenBLAS in our code.

In #51, we mentioned that moving threadpoolctl to CMA-ES failed due to the overhead of creating the context manager. The new decorator from threadpoolctl seems to resolve this.

Here are some approximate times from running the sphere example (`python examples/sphere.py cma_me_imp --dim 20` and `python examples/sphere.py cma_me_imp --dim 100`) with the different ways of calling threadpoolctl. Note that when threadpoolctl is disabled, the multithreading in OpenBLAS causes race conditions which slow down the execution (see #51).

| Method |  20-dim sphere | 100-dim sphere |
| ---------- | ------ | ----- |
| Only in CMA-ES (this PR) | 55s | 94s |
| In Optimizer (previous) | 55s | 98s |
| No threadpoolctl | 60s | 458s |

## TODO

<!-- Notable points that this PR has either accomplished or will accomplish. -->

## Questions

<!-- Any concerns or points of confusion? -->

## Status

- [x] I have read the guidelines in [CONTRIBUTING.md](https://github.com/icaros-usc/pyribs/blob/master/CONTRIBUTING.md)
- [x] I have formatted my code using `yapf`
- [x] I have tested my code by running `pytest`
- [x] I have linted my code with `pylint`
- [x] I have added a one-line description of my change to the changelog in `HISTORY.md`
- [x] This PR is ready to go
