### PR TITLE
Allow `sigma0` in `EvolutionStrategyEmitter` to be a vector

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,6 +6,7 @@
 
 #### API
 
+- Allow `sigma0` in `EvolutionStrategyEmitter` to be a vector (#245)
 - Specify that `x0` is 1D for all emitters (#244)
 - Add `best_elite` property for archives (#237)
 - Rename methods in ArchiveDataFrame and rename as_pandas behavior columns

--- a/ribs/emitters/_evolution_strategy_emitter.py
+++ b/ribs/emitters/_evolution_strategy_emitter.py
@@ -68,7 +68,9 @@ class EvolutionStrategyEmitter(EmitterBase):
                  seed=None):
         self._rng = np.random.default_rng(seed)
         self._x0 = np.array(x0, dtype=archive.dtype)
-        self._sigma0 = sigma0
+        self._sigma0 = archive.dtype(sigma0) if isinstance(
+            sigma0,
+            (float, np.floating)) else np.array(sigma0, dtype=archive.dtype)
         EmitterBase.__init__(
             self,
             archive,
@@ -142,7 +144,7 @@ class EvolutionStrategyEmitter(EmitterBase):
              objective_batch,
              measures_batch,
              status_batch,
-             values_batch,
+             value_batch,
              metadata_batch=None):
         """Gives the emitter results from evaluating solutions.
 
@@ -181,7 +183,7 @@ class EvolutionStrategyEmitter(EmitterBase):
         # Sort the solutions using ranker.
         indices, ranking_values = self._ranker.rank(
             self, self.archive, self._rng, solution_batch, objective_batch,
-            measures_batch, status_batch, values_batch, metadata_batch)
+            measures_batch, status_batch, value_batch, metadata_batch)
 
         # Select the number of parents.
         num_parents = (new_sols if self._selection_rule == "filter" else

--- a/tests/emitters/evolution_strategy_emitter_test.py
+++ b/tests/emitters/evolution_strategy_emitter_test.py
@@ -43,3 +43,21 @@ def test_dtypes(dtype):
                                                 measures_batch)
         emitter.tell(solution_batch, objective_batch, measures_batch,
                      status_batch, value_batch)
+
+
+def test_simga0_vector():
+    ranker = get_ranker("obj")
+    archive = GridArchive(10, [20, 20], [(-1.0, 1.0)] * 2)
+    emitter = EvolutionStrategyEmitter(archive, np.zeros(10), [1.0, 1.0],
+                                       ranker)
+
+    # Try running with the negative sphere function for a few iterations.
+    for _ in range(10):
+        solution_batch = emitter.ask()
+        objective_batch = -np.sum(np.square(solution_batch), axis=1)
+        measures_batch = solution_batch[:, :2]
+
+        status_batch, value_batch = archive.add(solution_batch, objective_batch,
+                                                measures_batch)
+        emitter.tell(solution_batch, objective_batch, measures_batch,
+                     status_batch, value_batch)


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the PR's purpose here. -->
Allow sigma0 in EvolutionStrategyEmitter to be a vector.

## TODO
- [ ] Figure out how to allow sigma to be a vector in CMA-ES.

## Status

- [x] I have read the guidelines in [CONTRIBUTING.md](https://github.com/icaros-usc/pyribs/blob/master/CONTRIBUTING.md)
- [x] I have formatted my code using `yapf`
- [x] I have tested my code by running `pytest`
- [x] I have linted my code with `pylint`
- [x] I have added a one-line description of my change to the changelog in `HISTORY.md`
- [x] This PR is ready to go
