### PR TITLE
Rename elites_with_measures to retrieve

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -53,14 +53,12 @@
   `RandomDirectionEmitter`, and `OptimizingEmitter` with
   `EvolutionStrategyEmitter` (#220, #223, #278)
 - Raise ValueError for incorrect array shapes in archive methods (#219)
-- Add elites_with_measures_single method for getting elite for a single
-  solution's measures (#215)
 - Introduced the Ranker object, which is responsible for ranking the solutions
   based on different objectives (#209, #222, #245)
 - Add index_of_single method for getting index of measures for one solution
   (#214)
 - **Backwards-incompatible:** Replace elite_with_behavior with batched
-  elites_with_measures method in archives (#213)
+  find_elites and find_elites_single in archives (#213, #215, #295)
 - **Backwards-incompatible:** Replace get_index with batched index_of method in
   archives (#208)
   - Also added `grid_to_int_index` and `int_to_grid_index` methods for

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -57,8 +57,8 @@
   based on different objectives (#209, #222, #245)
 - Add index_of_single method for getting index of measures for one solution
   (#214)
-- **Backwards-incompatible:** Replace elite_with_behavior with batched
-  find_elites and find_elites_single in archives (#213, #215, #295)
+- **Backwards-incompatible:** Replace elite_with_behavior with
+  retrieve and retrieve_single in archives (#213, #215, #295)
 - **Backwards-incompatible:** Replace get_index with batched index_of method in
   archives (#208)
   - Also added `grid_to_int_index` and `int_to_grid_index` methods for

--- a/ribs/archives/_archive_base.py
+++ b/ribs/archives/_archive_base.py
@@ -799,7 +799,7 @@ class ArchiveBase(ABC):  # pylint: disable = too-many-instance-attributes
 
         return status, objective - old_threshold
 
-    def find_elites(self, measures_batch):
+    def retrieve(self, measures_batch):
         """Retrieves the elites with measures in the same cells as the measures
         specified.
 
@@ -808,11 +808,11 @@ class ArchiveBase(ABC):  # pylint: disable = too-many-instance-attributes
         namedtuple, it can be unpacked::
 
             solution_batch, objective_batch, measures_batch, \\
-                index_batch, metadata_batch = archive.find_elites(...)
+                index_batch, metadata_batch = archive.retrieve(...)
 
         Or the fields may be accessed by name::
 
-            elite_batch = archive.find_elites(...)
+            elite_batch = archive.retrieve(...)
             elite_batch.solution_batch
             elite_batch.objective_batch
             elite_batch.measures_batch
@@ -839,7 +839,7 @@ class ArchiveBase(ABC):  # pylint: disable = too-many-instance-attributes
         * ``elite_batch.metadata_batch[i]`` will be None
 
         If you need to retrieve a *single* elite associated with some measures,
-        consider using :meth:`find_elites_single`.
+        consider using :meth:`retrieve_single`.
 
         Args:
             measures_batch (array-like): (batch_size, :attr:`measure_dim`)
@@ -901,13 +901,13 @@ class ArchiveBase(ABC):  # pylint: disable = too-many-instance-attributes
                 )),
         )
 
-    def find_elites_single(self, measures):
+    def retrieve_single(self, measures):
         """Retrieves the elite with measures in the same cell as the measures
         specified.
 
-        While :meth:`find_elites` takes in a *batch* of measures, this
-        method takes in the measures for only *one* solution and returns a
-        single :namedtuple:`Elite`.
+        While :meth:`retrieve` takes in a *batch* of measures, this method takes
+        in the measures for only *one* solution and returns a single
+        :namedtuple:`Elite`.
 
         Args:
             measures (array-like): (:attr:`measure_dim`,) array of measures.
@@ -916,7 +916,7 @@ class ArchiveBase(ABC):  # pylint: disable = too-many-instance-attributes
             specified, then this method returns an :namedtuple:`Elite` where all
             the fields hold the info of that elite. Otherwise, this method
             returns an :namedtuple:`Elite` filled with the same "empty" values
-            described in :meth:`find_elites`.
+            described in :meth:`retrieve`.
         Raises:
             ValueError: ``measures`` is not of shape (:attr:`measure_dim`,).
             ValueError: ``measures`` has non-finite values (inf or NaN).
@@ -925,7 +925,7 @@ class ArchiveBase(ABC):  # pylint: disable = too-many-instance-attributes
         check_1d_shape(measures, "measures", self.measure_dim, "measure_dim")
         check_finite(measures, "measures")
 
-        elite_batch = self.find_elites(measures[None])
+        elite_batch = self.retrieve(measures[None])
         return Elite(
             elite_batch.solution_batch[0],
             elite_batch.objective_batch[0],

--- a/ribs/archives/_archive_base.py
+++ b/ribs/archives/_archive_base.py
@@ -799,7 +799,7 @@ class ArchiveBase(ABC):  # pylint: disable = too-many-instance-attributes
 
         return status, objective - old_threshold
 
-    def elites_with_measures(self, measures_batch):
+    def find_elites(self, measures_batch):
         """Retrieves the elites with measures in the same cells as the measures
         specified.
 
@@ -808,11 +808,11 @@ class ArchiveBase(ABC):  # pylint: disable = too-many-instance-attributes
         namedtuple, it can be unpacked::
 
             solution_batch, objective_batch, measures_batch, \\
-                index_batch, metadata_batch = archive.elites_with_measures(...)
+                index_batch, metadata_batch = archive.find_elites(...)
 
         Or the fields may be accessed by name::
 
-            elite_batch = archive.elites_with_measures(...)
+            elite_batch = archive.find_elites(...)
             elite_batch.solution_batch
             elite_batch.objective_batch
             elite_batch.measures_batch
@@ -839,7 +839,7 @@ class ArchiveBase(ABC):  # pylint: disable = too-many-instance-attributes
         * ``elite_batch.metadata_batch[i]`` will be None
 
         If you need to retrieve a *single* elite associated with some measures,
-        consider using :meth:`elites_with_measures_single`.
+        consider using :meth:`find_elites_single`.
 
         Args:
             measures_batch (array-like): (batch_size, :attr:`measure_dim`)
@@ -901,11 +901,11 @@ class ArchiveBase(ABC):  # pylint: disable = too-many-instance-attributes
                 )),
         )
 
-    def elites_with_measures_single(self, measures):
+    def find_elites_single(self, measures):
         """Retrieves the elite with measures in the same cell as the measures
         specified.
 
-        While :meth:`elites_with_measures` takes in a *batch* of measures, this
+        While :meth:`find_elites` takes in a *batch* of measures, this
         method takes in the measures for only *one* solution and returns a
         single :namedtuple:`Elite`.
 
@@ -916,7 +916,7 @@ class ArchiveBase(ABC):  # pylint: disable = too-many-instance-attributes
             specified, then this method returns an :namedtuple:`Elite` where all
             the fields hold the info of that elite. Otherwise, this method
             returns an :namedtuple:`Elite` filled with the same "empty" values
-            described in :meth:`elites_with_measures`.
+            described in :meth:`find_elites`.
         Raises:
             ValueError: ``measures`` is not of shape (:attr:`measure_dim`,).
             ValueError: ``measures`` has non-finite values (inf or NaN).
@@ -925,7 +925,7 @@ class ArchiveBase(ABC):  # pylint: disable = too-many-instance-attributes
         check_1d_shape(measures, "measures", self.measure_dim, "measure_dim")
         check_finite(measures, "measures")
 
-        elite_batch = self.elites_with_measures(measures[None])
+        elite_batch = self.find_elites(measures[None])
         return Elite(
             elite_batch.solution_batch[0],
             elite_batch.objective_batch[0],

--- a/tests/archives/archive_base_test.py
+++ b/tests/archives/archive_base_test.py
@@ -195,7 +195,7 @@ def test_index_of_single():
 
 def test_index_of_single_wrong_shape(data):
     with pytest.raises(ValueError):
-        data.archive.find_elites_single(data.measures[:-1])
+        data.archive.retrieve_single(data.measures[:-1])
 
 
 #
@@ -264,8 +264,8 @@ def test_basic_stats(data):
     assert data.archive_with_elite.stats.obj_mean == data.objective
 
 
-def test_find_elites_gets_correct_elite(data):
-    elite_batch = data.archive_with_elite.find_elites([data.measures])
+def test_retrieve_gets_correct_elite(data):
+    elite_batch = data.archive_with_elite.retrieve([data.measures])
     assert np.all(elite_batch.solution_batch[0] == data.solution)
     assert elite_batch.objective_batch[0] == data.objective
     assert np.all(elite_batch.measures_batch[0] == data.measures)
@@ -273,8 +273,8 @@ def test_find_elites_gets_correct_elite(data):
     assert elite_batch.metadata_batch[0] == data.metadata
 
 
-def test_find_elites_empty_values(data):
-    elite_batch = data.archive.find_elites([data.measures])
+def test_retrieve_empty_values(data):
+    elite_batch = data.archive.retrieve([data.measures])
     assert np.all(np.isnan(elite_batch.solution_batch[0]))
     assert np.isnan(elite_batch.objective_batch)
     assert np.all(np.isnan(elite_batch.measures_batch[0]))
@@ -282,13 +282,13 @@ def test_find_elites_empty_values(data):
     assert elite_batch.metadata_batch[0] is None
 
 
-def test_find_elites_wrong_shape(data):
+def test_retrieve_wrong_shape(data):
     with pytest.raises(ValueError):
-        data.archive.find_elites([data.measures[:-1]])
+        data.archive.retrieve([data.measures[:-1]])
 
 
-def test_find_elites_single_gets_correct_elite(data):
-    elite = data.archive_with_elite.find_elites_single(data.measures)
+def test_retrieve_single_gets_correct_elite(data):
+    elite = data.archive_with_elite.retrieve_single(data.measures)
     assert np.all(elite.solution == data.solution)
     assert elite.objective == data.objective
     assert np.all(elite.measures == data.measures)
@@ -296,8 +296,8 @@ def test_find_elites_single_gets_correct_elite(data):
     assert elite.metadata == data.metadata
 
 
-def test_find_elites_single_empty_values(data):
-    elite = data.archive.find_elites_single(data.measures)
+def test_retrieve_single_empty_values(data):
+    elite = data.archive.retrieve_single(data.measures)
     assert np.all(np.isnan(elite.solution))
     assert np.isnan(elite.objective)
     assert np.all(np.isnan(elite.measures))
@@ -305,9 +305,9 @@ def test_find_elites_single_empty_values(data):
     assert elite.metadata is None
 
 
-def test_find_elites_single_wrong_shape(data):
+def test_retrieve_single_wrong_shape(data):
     with pytest.raises(ValueError):
-        data.archive.find_elites_single(data.measures[:-1])
+        data.archive.retrieve_single(data.measures[:-1])
 
 
 def test_sample_elites_gets_single_elite(data):

--- a/tests/archives/archive_base_test.py
+++ b/tests/archives/archive_base_test.py
@@ -195,7 +195,7 @@ def test_index_of_single():
 
 def test_index_of_single_wrong_shape(data):
     with pytest.raises(ValueError):
-        data.archive.elites_with_measures_single(data.measures[:-1])
+        data.archive.find_elites_single(data.measures[:-1])
 
 
 #
@@ -264,8 +264,8 @@ def test_basic_stats(data):
     assert data.archive_with_elite.stats.obj_mean == data.objective
 
 
-def test_elites_with_measures_gets_correct_elite(data):
-    elite_batch = data.archive_with_elite.elites_with_measures([data.measures])
+def test_find_elites_gets_correct_elite(data):
+    elite_batch = data.archive_with_elite.find_elites([data.measures])
     assert np.all(elite_batch.solution_batch[0] == data.solution)
     assert elite_batch.objective_batch[0] == data.objective
     assert np.all(elite_batch.measures_batch[0] == data.measures)
@@ -273,8 +273,8 @@ def test_elites_with_measures_gets_correct_elite(data):
     assert elite_batch.metadata_batch[0] == data.metadata
 
 
-def test_elites_with_measures_empty_values(data):
-    elite_batch = data.archive.elites_with_measures([data.measures])
+def test_find_elites_empty_values(data):
+    elite_batch = data.archive.find_elites([data.measures])
     assert np.all(np.isnan(elite_batch.solution_batch[0]))
     assert np.isnan(elite_batch.objective_batch)
     assert np.all(np.isnan(elite_batch.measures_batch[0]))
@@ -282,13 +282,13 @@ def test_elites_with_measures_empty_values(data):
     assert elite_batch.metadata_batch[0] is None
 
 
-def test_elites_with_measures_wrong_shape(data):
+def test_find_elites_wrong_shape(data):
     with pytest.raises(ValueError):
-        data.archive.elites_with_measures([data.measures[:-1]])
+        data.archive.find_elites([data.measures[:-1]])
 
 
-def test_elites_with_measures_single_gets_correct_elite(data):
-    elite = data.archive_with_elite.elites_with_measures_single(data.measures)
+def test_find_elites_single_gets_correct_elite(data):
+    elite = data.archive_with_elite.find_elites_single(data.measures)
     assert np.all(elite.solution == data.solution)
     assert elite.objective == data.objective
     assert np.all(elite.measures == data.measures)
@@ -296,8 +296,8 @@ def test_elites_with_measures_single_gets_correct_elite(data):
     assert elite.metadata == data.metadata
 
 
-def test_elites_with_measures_single_empty_values(data):
-    elite = data.archive.elites_with_measures_single(data.measures)
+def test_find_elites_single_empty_values(data):
+    elite = data.archive.find_elites_single(data.measures)
     assert np.all(np.isnan(elite.solution))
     assert np.isnan(elite.objective)
     assert np.all(np.isnan(elite.measures))
@@ -305,9 +305,9 @@ def test_elites_with_measures_single_empty_values(data):
     assert elite.metadata is None
 
 
-def test_elites_with_measures_single_wrong_shape(data):
+def test_find_elites_single_wrong_shape(data):
     with pytest.raises(ValueError):
-        data.archive.elites_with_measures_single(data.measures[:-1])
+        data.archive.find_elites_single(data.measures[:-1])
 
 
 def test_sample_elites_gets_single_elite(data):

--- a/tests/archives/grid_archive_test.py
+++ b/tests/archives/grid_archive_test.py
@@ -707,9 +707,9 @@ def test_nonfinite_inputs(data):
     with pytest.raises(ValueError):
         data.archive.add_single(data.solution, -np.inf, data.measures)
     with pytest.raises(ValueError):
-        data.archive.find_elites([data.measures])
+        data.archive.retrieve([data.measures])
     with pytest.raises(ValueError):
-        data.archive.find_elites_single(data.measures)
+        data.archive.retrieve_single(data.measures)
     with pytest.raises(ValueError):
         data.archive.index_of([data.measures])
     with pytest.raises(ValueError):

--- a/tests/archives/grid_archive_test.py
+++ b/tests/archives/grid_archive_test.py
@@ -707,9 +707,9 @@ def test_nonfinite_inputs(data):
     with pytest.raises(ValueError):
         data.archive.add_single(data.solution, -np.inf, data.measures)
     with pytest.raises(ValueError):
-        data.archive.elites_with_measures([data.measures])
+        data.archive.find_elites([data.measures])
     with pytest.raises(ValueError):
-        data.archive.elites_with_measures_single(data.measures)
+        data.archive.find_elites_single(data.measures)
     with pytest.raises(ValueError):
         data.archive.index_of([data.measures])
     with pytest.raises(ValueError):

--- a/tutorials/arm_repertoire.ipynb
+++ b/tutorials/arm_repertoire.ipynb
@@ -447,9 +447,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can also retrieve solutions that reached specific positions with `find_elites_single`. This method will check whether the archive cell with the specified measures contains a solution, and if so, it will return that solution. It looks like there is an arm configuration that can reach position (0,0), so let's see what that looks like.\n",
+    "We can also retrieve solutions that reached specific positions with `retrieve_single`. This method will check whether the archive cell with the specified measures contains a solution, and if so, it will return that solution. It looks like there is an arm configuration that can reach position (0,0), so let's see what that looks like.\n",
     "\n",
-    "If you want to query a batch of solutions, you can similarly use `find_elites`."
+    "If you want to query a batch of solutions, you can similarly use `retrieve`."
    ]
   },
   {
@@ -473,7 +473,7 @@
     }
    ],
    "source": [
-    "elite = archive.find_elites_single([0, 0])\n",
+    "elite = archive.retrieve_single([0, 0])\n",
     "_, ax = plt.subplots()\n",
     "if elite.solution is not None:  # This is None if there is no solution for [0,0].\n",
     "    visualize(elite.solution, link_lengths, elite.objective, ax)"
@@ -483,7 +483,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "As one might expect, the arm looks like a circle, as the joint angles in a circle are all equal. Since `find_elites_single` retrieves a solution in the same _cell_ as the measures specified, the actual measures of the solution may not exactly match (0,0)."
+    "As one might expect, the arm looks like a circle, as the joint angles in a circle are all equal. Since `retrieve_single` retrieves a solution in the same _cell_ as the measures specified, the actual measures of the solution may not exactly match (0,0)."
    ]
   },
   {

--- a/tutorials/arm_repertoire.ipynb
+++ b/tutorials/arm_repertoire.ipynb
@@ -447,9 +447,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can also retrieve solutions that reached specific positions with `elites_with_measures_single`. This method will check whether the archive cell with the specified measures contains a solution, and if so, it will return that solution. It looks like there is an arm configuration that can reach position (0,0), so let's see what that looks like.\n",
+    "We can also retrieve solutions that reached specific positions with `find_elites_single`. This method will check whether the archive cell with the specified measures contains a solution, and if so, it will return that solution. It looks like there is an arm configuration that can reach position (0,0), so let's see what that looks like.\n",
     "\n",
-    "If you want to query a batch of solutions, you can similarly use `elites_with_measures`."
+    "If you want to query a batch of solutions, you can similarly use `find_elites`."
    ]
   },
   {
@@ -473,7 +473,7 @@
     }
    ],
    "source": [
-    "elite = archive.elites_with_measures_single([0, 0])\n",
+    "elite = archive.find_elites_single([0, 0])\n",
     "_, ax = plt.subplots()\n",
     "if elite.solution is not None:  # This is None if there is no solution for [0,0].\n",
     "    visualize(elite.solution, link_lengths, elite.objective, ax)"
@@ -483,7 +483,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "As one might expect, the arm looks like a circle, as the joint angles in a circle are all equal. Since `elites_with_measures_single` retrieves a solution in the same _cell_ as the measures specified, the actual measures of the solution may not exactly match (0,0)."
+    "As one might expect, the arm looks like a circle, as the joint angles in a circle are all equal. Since `find_elites_single` retrieves a solution in the same _cell_ as the measures specified, the actual measures of the solution may not exactly match (0,0)."
    ]
   },
   {

--- a/tutorials/lunar_lander.ipynb
+++ b/tutorials/lunar_lander.ipynb
@@ -477,7 +477,7 @@
     }
    ],
    "source": [
-    "elite = archive.find_elites_single([-0.4, -0.10])\n",
+    "elite = archive.retrieve_single([-0.4, -0.10])\n",
     "if elite.solution is not None:\n",
     "    display_video(elite.solution)"
    ]
@@ -511,7 +511,7 @@
     }
    ],
    "source": [
-    "elite = archive.find_elites_single([0.4, -0.10])\n",
+    "elite = archive.retrieve_single([0.4, -0.10])\n",
     "if elite.solution is not None:\n",
     "    display_video(elite.solution)"
    ]
@@ -545,7 +545,7 @@
     }
    ],
    "source": [
-    "elite = archive.find_elites_single([0.0, -0.10])\n",
+    "elite = archive.retrieve_single([0.0, -0.10])\n",
     "if elite.solution is not None:\n",
     "    display_video(elite.solution)"
    ]

--- a/tutorials/lunar_lander.ipynb
+++ b/tutorials/lunar_lander.ipynb
@@ -477,7 +477,7 @@
     }
    ],
    "source": [
-    "elite = archive.elites_with_measures_single([-0.4, -0.10])\n",
+    "elite = archive.find_elites_single([-0.4, -0.10])\n",
     "if elite.solution is not None:\n",
     "    display_video(elite.solution)"
    ]
