### PR TITLE
Negative eigenvalue fix (#285)

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -96,6 +96,7 @@
 #### Bugs
 
 - Fix boundary lines in sliding boundaries archive heatmap (#271)
+- Fix negative eigenvalue in CMA-ES covariance matrix (#285)
 
 #### Documentation
 

--- a/ribs/emitters/opt/_cma_es.py
+++ b/ribs/emitters/opt/_cma_es.py
@@ -60,6 +60,7 @@ class DecompMatrix:
 
         # Note: eigh returns float64, so we must cast it.
         self.eigenvalues, self.eigenbasis = np.linalg.eigh(self.cov)
+        self.eigenvalues = np.abs(self.eigenvalues)
         self.eigenvalues = self.eigenvalues.real.astype(self.dtype)
         self.eigenbasis = self.eigenbasis.real.astype(self.dtype)
         self.condition_number = (np.max(self.eigenvalues) /


### PR DESCRIPTION
## Description

Fix issue with negative eigenvalue in CMA-ES covariance matrix (resolves #285)

## Status

- [x] I have read the guidelines in [CONTRIBUTING.md](https://github.com/icaros-usc/pyribs/blob/master/CONTRIBUTING.md)
- [x] I have formatted my code using `yapf`
- [x] I have tested my code by running `pytest`
- [x] I have linted my code with `pylint`
- [x] I have added a one-line description of my change to the changelog in `HISTORY.md`
- [x] This PR is ready to go
