### PR TITLE
Add normalized QD score to ArchiveStats

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,6 +6,7 @@
 
 #### API
 
+- Add normalized QD score to ArchiveStats (#276)
 - **Backwards-incompatible:** Make ArchiveStats a dataclass (#275)
 - **Backwards-incompatible:** Add shape checks to `tell()` and `tell_dqd()`
   methods (#269)

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,6 +6,7 @@
 
 #### API
 
+- **Backwards-incompatible:** Make ArchiveStats a dataclass (#275)
 - **Backwards-incompatible:** Add shape checks to `tell()` and `tell_dqd()`
   methods (#269)
 - Add method for computing CQD score in archives (#252)

--- a/ribs/archives/_archive_base.py
+++ b/ribs/archives/_archive_base.py
@@ -6,8 +6,7 @@ import numpy as np
 from numpy_groupies import aggregate_nb as aggregate
 
 from ribs._utils import (check_1d_shape, check_batch_shape, check_finite,
-                         check_is_1d, check_solution_batch_dim,
-                         validate_batch_args, validate_single_args)
+                         check_is_1d, validate_batch_args, validate_single_args)
 from ribs.archives._archive_data_frame import ArchiveDataFrame
 from ribs.archives._archive_stats import ArchiveStats
 from ribs.archives._cqd_score_result import CQDScoreResult
@@ -293,6 +292,7 @@ class ArchiveBase(ABC):  # pylint: disable = too-many-instance-attributes
             num_elites=0,
             coverage=self.dtype(0.0),
             qd_score=self.dtype(0.0),
+            norm_qd_score=self.dtype(0.0),
             obj_max=None,
             obj_mean=None,
         )
@@ -676,6 +676,7 @@ class ArchiveBase(ABC):  # pylint: disable = too-many-instance-attributes
             num_elites=len(self),
             coverage=self.dtype(len(self) / self.cells),
             qd_score=new_qd_score,
+            norm_qd_score=self.dtype(new_qd_score / self.cells),
             obj_max=new_obj_max,
             obj_mean=new_qd_score / self.dtype(len(self)),
         )
@@ -796,6 +797,7 @@ class ArchiveBase(ABC):  # pylint: disable = too-many-instance-attributes
                 num_elites=len(self),
                 coverage=self.dtype(len(self) / self.cells),
                 qd_score=new_qd_score,
+                norm_qd_score=self.dtype(new_qd_score / self.cells),
                 obj_max=new_obj_max,
                 obj_mean=new_qd_score / self.dtype(len(self)),
             )

--- a/ribs/archives/_archive_stats.py
+++ b/ribs/archives/_archive_stats.py
@@ -23,6 +23,10 @@ class ArchiveStats:
     #: **This score only makes sense if objective values are non-negative.**
     qd_score: np.floating
 
+    #: Normalized QD score, i.e. the QD score divided by the number of cells in
+    #: the archive.
+    norm_qd_score: np.floating
+
     #: Maximum objective value of the elites in the archive. None if there are
     #: no elites in the archive.
     obj_max: np.floating

--- a/ribs/archives/_archive_stats.py
+++ b/ribs/archives/_archive_stats.py
@@ -1,10 +1,11 @@
 """Provides ArchiveStats."""
-from typing import NamedTuple
+import dataclasses
 
 import numpy as np
 
 
-class ArchiveStats(NamedTuple):
+@dataclasses.dataclass
+class ArchiveStats:
     """Holds statistics about an archive.
 
     Attributes of type :class:`~numpy.floating` will match the

--- a/tests/archives/archive_base_test.py
+++ b/tests/archives/archive_base_test.py
@@ -96,6 +96,7 @@ def test_stats_dtype(dtype):
     assert isinstance(data.archive_with_elite.stats.num_elites, int)
     assert isinstance(data.archive_with_elite.stats.coverage, dtype)
     assert isinstance(data.archive_with_elite.stats.qd_score, dtype)
+    assert isinstance(data.archive_with_elite.stats.norm_qd_score, dtype)
     assert isinstance(data.archive_with_elite.stats.obj_max, dtype)
     assert isinstance(data.archive_with_elite.stats.obj_mean, dtype)
 
@@ -117,6 +118,7 @@ def test_stats_multiple_add(add_mode):
     assert archive.stats.num_elites == 3
     assert np.isclose(archive.stats.coverage, 3 / 200)
     assert np.isclose(archive.stats.qd_score, 6.0)
+    assert np.isclose(archive.stats.norm_qd_score, 6.0 / 200)
     assert np.isclose(archive.stats.obj_max, 3.0)
     assert np.isclose(archive.stats.obj_mean, 2.0)
 
@@ -140,6 +142,7 @@ def test_stats_add_and_overwrite(add_mode):
     assert archive.stats.num_elites == 3
     assert np.isclose(archive.stats.coverage, 3 / 200)
     assert np.isclose(archive.stats.qd_score, 9.0)
+    assert np.isclose(archive.stats.norm_qd_score, 9.0 / 200)
     assert np.isclose(archive.stats.obj_max, 5.0)
     assert np.isclose(archive.stats.obj_mean, 3.0)
 
@@ -248,12 +251,15 @@ def test_basic_stats(data):
     assert data.archive.stats.num_elites == 0
     assert data.archive.stats.coverage == 0.0
     assert data.archive.stats.qd_score == 0.0
+    assert data.archive.stats.norm_qd_score == 0.0
     assert data.archive.stats.obj_max is None
     assert data.archive.stats.obj_mean is None
 
     assert data.archive_with_elite.stats.num_elites == 1
     assert data.archive_with_elite.stats.coverage == 1 / data.cells
     assert data.archive_with_elite.stats.qd_score == data.objective
+    assert (data.archive_with_elite.stats.norm_qd_score == data.objective /
+            data.cells)
     assert data.archive_with_elite.stats.obj_max == data.objective
     assert data.archive_with_elite.stats.obj_mean == data.objective
 


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the PR's purpose here. -->

Normalized QD score divides the QD score by the number of cells in the archive.

Merge #275 first.

## TODO

<!-- Notable points that this PR has either accomplished or will accomplish. -->


## Questions

<!-- Any concerns or points of confusion? -->

## Status

- [x] I have read the guidelines in [CONTRIBUTING.md](https://github.com/icaros-usc/pyribs/blob/master/CONTRIBUTING.md)
- [x] I have formatted my code using `yapf`
- [x] I have tested my code by running `pytest`
- [x] I have linted my code with `pylint`
- [x] I have added a one-line description of my change to the changelog in `HISTORY.md`
- [x] This PR is ready to go
