### PR TITLE
Extract ranker initialization subroutine in emitter constructor to `get_ranker`

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,6 +6,7 @@
 
 #### API
 
+- Extract ranker initialization subroutine in emitter constructor to `get_ranker` (#245)
 - Add `best_elite` property for archives (#237)
 - Rename methods in ArchiveDataFrame and rename as_pandas behavior columns
   (#236)

--- a/ribs/emitters/_evolution_strategy_emitter.py
+++ b/ribs/emitters/_evolution_strategy_emitter.py
@@ -5,7 +5,7 @@ import numpy as np
 
 from ribs.emitters._emitter_base import EmitterBase
 from ribs.emitters.opt import CMAEvolutionStrategy
-from ribs.emitters.rankers import RankerBase, get_ranker
+from ribs.emitters.rankers import RankerBase, _get_ranker
 
 
 class EvolutionStrategyEmitter(EmitterBase):
@@ -90,17 +90,7 @@ class EvolutionStrategyEmitter(EmitterBase):
                                         self.archive.dtype)
         self.opt.reset(self._x0)
 
-        # Handling ranker initiation
-        if isinstance(ranker, str):
-            # get_ranker returns a subclass of RankerBase
-            ranker = get_ranker(ranker)
-        if callable(ranker):
-            self._ranker = ranker()
-            if not isinstance(self._ranker, RankerBase):
-                raise ValueError("Callable " + ranker +
-                                 " did not return a instance of RankerBase.")
-        else:
-            raise ValueError(ranker + " is not one of [Callable, str]")
+        self._ranker = _get_ranker(ranker)
         self._ranker.reset(self, archive, self._rng)
 
         self._batch_size = self.opt.batch_size

--- a/ribs/emitters/rankers.py
+++ b/ribs/emitters/rankers.py
@@ -359,14 +359,14 @@ def _get_ranker(klass):
         The corresponding ranker class.
     """
     if isinstance(klass, str):
-        if klass in _NAME_TO_RANKER_MAP:  # pylint: disable=consider-using-get
-            klass = _NAME_TO_RANKER_MAP[klass]
+        if klass in _NAME_TO_RANKER_MAP:
+            return _NAME_TO_RANKER_MAP[klass]()
+        raise ValueError(f"`{klass}` is not the full or abbreviated "
+                         "name of a valid ranker")
     if callable(klass):
         ranker = klass()
-        if not isinstance(ranker, RankerBase):
-            raise ValueError(
-                f"Callable {klass} did not return an instance of RankerBase.")
-        return ranker
-    raise ValueError(
-        f"{klass} is neither a callable nor the full or abbreviated name of a valid ranker."
-    )
+        if isinstance(ranker, RankerBase):
+            return ranker
+        raise ValueError(f"Callable `{klass}` did not return an instance "
+                         "of RankerBase.")
+    raise ValueError(f"`{klass}` is neither a callable nor a string")

--- a/ribs/emitters/rankers.py
+++ b/ribs/emitters/rankers.py
@@ -6,10 +6,21 @@ The ``Ranker`` object will define the :meth:`rank` method which returns the
 result of a descending argsort of the solutions. It will also define a
 :meth:`reset` method which resets the internal state of the object.
 
+When specifying which ranker to use for each emitter, one could either pass in
+the full name of a ranker, e.g. "ImprovementRanker", or the abbreviated name of
+a ranker, e.g. "imp".
+The supported abbreviations are:
+
+* ``imp``: :class:`ImprovementRanker`
+* ``2imp``: :class:`TwoStageImprovementRanker`
+* ``rd``: :class:`RandomDirectionRanker`
+* ``2rd``: :class:`TwoStageRandomDirectionRanker`
+* ``obj``: :class:`ObjectiveRanker`
+* ``2obj``: :class:`TwoStageObjectiveRanker`
+
 .. autosummary::
     :toctree:
 
-    ribs.emitters.rankers.get_ranker
     ribs.emitters.rankers.ImprovementRanker
     ribs.emitters.rankers.TwoStageImprovementRanker
     ribs.emitters.rankers.RandomDirectionRanker
@@ -25,7 +36,6 @@ import numpy as np
 from ribs._docstrings import DocstringComponents, core_args
 
 __all__ = [
-    "get_ranker",
     "ImprovementRanker",
     "TwoStageImprovementRanker",
     "RandomDirectionRanker",
@@ -333,7 +343,7 @@ _NAME_TO_RANKER_MAP = {
 }
 
 
-def get_ranker(name):
+def _get_ranker(klass):
     """Returns a ranker class based on its name.
 
     ``name`` may be the full name of a ranker, e.g. "ImprovementRanker" or
@@ -348,10 +358,21 @@ def get_ranker(name):
     * ``2obj``: :class:`TwoStageObjectiveRanker`
 
     Args:
-        name (str): Full or abbreviated name of the ranker.
+        klass (Callable or str): This parameter may either be a callable (e.g.
+            a class or a lambda function) that takes in no parameters and
+            returns an instance of :class:`RankerBase`, or it may be a full or
+            abbreviated ranker name.
     Returns:
         The corresponding ranker class.
     """
-    if name in _NAME_TO_RANKER_MAP:
-        return _NAME_TO_RANKER_MAP[name]
-    raise ValueError(f"Could not find ranker with name {name}")
+    if isinstance(klass, str):
+        klass = _NAME_TO_RANKER_MAP.get(klass)
+    if callable(klass):
+        ranker = klass()
+        if not isinstance(ranker, RankerBase):
+            raise ValueError(
+                f"Callable {klass} did not return a instance of RankerBase.")
+        return ranker
+    raise ValueError(
+        f"{klass} is neither a Callable nor the full or abbreviated name of a valid ranker."
+    )

--- a/ribs/emitters/rankers.py
+++ b/ribs/emitters/rankers.py
@@ -359,7 +359,7 @@ def _get_ranker(klass):
         The corresponding ranker class.
     """
     if isinstance(klass, str):
-        if klass in _NAME_TO_RANKER_MAP: # pylint: disable=consider-using-get
+        if klass in _NAME_TO_RANKER_MAP:  # pylint: disable=consider-using-get
             klass = _NAME_TO_RANKER_MAP[klass]
     if callable(klass):
         ranker = klass()

--- a/ribs/emitters/rankers.py
+++ b/ribs/emitters/rankers.py
@@ -365,8 +365,8 @@ def _get_ranker(klass):
         ranker = klass()
         if not isinstance(ranker, RankerBase):
             raise ValueError(
-                f"Callable {klass} did not return a instance of RankerBase.")
+                f"Callable {klass} did not return an instance of RankerBase.")
         return ranker
     raise ValueError(
-        f"{klass} is neither a Callable nor the full or abbreviated name of a valid ranker."
+        f"{klass} is neither a callable nor the full or abbreviated name of a valid ranker."
     )

--- a/ribs/emitters/rankers.py
+++ b/ribs/emitters/rankers.py
@@ -359,7 +359,8 @@ def _get_ranker(klass):
         The corresponding ranker class.
     """
     if isinstance(klass, str):
-        klass = _NAME_TO_RANKER_MAP.get(klass)
+        if klass in _NAME_TO_RANKER_MAP: # pylint: disable=consider-using-get
+            klass = _NAME_TO_RANKER_MAP[klass]
     if callable(klass):
         ranker = klass()
         if not isinstance(ranker, RankerBase):

--- a/ribs/emitters/rankers.py
+++ b/ribs/emitters/rankers.py
@@ -346,16 +346,9 @@ _NAME_TO_RANKER_MAP = {
 def _get_ranker(klass):
     """Returns a ranker class based on its name.
 
-    ``name`` may be the full name of a ranker, e.g. "ImprovementRanker" or
-    "RandomDirectionRanker". Alternatively, it can be the abbreviated name
-    for a ranker -- the supported abbreviations are:
-
-    * ``imp``: :class:`ImprovementRanker`
-    * ``2imp``: :class:`TwoStageImprovementRanker`
-    * ``rd``: :class:`RandomDirectionRanker`
-    * ``2rd``: :class:`TwoStageRandomDirectionRanker`
-    * ``obj``: :class:`ObjectiveRanker`
-    * ``2obj``: :class:`TwoStageObjectiveRanker`
+    ``klass`` can be a reference to the class of the ranker, the full name of
+    a ranker, e.g. "ImprovementRanker", or the abbreviated name for a ranker
+    such as "imp".
 
     Args:
         klass (Callable or str): This parameter may either be a callable (e.g.

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ extras_require = {
     ],
     "dev": [
         "pip>=20.3",
-        "pylint",
+        "pylint==2.8.3",
         "yapf",
 
         # Testing

--- a/tests/emitters/evolution_strategy_emitter_test.py
+++ b/tests/emitters/evolution_strategy_emitter_test.py
@@ -4,21 +4,18 @@ import pytest
 
 from ribs.archives import GridArchive
 from ribs.emitters import EvolutionStrategyEmitter
-from ribs.emitters.rankers import get_ranker
 
 
 def test_auto_batch_size():
-    ranker = get_ranker("obj")
     archive = GridArchive(10, [20, 20], [(-1.0, 1.0)] * 2)
-    emitter = EvolutionStrategyEmitter(archive, np.zeros(10), 1.0, ranker)
+    emitter = EvolutionStrategyEmitter(archive, np.zeros(10), 1.0, "obj")
     assert emitter.batch_size is not None
     assert isinstance(emitter.batch_size, int)
 
 
 def test_list_as_initial_solution():
-    ranker = get_ranker("obj")
     archive = GridArchive(10, [20, 20], [(-1.0, 1.0)] * 2)
-    emitter = EvolutionStrategyEmitter(archive, [0.0] * 10, 1.0, ranker)
+    emitter = EvolutionStrategyEmitter(archive, [0.0] * 10, 1.0, "obj")
 
     # The list was passed in but should be converted to a numpy array.
     assert isinstance(emitter.x0, np.ndarray)
@@ -28,9 +25,8 @@ def test_list_as_initial_solution():
 @pytest.mark.parametrize("dtype", [np.float64, np.float32],
                          ids=["float64", "float32"])
 def test_dtypes(dtype):
-    ranker = get_ranker("obj")
     archive = GridArchive(10, [20, 20], [(-1.0, 1.0)] * 2, dtype=dtype)
-    emitter = EvolutionStrategyEmitter(archive, np.zeros(10), 1.0, ranker)
+    emitter = EvolutionStrategyEmitter(archive, np.zeros(10), 1.0, "obj")
     assert emitter.x0.dtype == dtype
 
     # Try running with the negative sphere function for a few iterations.


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the PR's purpose here. -->
Handle complex ranker initialization logic from evolution_strategy_emitter in `get_ranker()`.

## Status

- [x] I have read the guidelines in [CONTRIBUTING.md](https://github.com/icaros-usc/pyribs/blob/master/CONTRIBUTING.md)
- [x] I have formatted my code using `yapf`
- [x] I have tested my code by running `pytest`
- [x] I have linted my code with `pylint`
- [x] I have added a one-line description of my change to the changelog in `HISTORY.md`
- [x] This PR is ready to go
