### PR TITLE
Replace CMA-ES with ES in emitter docstrings

### DIFF
--- a/ribs/emitters/_evolution_strategy_emitter.py
+++ b/ribs/emitters/_evolution_strategy_emitter.py
@@ -8,12 +8,12 @@ from ribs.emitters.rankers import _get_ranker
 
 
 class EvolutionStrategyEmitter(EmitterBase):
-    """Adapts a distribution of solutions with CMA-ES.
+    """Adapts a distribution of solutions with an ES.
 
     This emitter originates in `Fontaine 2020
     <https://arxiv.org/abs/1912.02400>`_. The multivariate Gaussian solution
     distribution begins at ``x0`` with standard deviation ``sigma0``. Based on
-    how the generated solutions are ranked (see ``ranker``), CMA-ES then adapts
+    how the generated solutions are ranked (see ``ranker``), the ES then adapts
     the mean and covariance of the distribution.
 
     Args:

--- a/ribs/emitters/_gradient_arborescence_emitter.py
+++ b/ribs/emitters/_gradient_arborescence_emitter.py
@@ -9,7 +9,7 @@ from ribs.emitters.rankers import _get_ranker
 
 class GradientArborescenceEmitter(EmitterBase):
     """Generates solutions with a gradient arborescence, with coefficients
-    parameterized by CMA-ES.
+    parameterized by an ES.
 
     This emitter originates in `Fontaine 2021
     <https://arxiv.org/abs/2106.03894>`_. It leverages the gradient information
@@ -17,7 +17,8 @@ class GradientArborescenceEmitter(EmitterBase):
     "solution point" using gradient arborescence with coefficients drawn from a
     Gaussian distribution. Based on how the solutions are ranked after being
     inserted into the archive (see ``ranker``), the solution point is updated
-    with gradient ascent, and the distribution is updated with CMA-ES.
+    with gradient ascent, and the distribution is updated with an ES (the
+    default ES is CMA-ES).
 
     Note that unlike non-gradient emitters, GradientArborescenceEmitter requires
     calling :meth:`ask_dqd` and :meth:`tell_dqd` (in this order) before calling


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the PR's purpose here. -->

Since the ES in these emitters is no longer limited to CMA-ES, these docstrings were inaccurate.

## TODO

<!-- Notable points that this PR has either accomplished or will accomplish. -->

## Questions

<!-- Any concerns or points of confusion? -->

## Status

- [x] I have read the guidelines in [CONTRIBUTING.md](https://github.com/icaros-usc/pyribs/blob/master/CONTRIBUTING.md)
- [x] I have formatted my code using `yapf`
- [x] I have tested my code by running `pytest`
- [x] I have linted my code with `pylint`
- [x] ~I have added a one-line description of my change to the changelog in `HISTORY.md`~
- [x] This PR is ready to go
