### PR TITLE
Fix rendering of math in tutorial notebooks

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -246,10 +246,10 @@ plot_html_show_source_link = False
 
 # Intersphinx
 intersphinx_mapping = {
-    "matplotlib": ("https://matplotlib.org", None),
+    "matplotlib": ("https://matplotlib.org/stable/", None),
     "numpy": ("https://numpy.org/doc/stable/", None),
     "pandas": ("https://pandas.pydata.org/pandas-docs/stable/", None),
-    "python": ("https://docs.python.org/3", None),
-    "scipy": ("https://docs.scipy.org/doc/scipy/reference", None),
-    "sklearn": ("https://scikit-learn.org/stable", None),
+    "python": ("https://docs.python.org/3/", None),
+    "scipy": ("https://docs.scipy.org/doc/scipy/", None),
+    "sklearn": ("https://scikit-learn.org/stable/", None),
 }

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -67,6 +67,15 @@ napoleon_include_special_with_doc = True
 # while to run.
 nb_execution_mode = "off"
 
+# https://github.com/executablebooks/MyST-NB/issues/441
+myst_enable_extensions = [
+    "amsmath",
+    "colon_fence",
+    "deflist",
+    "dollarmath",
+    "html_image",
+]
+
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]
 

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ extras_require = {
         "sphinx-material==0.0.32",
         "sphinx-autobuild==2020.9.1",
         "sphinx-copybutton==0.3.1",
-        "myst-nb==0.15.0",
+        "myst-nb==0.17.1",
         "sphinx-toolbox==3.1.0",
         "sphinx-autodoc-typehints==1.18.2",
         "sphinx-codeautolink==0.11.0",


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the PR's purpose here. -->

Turned out this was due to an issue with the myst-nb configuration as described in https://github.com/executablebooks/MyST-NB/issues/441

## TODO

<!-- Notable points that this PR has either accomplished or will accomplish. -->

## Questions

<!-- Any concerns or points of confusion? -->

## Status

- [x] I have read the guidelines in [CONTRIBUTING.md](https://github.com/icaros-usc/pyribs/blob/master/CONTRIBUTING.md)
- [x] I have formatted my code using `yapf`
- [x] I have tested my code by running `pytest`
- [x] I have linted my code with `pylint`
- [x] ~I have added a one-line description of my change to the changelog in `HISTORY.md`~
- [x] This PR is ready to go
