### PR TITLE
Deprecate positional arguments in constructors

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,7 +6,8 @@
 
 #### API
 
-- Allow custom initialization in Gaussian and IsoLine emitters (#259)
+- **Backwards-incompatible:** Deprecate positional arguments in constructors (#261)
+- **Backwards-incompatible:** Allow custom initialization in Gaussian and IsoLine emitters (#259)
 - Implement CMA-MAE archive thresholds (#256, #260)
   - Revive the old implementation of `add_single` removed in (#221)
   - Add separate tests for `add_single` and `add` with single solution

--- a/examples/lunar_lander.py
+++ b/examples/lunar_lander.py
@@ -165,7 +165,7 @@ def create_scheduler(seed, n_emitters, sigma0, batch_size):
     emitters = [
         EvolutionStrategyEmitter(
             archive,
-            initial_model.flatten(),
+            x0=initial_model.flatten(),
             sigma0=sigma0,
             ranker="2imp",
             batch_size=batch_size,

--- a/examples/sphere.py
+++ b/examples/sphere.py
@@ -254,10 +254,10 @@ def create_scheduler(algorithm,
         }[algorithm]
         emitters = [
             EvolutionStrategyEmitter(
-                archive=archive,
-                x0=initial_sol,
-                sigma0=0.5,
-                ranker=ranker,
+                archive,
+                initial_sol,
+                0.5,
+                ranker,
                 selection_rule=selection_rule,
                 restart_rule=restart_rule,
                 batch_size=batch_size,
@@ -297,10 +297,10 @@ def create_scheduler(algorithm,
     elif algorithm == "cma_mae":
         emitters = [
             EvolutionStrategyEmitter(
-                archive=archive,
-                x0=initial_sol,
-                sigma0=0.5,
-                ranker="imp",
+                archive,
+                initial_sol,
+                0.5,
+                "imp",
                 selection_rule="mu",
                 restart_rule="basic",
                 batch_size=batch_size,
@@ -325,7 +325,10 @@ def create_scheduler(algorithm,
         f"Created Scheduler for {algorithm} with learning rate {learning_rate} "
         f"and add mode {mode}, using solution dim {solution_dim} and archive "
         f"dims {archive_dims}.")
-    return Scheduler(archive, emitters, result_archive, add_mode=mode)
+    return Scheduler(archive,
+                     emitters,
+                     result_archive=result_archive,
+                     add_mode=mode)
 
 
 def save_heatmap(archive, heatmap_path):

--- a/examples/sphere.py
+++ b/examples/sphere.py
@@ -207,7 +207,7 @@ def create_scheduler(algorithm,
         emitters = [
             GaussianEmitter(
                 archive,
-                0.5,
+                sigma=0.5,
                 x0=initial_sol,
                 batch_size=batch_size,
                 seed=s,
@@ -228,18 +228,18 @@ def create_scheduler(algorithm,
         emitters = [
             EvolutionStrategyEmitter(
                 archive,
-                initial_sol,
-                0.5,
-                "2rd",
+                x0=initial_sol,
+                sigma0=0.5,
+                ranker="2rd",
                 batch_size=batch_size,
                 seed=s,
             ) for s in emitter_seeds[:7]
         ] + [
             EvolutionStrategyEmitter(
                 archive,
-                initial_sol,
-                0.5,
-                "2imp",
+                x0=initial_sol,
+                sigma0=0.5,
+                ranker="2imp",
                 batch_size=batch_size,
                 seed=s,
             ) for s in emitter_seeds[7:]
@@ -255,9 +255,9 @@ def create_scheduler(algorithm,
         emitters = [
             EvolutionStrategyEmitter(
                 archive,
-                initial_sol,
-                0.5,
-                ranker,
+                x0=initial_sol,
+                sigma0=0.5,
+                ranker=ranker,
                 selection_rule=selection_rule,
                 restart_rule=restart_rule,
                 batch_size=batch_size,
@@ -270,7 +270,7 @@ def create_scheduler(algorithm,
         emitters = [
             GradientAborescenceEmitter(
                 archive,
-                initial_sol,
+                x0=initial_sol,
                 sigma0=10.0,
                 step_size=1.0,
                 grad_opt="gradient_ascent",
@@ -285,7 +285,7 @@ def create_scheduler(algorithm,
         emitters = [
             GradientAborescenceEmitter(
                 archive,
-                initial_sol,
+                x0=initial_sol,
                 sigma0=10.0,
                 step_size=0.002,
                 grad_opt="adam",
@@ -298,9 +298,9 @@ def create_scheduler(algorithm,
         emitters = [
             EvolutionStrategyEmitter(
                 archive,
-                initial_sol,
-                0.5,
-                "imp",
+                x0=initial_sol,
+                sigma0=0.5,
+                ranker="imp",
                 selection_rule="mu",
                 restart_rule="basic",
                 batch_size=batch_size,
@@ -310,7 +310,7 @@ def create_scheduler(algorithm,
     elif algorithm in ["cma_maega"]:
         emitters = [
             GradientAborescenceEmitter(archive,
-                                       initial_sol,
+                                       x0=initial_sol,
                                        sigma0=10.0,
                                        step_size=1.0,
                                        ranker="imp",

--- a/examples/tutorials/fooling_mnist.ipynb
+++ b/examples/tutorials/fooling_mnist.ipynb
@@ -203,7 +203,7 @@
     "emitters = [\n",
     "    GaussianEmitter(\n",
     "        archive,\n",
-    "        0.5,\n",
+    "        sigma0=0.5,\n",
     "        # Start with a grey image.\n",
     "        x0=np.full(flat_img_size, 0.5),\n",
     "        # Bound the generated images to the pixel range.\n",

--- a/examples/tutorials/fooling_mnist.ipynb
+++ b/examples/tutorials/fooling_mnist.ipynb
@@ -203,7 +203,7 @@
     "emitters = [\n",
     "    GaussianEmitter(\n",
     "        archive,\n",
-    "        sigma0=0.5,\n",
+    "        sigma=0.5,\n",
     "        # Start with a grey image.\n",
     "        x0=np.full(flat_img_size, 0.5),\n",
     "        # Bound the generated images to the pixel range.\n",

--- a/ribs/archives/_archive_base.py
+++ b/ribs/archives/_archive_base.py
@@ -148,10 +148,10 @@ class ArchiveBase(ABC):  # pylint: disable = too-many-instance-attributes
     """
 
     def __init__(self,
+                 *,
                  solution_dim,
                  cells,
                  measure_dim,
-                 *,
                  learning_rate=1.0,
                  threshold_min=-np.inf,
                  seed=None,

--- a/ribs/archives/_archive_base.py
+++ b/ribs/archives/_archive_base.py
@@ -151,6 +151,7 @@ class ArchiveBase(ABC):  # pylint: disable = too-many-instance-attributes
                  solution_dim,
                  cells,
                  measure_dim,
+                 *,
                  learning_rate=1.0,
                  threshold_min=-np.inf,
                  seed=None,

--- a/ribs/archives/_cvt_archive.py
+++ b/ribs/archives/_cvt_archive.py
@@ -100,6 +100,7 @@ class CVTArchive(ArchiveBase):
                  solution_dim,
                  cells,
                  ranges,
+                 *,
                  learning_rate=1.0,
                  threshold_min=-np.inf,
                  seed=None,

--- a/ribs/archives/_cvt_archive.py
+++ b/ribs/archives/_cvt_archive.py
@@ -97,10 +97,10 @@ class CVTArchive(ArchiveBase):
     """
 
     def __init__(self,
+                 *,
                  solution_dim,
                  cells,
                  ranges,
-                 *,
                  learning_rate=1.0,
                  threshold_min=-np.inf,
                  seed=None,

--- a/ribs/archives/_grid_archive.py
+++ b/ribs/archives/_grid_archive.py
@@ -52,6 +52,7 @@ class GridArchive(ArchiveBase):
                  solution_dim,
                  dims,
                  ranges,
+                 *,
                  learning_rate=1.0,
                  threshold_min=-np.inf,
                  epsilon=1e-6,

--- a/ribs/archives/_grid_archive.py
+++ b/ribs/archives/_grid_archive.py
@@ -49,10 +49,10 @@ class GridArchive(ArchiveBase):
     """
 
     def __init__(self,
+                 *,
                  solution_dim,
                  dims,
                  ranges,
-                 *,
                  learning_rate=1.0,
                  threshold_min=-np.inf,
                  epsilon=1e-6,

--- a/ribs/archives/_sliding_boundaries_archive.py
+++ b/ribs/archives/_sliding_boundaries_archive.py
@@ -134,10 +134,10 @@ class SlidingBoundariesArchive(ArchiveBase):
     """
 
     def __init__(self,
+                 *,
                  solution_dim,
                  dims,
                  ranges,
-                 *,
                  epsilon=1e-6,
                  seed=None,
                  dtype=np.float64,

--- a/ribs/archives/_sliding_boundaries_archive.py
+++ b/ribs/archives/_sliding_boundaries_archive.py
@@ -137,6 +137,7 @@ class SlidingBoundariesArchive(ArchiveBase):
                  solution_dim,
                  dims,
                  ranges,
+                 *,
                  epsilon=1e-6,
                  seed=None,
                  dtype=np.float64,

--- a/ribs/emitters/_emitter_base.py
+++ b/ribs/emitters/_emitter_base.py
@@ -27,7 +27,7 @@ class EmitterBase(ABC):
             are set to -inf.
     """
 
-    def __init__(self, archive, solution_dim, bounds):
+    def __init__(self, archive, *, solution_dim, bounds):
         self._archive = archive
         self._solution_dim = solution_dim
         (self._lower_bounds,

--- a/ribs/emitters/_evolution_strategy_emitter.py
+++ b/ribs/emitters/_evolution_strategy_emitter.py
@@ -81,8 +81,8 @@ class EvolutionStrategyEmitter(EmitterBase):
         EmitterBase.__init__(
             self,
             archive,
-            len(self._x0),
-            bounds,
+            solution_dim=len(self._x0),
+            bounds=bounds,
         )
 
         if selection_rule not in ["mu", "filter"]:

--- a/ribs/emitters/_evolution_strategy_emitter.py
+++ b/ribs/emitters/_evolution_strategy_emitter.py
@@ -64,6 +64,7 @@ class EvolutionStrategyEmitter(EmitterBase):
                  x0,
                  sigma0,
                  ranker,
+                 *,
                  selection_rule="filter",
                  restart_rule="no_improvement",
                  bounds=None,
@@ -73,8 +74,8 @@ class EvolutionStrategyEmitter(EmitterBase):
 
         self._x0 = np.array(x0, dtype=archive.dtype)
         if self._x0.ndim != 1:
-            raise ValueError(
-                f"x0 has shape {self._x0.shape}, should be 1-dimensional.")
+            raise ValueError(f"x0 has shape {self._x0.shape}, should be"
+                             f"1-dimensional.")
 
         self._sigma0 = sigma0
         EmitterBase.__init__(
@@ -91,7 +92,7 @@ class EvolutionStrategyEmitter(EmitterBase):
         self._restart_rule = restart_rule
         self._restarts = 0
         self._itrs = 0
-        # Check if the restart_rule is valid.
+        # Check if the restart_rule is valid, discard check_restart result.
         _ = self._check_restart(0)
 
         opt_seed = None if seed is None else self._rng.integers(10_000)

--- a/ribs/emitters/_evolution_strategy_emitter.py
+++ b/ribs/emitters/_evolution_strategy_emitter.py
@@ -61,10 +61,10 @@ class EvolutionStrategyEmitter(EmitterBase):
 
     def __init__(self,
                  archive,
+                 *,
                  x0,
                  sigma0,
                  ranker,
-                 *,
                  selection_rule="filter",
                  restart_rule="no_improvement",
                  bounds=None,

--- a/ribs/emitters/_gaussian_emitter.py
+++ b/ribs/emitters/_gaussian_emitter.py
@@ -47,8 +47,8 @@ class GaussianEmitter(EmitterBase):
 
     def __init__(self,
                  archive,
-                 sigma,
                  *,
+                 sigma,
                  x0=None,
                  initial_solutions=None,
                  bounds=None,

--- a/ribs/emitters/_gaussian_emitter.py
+++ b/ribs/emitters/_gaussian_emitter.py
@@ -48,6 +48,7 @@ class GaussianEmitter(EmitterBase):
     def __init__(self,
                  archive,
                  sigma,
+                 *,
                  x0=None,
                  initial_solutions=None,
                  bounds=None,
@@ -59,8 +60,8 @@ class GaussianEmitter(EmitterBase):
         self._sigma = np.array(sigma, dtype=archive.dtype)
 
         if x0 is None and initial_solutions is None:
-            raise ValueError("At least one of x0 or initial_solutions must "
-                             "be set.")
+            raise ValueError("If initial_solutions is not specified, you must"
+                             "specify an initial solution x0.")
 
         self._x0 = np.array(x0, dtype=archive.dtype)
         check_is_1d(self._x0, "x0")
@@ -68,7 +69,7 @@ class GaussianEmitter(EmitterBase):
         self._initial_solutions = None
         if initial_solutions is not None:
             self._initial_solutions = np.asarray(initial_solutions,
-                                               dtype=archive.dtype)
+                                                 dtype=archive.dtype)
             check_batch_shape(self._initial_solutions, "initial_solutions",
                               archive.solution_dim, "solution_dim")
 

--- a/ribs/emitters/_gaussian_emitter.py
+++ b/ribs/emitters/_gaussian_emitter.py
@@ -76,8 +76,8 @@ class GaussianEmitter(EmitterBase):
         EmitterBase.__init__(
             self,
             archive,
-            len(self._x0),
-            bounds,
+            solution_dim=len(self._x0),
+            bounds=bounds,
         )
 
     @property

--- a/ribs/emitters/_gradient_aborescence_emitter.py
+++ b/ribs/emitters/_gradient_aborescence_emitter.py
@@ -104,8 +104,8 @@ class GradientAborescenceEmitter(DQDEmitterBase):
         DQDEmitterBase.__init__(
             self,
             archive,
-            len(self._x0),
-            bounds,
+            solution_dim=len(self._x0),
+            bounds=bounds,
         )
 
         self._ranker = _get_ranker(ranker)

--- a/ribs/emitters/_gradient_aborescence_emitter.py
+++ b/ribs/emitters/_gradient_aborescence_emitter.py
@@ -81,10 +81,10 @@ class GradientAborescenceEmitter(DQDEmitterBase):
 
     def __init__(self,
                  archive,
+                 *,
                  x0,
                  sigma0,
                  step_size,
-                 *,
                  ranker="2imp",
                  selection_rule="filter",
                  restart_rule="no_improvement",

--- a/ribs/emitters/_gradient_aborescence_emitter.py
+++ b/ribs/emitters/_gradient_aborescence_emitter.py
@@ -84,6 +84,7 @@ class GradientAborescenceEmitter(DQDEmitterBase):
                  x0,
                  sigma0,
                  step_size,
+                 *,
                  ranker="2imp",
                  selection_rule="filter",
                  restart_rule="no_improvement",

--- a/ribs/emitters/_iso_line_emitter.py
+++ b/ribs/emitters/_iso_line_emitter.py
@@ -52,6 +52,7 @@ class IsoLineEmitter(EmitterBase):
 
     def __init__(self,
                  archive,
+                 *,
                  iso_sigma=0.01,
                  line_sigma=0.2,
                  x0=None,

--- a/ribs/emitters/_iso_line_emitter.py
+++ b/ribs/emitters/_iso_line_emitter.py
@@ -83,8 +83,8 @@ class IsoLineEmitter(EmitterBase):
         EmitterBase.__init__(
             self,
             archive,
-            len(self._x0),
-            bounds,
+            solution_dim=len(self._x0),
+            bounds=bounds,
         )
 
     @property

--- a/ribs/schedulers/_scheduler.py
+++ b/ribs/schedulers/_scheduler.py
@@ -51,6 +51,7 @@ class Scheduler:
     def __init__(self,
                  archive,
                  emitters,
+                 *,
                  result_archive=None,
                  add_mode="batch"):
         if len(emitters) == 0:

--- a/ribs/schedulers/_scheduler.py
+++ b/ribs/schedulers/_scheduler.py
@@ -320,8 +320,8 @@ class Scheduler:
                 contains the objective function evaluation of a solution.
             measures_batch ((batch_size, measures_dm) array): Each row of
                 this array contains a solution's coordinates in measure space.
-            metadata ((batch_size,) array): Each entry of this array contains
-                an object holding metadata for a solution.
+            metadata_batch ((batch_size,) array): Each entry of this array
+                contains an object holding metadata for a solution.
         Raises:
             RuntimeError: This method is called without first calling
                 :meth:`ask`.

--- a/tests/archives/conftest.py
+++ b/tests/archives/conftest.py
@@ -126,17 +126,20 @@ def get_archive_data(name, dtype=np.float64):
         # Sliding boundary archive with 10 cells and range (-1, 1) in first dim,
         # and 20 cells and range (-2, 2) in second dim.
         cells = 10 * 20
-        archive = SlidingBoundariesArchive(len(solution), [10, 20], [(-1, 1),
-                                                                     (-2, 2)],
+        archive = SlidingBoundariesArchive(solution_dim=len(solution),
+                                           dims=[10, 20],
+                                           ranges=[(-1, 1), (-2, 2)],
                                            remap_frequency=100,
                                            buffer_capacity=1000,
                                            dtype=dtype)
 
-        archive_with_elite = SlidingBoundariesArchive(len(solution), [10, 20],
-                                                      [(-1, 1), (-2, 2)],
-                                                      remap_frequency=100,
-                                                      buffer_capacity=1000,
-                                                      dtype=dtype)
+        archive_with_elite = SlidingBoundariesArchive(
+            solution_dim=len(solution),
+            dims=[10, 20],
+            ranges=[(-1, 1), (-2, 2)],
+            remap_frequency=100,
+            buffer_capacity=1000,
+            dtype=dtype)
         grid_indices = (6, 11)
         int_index = 131
 

--- a/tests/archives/sliding_boundaries_archive_benchmark.py
+++ b/tests/archives/sliding_boundaries_archive_benchmark.py
@@ -8,8 +8,9 @@ def benchmark_add_10k(benchmark, benchmark_data_10k):
     n, solution_batch, objective_batch, measures_batch = benchmark_data_10k
 
     def setup():
-        archive = SlidingBoundariesArchive(solution_batch.shape[1], [10, 20],
-                                           [(-1, 1), (-2, 2)],
+        archive = SlidingBoundariesArchive(solution_dim=solution_batch.shape[1],
+                                           dims=[10, 20],
+                                           ranges=[(-1, 1), (-2, 2)],
                                            remap_frequency=100,
                                            buffer_capacity=1000)
 
@@ -27,7 +28,9 @@ def benchmark_add_10k(benchmark, benchmark_data_10k):
 
 def benchmark_as_pandas_2048_elements(benchmark):
     # TODO (btjanaka): Make this size smaller so that we do a remap.
-    archive = SlidingBoundariesArchive(10, [32, 64], [(-1, 1), (-2, 2)],
+    archive = SlidingBoundariesArchive(solution_dim=10,
+                                       dims=[32, 64],
+                                       ranges=[(-1, 1), (-2, 2)],
                                        remap_frequency=20000,
                                        buffer_capacity=20000)
 

--- a/tests/archives/sliding_boundaries_archive_test.py
+++ b/tests/archives/sliding_boundaries_archive_test.py
@@ -19,7 +19,7 @@ def data():
 def test_fails_on_dim_mismatch():
     with pytest.raises(ValueError):
         SlidingBoundariesArchive(
-            0,
+            solution_dim=0,
             dims=[10] * 2,  # 2D space here.
             ranges=[(-1, 1)] * 3,  # But 3D space here.
         )
@@ -90,7 +90,9 @@ def test_add_without_overwrite(data):
 def test_initial_remap():
     """Checks that boundaries and entries are correct after initial remap."""
     # remap_frequency is (10 + 1) * (20 + 1)
-    archive = SlidingBoundariesArchive(2, [10, 20], [(-1, 1), (-2, 2)],
+    archive = SlidingBoundariesArchive(solution_dim=2,
+                                       dims=[10, 20],
+                                       ranges=[(-1, 1), (-2, 2)],
                                        remap_frequency=231,
                                        buffer_capacity=1000)
 
@@ -159,7 +161,9 @@ def test_add_to_archive_with_full_buffer(data):
 
 def test_adds_solutions_from_old_archive():
     """Solutions from previous archive should be inserted during remap."""
-    archive = SlidingBoundariesArchive(2, [10, 20], [(-1, 1), (-2, 2)],
+    archive = SlidingBoundariesArchive(solution_dim=2,
+                                       dims=[10, 20],
+                                       ranges=[(-1, 1), (-2, 2)],
                                        remap_frequency=231,
                                        buffer_capacity=231)
 

--- a/tests/emitters/conftest.py
+++ b/tests/emitters/conftest.py
@@ -9,5 +9,7 @@ from ribs.archives import GridArchive
 def archive_fixture():
     """Provides a simple archive and initial solution."""
     x0 = np.array([1, 2, 3, 4])
-    archive = GridArchive(len(x0), [10, 10], [(-1, 1), (-1, 1)])
+    archive = GridArchive(solution_dim=len(x0),
+                          dims=[10, 10],
+                          ranges=[(-1, 1), (-1, 1)])
     return archive, x0

--- a/tests/emitters/emitter_base_test.py
+++ b/tests/emitters/emitter_base_test.py
@@ -23,26 +23,29 @@ def emitter_fixture(request, archive_fixture):
     batch_size = 3
 
     if emitter_type == "GaussianEmitter":
-        emitter = GaussianEmitter(archive, 5, x0=x0, batch_size=batch_size)
+        emitter = GaussianEmitter(archive,
+                                  sigma=5,
+                                  x0=x0,
+                                  batch_size=batch_size)
     elif emitter_type == "IsoLineEmitter":
         emitter = IsoLineEmitter(archive, x0=x0, batch_size=batch_size)
     elif emitter_type == "ImprovementEmitter":
         emitter = EvolutionStrategyEmitter(archive,
-                                           x0,
-                                           5,
-                                           "2imp",
+                                           x0=x0,
+                                           sigma0=5,
+                                           ranker="2imp",
                                            batch_size=batch_size)
     elif emitter_type == "RandomDirectionEmitter":
         emitter = EvolutionStrategyEmitter(archive,
-                                           x0,
-                                           5,
-                                           "2rd",
+                                           x0=x0,
+                                           sigma0=5,
+                                           ranker="2rd",
                                            batch_size=batch_size)
     elif emitter_type == "OptimizingEmitter":
         emitter = EvolutionStrategyEmitter(archive,
-                                           x0,
-                                           5,
-                                           "2obj",
+                                           x0=x0,
+                                           sigma0=5,
+                                           ranker="2obj",
                                            batch_size=batch_size)
     else:
         raise NotImplementedError(f"Unknown emitter type {emitter_type}")
@@ -79,7 +82,7 @@ def test_array_bound_correct(archive_fixture):
     for i in range(len(x0) - 1):
         bounds.append((-i, i))
     bounds.append(None)
-    emitter = GaussianEmitter(archive, 1, x0=x0, bounds=bounds)
+    emitter = GaussianEmitter(archive, sigma=1, x0=x0, bounds=bounds)
 
     lower_bounds = np.concatenate((-np.arange(len(x0) - 1), [-np.inf]))
     upper_bounds = np.concatenate((np.arange(len(x0) - 1), [np.inf]))
@@ -92,7 +95,7 @@ def test_long_array_bound_fails(archive_fixture):
     archive, x0 = archive_fixture
     bounds = [(-1, 1)] * (len(x0) + 1)  # More bounds than solution dims.
     with pytest.raises(ValueError):
-        GaussianEmitter(archive, 1, x0=x0, bounds=bounds)
+        GaussianEmitter(archive, sigma=1, x0=x0, bounds=bounds)
 
 
 def test_array_bound_bad_entry_fails(archive_fixture):
@@ -100,7 +103,7 @@ def test_array_bound_bad_entry_fails(archive_fixture):
     bounds = [(-1, 1)] * len(x0)
     bounds[0] = (-1, 0, 1)  # Invalid entry.
     with pytest.raises(ValueError):
-        GaussianEmitter(archive, 1, x0=x0, bounds=bounds)
+        GaussianEmitter(archive, sigma=1, x0=x0, bounds=bounds)
 
 
 @pytest.mark.parametrize(
@@ -111,8 +114,11 @@ def test_emitters_fail_when_x0_not_1d(emitter_type, archive_fixture):
 
     with pytest.raises(ValueError):
         if emitter_type == "GaussianEmitter":
-            _ = GaussianEmitter(archive, 5, x0=x0)
+            _ = GaussianEmitter(archive, sigma=5, x0=x0)
         elif emitter_type == "IsoLineEmitter":
             _ = IsoLineEmitter(archive, x0=x0)
         elif emitter_type == "ImprovementEmitter":
-            _ = EvolutionStrategyEmitter(archive, x0, 5, "2imp")
+            _ = EvolutionStrategyEmitter(archive,
+                                         x0=x0,
+                                         sigma0=5,
+                                         ranker="2imp")

--- a/tests/emitters/evolution_strategy_emitter_test.py
+++ b/tests/emitters/evolution_strategy_emitter_test.py
@@ -7,15 +7,25 @@ from ribs.emitters import EvolutionStrategyEmitter
 
 
 def test_auto_batch_size():
-    archive = GridArchive(10, [20, 20], [(-1.0, 1.0)] * 2)
-    emitter = EvolutionStrategyEmitter(archive, np.zeros(10), 1.0, "obj")
+    archive = GridArchive(solution_dim=10,
+                          dims=[20, 20],
+                          ranges=[(-1.0, 1.0)] * 2)
+    emitter = EvolutionStrategyEmitter(archive,
+                                       x0=np.zeros(10),
+                                       sigma0=1.0,
+                                       ranker="obj")
     assert emitter.batch_size is not None
     assert isinstance(emitter.batch_size, int)
 
 
 def test_list_as_initial_solution():
-    archive = GridArchive(10, [20, 20], [(-1.0, 1.0)] * 2)
-    emitter = EvolutionStrategyEmitter(archive, [0.0] * 10, 1.0, "obj")
+    archive = GridArchive(solution_dim=10,
+                          dims=[20, 20],
+                          ranges=[(-1.0, 1.0)] * 2)
+    emitter = EvolutionStrategyEmitter(archive,
+                                       x0=[0.0] * 10,
+                                       sigma0=1.0,
+                                       ranker="obj")
 
     # The list was passed in but should be converted to a numpy array.
     assert isinstance(emitter.x0, np.ndarray)
@@ -25,8 +35,14 @@ def test_list_as_initial_solution():
 @pytest.mark.parametrize("dtype", [np.float64, np.float32],
                          ids=["float64", "float32"])
 def test_dtypes(dtype):
-    archive = GridArchive(10, [20, 20], [(-1.0, 1.0)] * 2, dtype=dtype)
-    emitter = EvolutionStrategyEmitter(archive, np.zeros(10), 1.0, "obj")
+    archive = GridArchive(solution_dim=10,
+                          dims=[20, 20],
+                          ranges=[(-1.0, 1.0)] * 2,
+                          dtype=dtype)
+    emitter = EvolutionStrategyEmitter(archive,
+                                       x0=np.zeros(10),
+                                       sigma0=1.0,
+                                       ranker="obj")
     assert emitter.x0.dtype == dtype
 
     # Try running with the negative sphere function for a few iterations.

--- a/tests/emitters/gaussian_emitter_test.py
+++ b/tests/emitters/gaussian_emitter_test.py
@@ -9,7 +9,10 @@ def test_properties_are_correct(archive_fixture):
     archive, x0 = archive_fixture
     sigma = 1
     batch_size = 2
-    emitter = GaussianEmitter(archive, sigma, x0=x0, batch_size=batch_size)
+    emitter = GaussianEmitter(archive,
+                              sigma=sigma,
+                              x0=x0,
+                              batch_size=batch_size)
 
     assert np.all(emitter.x0 == x0)
     assert emitter.sigma == sigma
@@ -21,7 +24,7 @@ def test_initial_solutions_are_correct(archive_fixture):
     sigma = 1
     initial_solutions = [[0, 1, 2, 3], [-1, -2, -3, -4]]
     emitter = GaussianEmitter(archive,
-                              sigma,
+                              sigma=sigma,
                               x0=x0,
                               initial_solutions=initial_solutions)
 
@@ -36,28 +39,31 @@ def test_initial_solutions_shape(archive_fixture):
     # archive.solution_dim = 4
     with pytest.raises(ValueError):
         GaussianEmitter(archive,
-                        sigma,
+                        sigma=sigma,
                         x0=x0,
                         initial_solutions=initial_solutions)
 
 
 def test_upper_bounds_enforced(archive_fixture):
     archive, _ = archive_fixture
-    emitter = GaussianEmitter(archive, 0, x0=[2, 2], bounds=[(-1, 1)] * 2)
+    emitter = GaussianEmitter(archive, sigma=0, x0=[2, 2], bounds=[(-1, 1)] * 2)
     sols = emitter.ask()
     assert np.all(sols <= 1)
 
 
 def test_lower_bounds_enforced(archive_fixture):
     archive, _ = archive_fixture
-    emitter = GaussianEmitter(archive, 0, x0=[-2, -2], bounds=[(-1, 1)] * 2)
+    emitter = GaussianEmitter(archive,
+                              sigma=0,
+                              x0=[-2, -2],
+                              bounds=[(-1, 1)] * 2)
     sols = emitter.ask()
     assert np.all(sols >= -1)
 
 
 def test_degenerate_gauss_emits_x0(archive_fixture):
     archive, x0 = archive_fixture
-    emitter = GaussianEmitter(archive, 0, x0=x0, batch_size=2)
+    emitter = GaussianEmitter(archive, sigma=0, x0=x0, batch_size=2)
     solutions = emitter.ask()
     assert (solutions == np.expand_dims(x0, axis=0)).all()
 
@@ -66,7 +72,7 @@ def test_degenerate_gauss_emits_parent(archive_fixture):
     archive, x0 = archive_fixture
     parent_sol = x0 * 5
     archive.add_single(parent_sol, 1, np.array([0, 0]))
-    emitter = GaussianEmitter(archive, 0, x0=x0, batch_size=2)
+    emitter = GaussianEmitter(archive, sigma=0, x0=x0, batch_size=2)
 
     # All solutions should be generated "around" the single parent solution in
     # the archive.

--- a/tests/emitters/gradient_aborescence_emitter_test.py
+++ b/tests/emitters/gradient_aborescence_emitter_test.py
@@ -7,15 +7,25 @@ from ribs.emitters import GradientAborescenceEmitter
 
 
 def test_auto_batch_size():
-    archive = GridArchive(10, [20, 20], [(-1.0, 1.0)] * 2)
-    emitter = GradientAborescenceEmitter(archive, np.zeros(10), 1.0, 1.0)
+    archive = GridArchive(solution_dim=10,
+                          dims=[20, 20],
+                          ranges=[(-1.0, 1.0)] * 2)
+    emitter = GradientAborescenceEmitter(archive,
+                                         x0=np.zeros(10),
+                                         sigma0=1.0,
+                                         step_size=1.0)
     assert emitter.batch_size is not None
     assert isinstance(emitter.batch_size, int)
 
 
 def test_list_as_initial_solution():
-    archive = GridArchive(10, [20, 20], [(-1.0, 1.0)] * 2)
-    emitter = GradientAborescenceEmitter(archive, [0.0] * 10, 1.0, 1.0)
+    archive = GridArchive(solution_dim=10,
+                          dims=[20, 20],
+                          ranges=[(-1.0, 1.0)] * 2)
+    emitter = GradientAborescenceEmitter(archive,
+                                         x0=[0.0] * 10,
+                                         sigma0=1.0,
+                                         step_size=1.0)
 
     # The list was passed in but should be converted to a numpy array.
     assert isinstance(emitter.x0, np.ndarray)
@@ -25,6 +35,12 @@ def test_list_as_initial_solution():
 @pytest.mark.parametrize("dtype", [np.float64, np.float32],
                          ids=["float64", "float32"])
 def test_dtypes(dtype):
-    archive = GridArchive(10, [20, 20], [(-1.0, 1.0)] * 2, dtype=dtype)
-    emitter = GradientAborescenceEmitter(archive, np.zeros(10), 1.0, 1.0)
+    archive = GridArchive(solution_dim=10,
+                          dims=[20, 20],
+                          ranges=[(-1.0, 1.0)] * 2,
+                          dtype=dtype)
+    emitter = GradientAborescenceEmitter(archive,
+                                         x0=np.zeros(10),
+                                         sigma0=1.0,
+                                         step_size=1.0)
     assert emitter.x0.dtype == dtype

--- a/tests/emitters/iso_line_emitter_test.py
+++ b/tests/emitters/iso_line_emitter_test.py
@@ -11,8 +11,8 @@ def test_properties_are_correct(archive_fixture):
     line_sigma = 2
     batch_size = 2
     emitter = IsoLineEmitter(archive,
-                             iso_sigma,
-                             line_sigma,
+                             iso_sigma=iso_sigma,
+                             line_sigma=line_sigma,
                              x0=x0,
                              batch_size=batch_size)
 

--- a/tests/emitters/rankers_test.py
+++ b/tests/emitters/rankers_test.py
@@ -63,7 +63,9 @@ def test_two_stage_improvement_ranker(archive_fixture, emitter, rng):
 
 def test_random_direction_ranker(emitter, rng):
     x0 = np.array([1, 2, 3, 4])
-    archive = GridArchive(len(x0), [10, 10, 10], [(-1, 1), (-1, 1), (-1, 1)])
+    archive = GridArchive(solution_dim=len(x0),
+                          dims=[10, 10, 10],
+                          ranges=[(-1, 1), (-1, 1), (-1, 1)])
     solution_batch = [x0, x0, x0, x0]
     objective_batch = [0, 1, 2, 3]
     measures_batch = [
@@ -89,7 +91,9 @@ def test_random_direction_ranker(emitter, rng):
 
 def test_two_stage_random_direction(emitter, rng):
     x0 = np.array([1, 2, 3, 4])
-    archive = GridArchive(len(x0), [10, 10, 10], [(-1, 1), (-1, 1), (-1, 1)])
+    archive = GridArchive(solution_dim=len(x0),
+                          dims=[10, 10, 10],
+                          ranges=[(-1, 1), (-1, 1), (-1, 1)])
     solution_batch = [x0, x0, x0, x0]
     objective_batch = [0, 1, 2, 3]
     measures_batch = [

--- a/tests/schedulers/scheduler_test.py
+++ b/tests/schedulers/scheduler_test.py
@@ -16,9 +16,14 @@ def scheduler_fixture():
     """Returns a Scheduler with GridArchive and one GaussianEmitter."""
     solution_dim = 2
     num_solutions = 4
-    archive = GridArchive(solution_dim, [100, 100], [(-1, 1), (-1, 1)])
+    archive = GridArchive(solution_dim=solution_dim,
+                          dims=[100, 100],
+                          ranges=[(-1, 1), (-1, 1)])
     emitters = [
-        GaussianEmitter(archive, 1, x0=[0.0, 0.0], batch_size=num_solutions)
+        GaussianEmitter(archive,
+                        sigma=1,
+                        x0=[0.0, 0.0],
+                        batch_size=num_solutions)
     ]
     return Scheduler(archive, emitters), solution_dim, num_solutions
 
@@ -31,7 +36,9 @@ def add_mode(request):
 
 def test_init_fails_with_no_emitters():
     # arbitrary sol_dim
-    archive = GridArchive(10, [100, 100], [(-1, 1), (-1, 1)])
+    archive = GridArchive(solution_dim=10,
+                          dims=[100, 100],
+                          ranges=[(-1, 1), (-1, 1)])
     emitters = []
     with pytest.raises(ValueError):
         Scheduler(archive, emitters)
@@ -44,19 +51,22 @@ def test_init_fails_on_non_unique_emitter_instances():
 
     # All emitters are the same instance. This is bad because the same emitter
     # gets called multiple times.
-    emitters = [GaussianEmitter(archive, 1, x0=[0.0, 0.0], batch_size=1)] * 5
+    emitters = [GaussianEmitter(archive, sigma=1, x0=[0.0, 0.0], batch_size=1)
+               ] * 5
 
     with pytest.raises(ValueError):
         Scheduler(archive, emitters)
 
 
 def test_init_fails_with_mismatched_emitters():
-    archive = GridArchive(2, [100, 100], [(-1, 1), (-1, 1)])
+    archive = GridArchive(solution_dim=2,
+                          dims=[100, 100],
+                          ranges=[(-1, 1), (-1, 1)])
     emitters = [
         # Emits 2D solutions.
-        GaussianEmitter(archive, 1, x0=[0.0, 0.0]),
+        GaussianEmitter(archive, sigma=1, x0=[0.0, 0.0]),
         # Mismatch -- emits 3D solutions rather than 2D solutions.
-        GaussianEmitter(archive, 1, x0=[0.0, 0.0, 0.0]),
+        GaussianEmitter(archive, sigma=1, x0=[0.0, 0.0, 0.0]),
     ]
     with pytest.raises(ValueError):
         Scheduler(archive, emitters)
@@ -79,8 +89,12 @@ def test_ask_fails_when_called_twice(scheduler_fixture):
                          ids=["metadata", "no_metadata"])
 def test_tell_inserts_solutions_into_archive(add_mode, tell_metadata):
     batch_size = 4
-    archive = GridArchive(2, [100, 100], [(-1, 1), (-1, 1)])
-    emitters = [GaussianEmitter(archive, 1, x0=[0.0, 0.0], batch_size=batch_size)]
+    archive = GridArchive(solution_dim=2,
+                          dims=[100, 100],
+                          ranges=[(-1, 1), (-1, 1)])
+    emitters = [
+        GaussianEmitter(archive, sigma=1, x0=[0.0, 0.0], batch_size=batch_size)
+    ]
     scheduler = Scheduler(archive, emitters, add_mode=add_mode)
 
     measures_batch = [[1.0, 1.0], [-1.0, 1.0], [-1.0, -1.0], [1.0, -1.0]]
@@ -105,11 +119,13 @@ def test_tell_inserts_solutions_into_archive(add_mode, tell_metadata):
 @pytest.mark.parametrize("tell_metadata", [True, False],
                          ids=["metadata", "no_metadata"])
 def test_tell_inserts_solutions_with_multiple_emitters(add_mode, tell_metadata):
-    archive = GridArchive(2, [100, 100], [(-1, 1), (-1, 1)])
+    archive = GridArchive(solution_dim=2,
+                          dims=[100, 100],
+                          ranges=[(-1, 1), (-1, 1)])
     emitters = [
-        GaussianEmitter(archive, 1, x0=[0.0, 0.0], batch_size=1),
-        GaussianEmitter(archive, 1, x0=[0.5, 0.5], batch_size=2),
-        GaussianEmitter(archive, 1, x0=[-0.5, -0.5], batch_size=3),
+        GaussianEmitter(archive, sigma=1, x0=[0.0, 0.0], batch_size=1),
+        GaussianEmitter(archive, sigma=1, x0=[0.5, 0.5], batch_size=2),
+        GaussianEmitter(archive, sigma=1, x0=[-0.5, -0.5], batch_size=3),
     ]
     scheduler = Scheduler(archive, emitters, add_mode=add_mode)
 


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the PR's purpose here. -->
Deprecate positional arguments in constructor of all objects.
This PR is inspired by:
- https://scikit-learn-enhancement-proposals.readthedocs.io/en/latest/slep009/proposal.html
- https://github.com/scikit-learn/scikit-learn/issues/15005
- https://scikit-learn.org/stable/whats_new/v0.23.html#enforcing-keyword-only-arguments

Everything in the constructors are now keyword arguments except for `archive` and `emitter` parameters.

## TODO

<!-- Notable points that this PR has either accomplished or will accomplish. -->

Deprecate positional arguments in:
- [x] Emitters
- [x] Archives
- [x] Schedulers

Fix code in:
- [x] tests
- [x] examples
- [x] tutorials

## Status

- [x] I have read the guidelines in [CONTRIBUTING.md](https://github.com/icaros-usc/pyribs/blob/master/CONTRIBUTING.md)
- [x] I have formatted my code using `yapf`
- [x] I have tested my code by running `pytest`
- [x] I have linted my code with `pylint`
- [x] I have added a one-line description of my change to the changelog in `HISTORY.md`
- [x] This PR is ready to go