@@ -511,7 +511,7 @@
     }
    ],
    "source": [
-    "elite = archive.elites_with_measures_single([0.4, -0.10])\n",
+    "elite = archive.find_elites_single([0.4, -0.10])\n",
     "if elite.solution is not None:\n",
     "    display_video(elite.solution)"
    ]
@@ -545,7 +545,7 @@
     }
    ],
    "source": [
-    "elite = archive.elites_with_measures_single([0.0, -0.10])\n",
+    "elite = archive.find_elites_single([0.0, -0.10])\n",
     "if elite.solution is not None:\n",
     "    display_video(elite.solution)"
    ]


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the PR's purpose here. -->

`elites_with_measures` and `elites_with_measures_single` is a very long name. `retrieve` is much more succinct.

While the name may be more vague, we think this is okay because we review the method in the lunar lander tutorial. Furthermore, the usage makes the meaning very clear; e.g., `elite_batch = archive.retrieve(measures_batch)`.

We also considered the name `find` but `find` implies a search, which is not what this method is doing. This method is merely _retrieving_ the elite at a given cell, not searching the archive to find an elite with the given measures.

## TODO

<!-- Notable points that this PR has either accomplished or will accomplish. -->

## Questions

<!-- Any concerns or points of confusion? -->

## Status

- [x] I have read the guidelines in [CONTRIBUTING.md](https://github.com/icaros-usc/pyribs/blob/master/CONTRIBUTING.md)
- [x] I have formatted my code using `yapf`
- [x] I have tested my code by running `pytest`
- [x] I have linted my code with `pylint`
- [x] I have added a one-line description of my change to the changelog in `HISTORY.md`
- [x] This PR is ready to go
