### PR TITLE
Reset thresholds when calling clear

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,7 +6,7 @@
 
 #### API
 
-- Implement CMA-MAE archive thresholds (#256)
+- Implement CMA-MAE archive thresholds (#256, #260)
   - Revive the old implementation of `add_single` removed in (#221)
   - Add separate tests for `add_single` and `add` with single solution
 - Fix all examples and tutorials (#253)

--- a/ribs/archives/_archive_base.py
+++ b/ribs/archives/_archive_base.py
@@ -355,11 +355,14 @@ class ArchiveBase(ABC):  # pylint: disable = too-many-instance-attributes
 
         After this method is called, the archive will be :attr:`empty`.
         """
-        # Only ``self._occupied_indices`` and ``self._occupied_arr`` are
-        # cleared, as a cell can have arbitrary values when its index is marked
-        # as unoccupied.
-        self._num_occupied = 0
+        # Clear ``self._occupied_indices`` and ``self._occupied_arr`` since a
+        # cell can have arbitrary values when its index is marked as unoccupied.
+        self._num_occupied = 0  # Corresponds to clearing _occupied_indices.
         self._occupied_arr.fill(False)
+
+        # We also need to reset thresholds since archive addition is based on
+        # thresholds.
+        self._threshold_arr.fill(self._threshold_min)
 
         self._state["clear"] += 1
         self._state["add"] = 0

--- a/tests/archives/grid_archive_test.py
+++ b/tests/archives/grid_archive_test.py
@@ -269,6 +269,11 @@ def test_add_single_threshold_update(add_mode):
 
 
 def test_add_single_after_clear(data):
+    """After clearing, we should still get the same status and value when adding
+    to the archive.
+
+    https://github.com/icaros-usc/pyribs/pull/260
+    """
     status, value = data.archive.add_single(data.solution, data.objective,
                                             data.measures)
 
@@ -277,8 +282,6 @@ def test_add_single_after_clear(data):
 
     data.archive.clear()
 
-    # After clearing, we should still get the same status and value when adding
-    # to the archive.
     status, value = data.archive.add_single(data.solution, data.objective,
                                             data.measures)
 

--- a/tests/archives/grid_archive_test.py
+++ b/tests/archives/grid_archive_test.py
@@ -268,6 +268,24 @@ def test_add_single_threshold_update(add_mode):
     assert np.isclose(value, 0.1)  # -0.8 - (-0.9)
 
 
+def test_add_single_after_clear(data):
+    status, value = data.archive.add_single(data.solution, data.objective,
+                                            data.measures)
+
+    assert status == 2
+    assert value == data.objective
+
+    data.archive.clear()
+
+    # After clearing, we should still get the same status and value when adding
+    # to the archive.
+    status, value = data.archive.add_single(data.solution, data.objective,
+                                            data.measures)
+
+    assert status == 2
+    assert value == data.objective
+
+
 def test_add_single_wrong_shapes(data):
     with pytest.raises(ValueError):
         data.archive.add_single(


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the PR's purpose here. -->

We encountered a bug where after calling clear(), adding to the archive did not result in the correct statuses and values. This happens because we did not reset the thresholds when calling clear(), and since archive addition is based on crossing the thresholds, nothing was being added to the archive. This PR clears the thresholds to resolve this bug.

## TODO

<!-- Notable points that this PR has either accomplished or will accomplish. -->

## Questions

<!-- Any concerns or points of confusion? -->

## Status

- [x] I have read the guidelines in [CONTRIBUTING.md](https://github.com/icaros-usc/pyribs/blob/master/CONTRIBUTING.md)
- [x] I have formatted my code using `yapf`
- [x] I have tested my code by running `pytest`
- [x] I have linted my code with `pylint`
- [x] I have added a one-line description of my change to the changelog in `HISTORY.md`
- [x] This PR is ready to go
