### PR TITLE
Fix bug in CMA-ES introduced in #240

### DIFF
--- a/ribs/emitters/opt/_cma_es.py
+++ b/ribs/emitters/opt/_cma_es.py
@@ -231,7 +231,9 @@ class CMAEvolutionStrategy:
                        np.log(np.arange(1, num_parents + 1)))
             total_weights = np.sum(weights)
             weights = weights / total_weights
-            mueff = total_weights**2 / np.sum(weights**2)
+            # Note: Since `weights` changes on the line above, np.sum(weights)
+            # is NOT the same as total_weights.
+            mueff = np.sum(weights)**2 / np.sum(weights**2)
         elif self.weight_rule == "active":
             weights = None
 


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the PR's purpose here. -->

In #240, we introduced a slight change to CMA-ES that resulted in buggy code -- in particular, we received warnings about nan values in sqrt in the tests. This PR reverts that bug.

## TODO

<!-- Notable points that this PR has either accomplished or will accomplish. -->

## Questions

<!-- Any concerns or points of confusion? -->

## Status

- [x] I have read the guidelines in [CONTRIBUTING.md](https://github.com/icaros-usc/pyribs/blob/master/CONTRIBUTING.md)
- [x] I have formatted my code using `yapf`
- [x] I have tested my code by running `pytest`
- [x] I have linted my code with `pylint`
- [x] I have added a one-line description of my change to the changelog in `HISTORY.md`
- [x] This PR is ready to go
