### PR TITLE
Make ArchiveStats a dataclass

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,6 +6,7 @@
 
 #### API
 
+- **Backwards-incompatible:** Make ArchiveStats a dataclass (#275)
 - **Backwards-incompatible:** Add shape checks to `tell()` and `tell_dqd()`
   methods (#269)
 - Add method for computing CQD score in archives (#252)

--- a/ribs/archives/_archive_stats.py
+++ b/ribs/archives/_archive_stats.py
@@ -1,10 +1,11 @@
 """Provides ArchiveStats."""
-from typing import NamedTuple
+import dataclasses
 
 import numpy as np
 
 
-class ArchiveStats(NamedTuple):
+@dataclasses.dataclass
+class ArchiveStats:
     """Holds statistics about an archive.
 
     Attributes of type :class:`~numpy.floating` will match the


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the PR's purpose here. -->

The stats no longer need to be a namedtuple since we dropped Python 3.6 support. As we add more fields to the namedtuple, it will also get messy if there are users who still unpack it.

## TODO

<!-- Notable points that this PR has either accomplished or will accomplish. -->

## Questions

<!-- Any concerns or points of confusion? -->

## Status

- [x] I have read the guidelines in [CONTRIBUTING.md](https://github.com/icaros-usc/pyribs/blob/master/CONTRIBUTING.md)
- [x] I have formatted my code using `yapf`
- [x] I have tested my code by running `pytest`
- [x] I have linted my code with `pylint`
- [x] I have added a one-line description of my change to the changelog in `HISTORY.md`
- [x] This PR is ready to go
