### PR TITLE
Add QD score offset to archives

### DIFF
--- a/ribs/archives/_archive_base.py
+++ b/ribs/archives/_archive_base.py
@@ -668,7 +668,8 @@ class ArchiveBase(ABC):  # pylint: disable = too-many-instance-attributes
         # here.
         new_qd_score = (
             self._stats.qd_score +
-            np.sum(objective_batch_insert - old_objective_batch_insert))
+            np.sum(objective_batch_insert - old_objective_batch_insert -
+                   self._qd_score_offset))
         max_idx = np.argmax(objective_batch_insert)
         max_obj_insert = objective_batch_insert[max_idx]
 
@@ -791,7 +792,8 @@ class ArchiveBase(ABC):  # pylint: disable = too-many-instance-attributes
 
         if status:
             # Update archive stats.
-            new_qd_score = self._stats.qd_score + (objective - old_objective)
+            new_qd_score = (self._stats.qd_score + (objective - old_objective) -
+                            self._qd_score_offset)
 
             if self._stats.obj_max is None or objective > self._stats.obj_max:
                 new_obj_max = objective

--- a/ribs/archives/_archive_base.py
+++ b/ribs/archives/_archive_base.py
@@ -116,7 +116,7 @@ class ArchiveBase(ABC):  # pylint: disable = too-many-instance-attributes
             values, and if the QD score were to be computed with these negative
             objectives, the algorithm would be penalized for adding new cells
             with negative objectives. Thus, a standard practice is to normalize
-            all the objectives so that they are positive by introducing an
+            all the objectives so that they are non-negative by introducing an
             offset. This QD score offset will be *subtracted* from all
             objectives in the archive, e.g., if your objectives go as low as
             -300, pass in -300 so that each objective will be transformed as
@@ -259,7 +259,7 @@ class ArchiveBase(ABC):  # pylint: disable = too-many-instance-attributes
 
     @property
     def qd_score_offset(self):
-        """float: The offset which is subtracted from objective values before
+        """float: The offset which is subtracted from objective values when
         computing the QD score."""
         return self._qd_score_offset
 

--- a/ribs/archives/_archive_base.py
+++ b/ribs/archives/_archive_base.py
@@ -112,6 +112,15 @@ class ArchiveBase(ABC):  # pylint: disable = too-many-instance-attributes
         measure_dim (int): The dimension of the measure space.
         learning_rate (float): The learning rate for threshold updates.
         threshold_min (float): The initial threshold value for all the cells.
+        qd_score_offset (float): Archives often contain negative objective
+            values, and if the QD score were to be computed with these negative
+            objectives, the algorithm would be penalized for adding new cells
+            with negative objectives. Thus, a standard practice is to normalize
+            all the objectives so that they are positive by introducing an
+            offset. This QD score offset will be *subtracted* from all
+            objectives in the archive, e.g., if your objectives go as low as
+            -300, pass in -300 so that each objective will be transformed as
+            ``objective - (-300)``.
         seed (int): Value to seed the random number generator. Set to None to
             avoid a fixed seed.
         dtype (str or data-type): Data type of the solutions, objectives,
@@ -150,6 +159,7 @@ class ArchiveBase(ABC):  # pylint: disable = too-many-instance-attributes
                  measure_dim,
                  learning_rate=1.0,
                  threshold_min=-np.inf,
+                 qd_score_offset=0.0,
                  seed=None,
                  dtype=np.float64):
 
@@ -180,6 +190,7 @@ class ArchiveBase(ABC):  # pylint: disable = too-many-instance-attributes
                                       threshold_min,
                                       dtype=self.dtype)
 
+        self._qd_score_offset = self._dtype(qd_score_offset)
         self._stats = None
         self._stats_reset()
 
@@ -241,6 +252,12 @@ class ArchiveBase(ABC):  # pylint: disable = too-many-instance-attributes
     def threshold_min(self):
         """float: The initial threshold value for all the cells."""
         return self._threshold_min
+
+    @property
+    def qd_score_offset(self):
+        """float: The offset which is subtracted from objective values before
+        computing the QD score."""
+        return self._qd_score_offset
 
     @property
     def stats(self):

--- a/ribs/archives/_archive_stats.py
+++ b/ribs/archives/_archive_stats.py
@@ -19,8 +19,10 @@ class ArchiveStats:
     #: range :math:`[0,1]`.
     coverage: np.floating
 
-    #: QD score, i.e. sum of objective values of all elites in the archive.
-    #: **This score only makes sense if objective values are non-negative.**
+    #: QD score, i.e. sum of objective values of all elites in the archive. If
+    #: ``qd_score_offset`` was passed in to the archive, this QD score
+    #: normalizes the objectives by subtracting the offset from all objective
+    #: values before computing the QD score.
     qd_score: np.floating
 
     #: Normalized QD score, i.e. the QD score divided by the number of cells in

--- a/ribs/archives/_cvt_archive.py
+++ b/ribs/archives/_cvt_archive.py
@@ -67,6 +67,15 @@ class CVTArchive(ArchiveBase):
             ``dims``.
         learning_rate (float): The learning rate for threshold updates.
         threshold_min (float): The initial threshold value for all the cells.
+        qd_score_offset (float): Archives often contain negative objective
+            values, and if the QD score were to be computed with these negative
+            objectives, the algorithm would be penalized for adding new cells
+            with negative objectives. Thus, a standard practice is to normalize
+            all the objectives so that they are positive by introducing an
+            offset. This QD score offset will be *subtracted* from all
+            objectives in the archive, e.g., if your objectives go as low as
+            -300, pass in -300 so that each objective will be transformed as
+            ``objective - (-300)``.
         seed (int): Value to seed the random number generator as well as
             :func:`~sklearn.cluster.k_means`. Set to None to avoid a fixed seed.
         dtype (str or data-type): Data type of the solutions, objectives,
@@ -103,6 +112,7 @@ class CVTArchive(ArchiveBase):
                  ranges,
                  learning_rate=1.0,
                  threshold_min=-np.inf,
+                 qd_score_offset=0.0,
                  seed=None,
                  dtype=np.float64,
                  samples=100_000,
@@ -118,6 +128,7 @@ class CVTArchive(ArchiveBase):
             measure_dim=len(ranges),
             learning_rate=learning_rate,
             threshold_min=threshold_min,
+            qd_score_offset=qd_score_offset,
             seed=seed,
             dtype=dtype,
         )

--- a/ribs/archives/_cvt_archive.py
+++ b/ribs/archives/_cvt_archive.py
@@ -71,7 +71,7 @@ class CVTArchive(ArchiveBase):
             values, and if the QD score were to be computed with these negative
             objectives, the algorithm would be penalized for adding new cells
             with negative objectives. Thus, a standard practice is to normalize
-            all the objectives so that they are positive by introducing an
+            all the objectives so that they are non-negative by introducing an
             offset. This QD score offset will be *subtracted* from all
             objectives in the archive, e.g., if your objectives go as low as
             -300, pass in -300 so that each objective will be transformed as

--- a/ribs/archives/_grid_archive.py
+++ b/ribs/archives/_grid_archive.py
@@ -43,7 +43,7 @@ class GridArchive(ArchiveBase):
             values, and if the QD score were to be computed with these negative
             objectives, the algorithm would be penalized for adding new cells
             with negative objectives. Thus, a standard practice is to normalize
-            all the objectives so that they are positive by introducing an
+            all the objectives so that they are non-negative by introducing an
             offset. This QD score offset will be *subtracted* from all
             objectives in the archive, e.g., if your objectives go as low as
             -300, pass in -300 so that each objective will be transformed as

--- a/ribs/archives/_grid_archive.py
+++ b/ribs/archives/_grid_archive.py
@@ -39,6 +39,15 @@ class GridArchive(ArchiveBase):
             Pass this parameter to configure that epsilon.
         learning_rate (float): The learning rate for threshold updates.
         threshold_min (float): The initial threshold value for all the cells.
+        qd_score_offset (float): Archives often contain negative objective
+            values, and if the QD score were to be computed with these negative
+            objectives, the algorithm would be penalized for adding new cells
+            with negative objectives. Thus, a standard practice is to normalize
+            all the objectives so that they are positive by introducing an
+            offset. This QD score offset will be *subtracted* from all
+            objectives in the archive, e.g., if your objectives go as low as
+            -300, pass in -300 so that each objective will be transformed as
+            ``objective - (-300)``.
         seed (int): Value to seed the random number generator. Set to None to
             avoid a fixed seed.
         dtype (str or data-type): Data type of the solutions, objectives,
@@ -56,6 +65,7 @@ class GridArchive(ArchiveBase):
                  learning_rate=1.0,
                  threshold_min=-np.inf,
                  epsilon=1e-6,
+                 qd_score_offset=0.0,
                  seed=None,
                  dtype=np.float64):
         self._dims = np.array(dims, dtype=np.int32)
@@ -70,6 +80,7 @@ class GridArchive(ArchiveBase):
             measure_dim=len(self._dims),
             learning_rate=learning_rate,
             threshold_min=threshold_min,
+            qd_score_offset=qd_score_offset,
             seed=seed,
             dtype=dtype,
         )

--- a/ribs/archives/_sliding_boundaries_archive.py
+++ b/ribs/archives/_sliding_boundaries_archive.py
@@ -5,8 +5,8 @@ from collections import deque
 import numpy as np
 from sortedcontainers import SortedList
 
-from ribs._utils import (check_batch_shape, validate_single_args,
-                         validate_batch_args)
+from ribs._utils import (check_batch_shape, validate_batch_args,
+                         validate_single_args)
 from ribs.archives._archive_base import ArchiveBase
 from ribs.archives._grid_archive import GridArchive
 
@@ -122,6 +122,15 @@ class SlidingBoundariesArchive(ArchiveBase):
             method -- refer to the implementation `here
             <../_modules/ribs/archives/_sliding_boundaries_archive.html#SlidingBoundariesArchive.index_of>`_.
             Pass this parameter to configure that epsilon.
+        qd_score_offset (float): Archives often contain negative objective
+            values, and if the QD score were to be computed with these negative
+            objectives, the algorithm would be penalized for adding new cells
+            with negative objectives. Thus, a standard practice is to normalize
+            all the objectives so that they are positive by introducing an
+            offset. This QD score offset will be *subtracted* from all
+            objectives in the archive, e.g., if your objectives go as low as
+            -300, pass in -300 so that each objective will be transformed as
+            ``objective - (-300)``.
         seed (int): Value to seed the random number generator. Set to None to
             avoid a fixed seed.
         dtype (str or data-type): Data type of the solutions, objectives,
@@ -140,6 +149,7 @@ class SlidingBoundariesArchive(ArchiveBase):
                  dims,
                  ranges,
                  epsilon=1e-6,
+                 qd_score_offset=0.0,
                  seed=None,
                  dtype=np.float64,
                  remap_frequency=100,
@@ -154,6 +164,7 @@ class SlidingBoundariesArchive(ArchiveBase):
             solution_dim=solution_dim,
             cells=np.product(self._dims),
             measure_dim=len(self._dims),
+            qd_score_offset=qd_score_offset,
             seed=seed,
             dtype=dtype,
         )

--- a/ribs/archives/_sliding_boundaries_archive.py
+++ b/ribs/archives/_sliding_boundaries_archive.py
@@ -126,7 +126,7 @@ class SlidingBoundariesArchive(ArchiveBase):
             values, and if the QD score were to be computed with these negative
             objectives, the algorithm would be penalized for adding new cells
             with negative objectives. Thus, a standard practice is to normalize
-            all the objectives so that they are positive by introducing an
+            all the objectives so that they are non-negative by introducing an
             offset. This QD score offset will be *subtracted* from all
             objectives in the archive, e.g., if your objectives go as low as
             -300, pass in -300 so that each objective will be transformed as

--- a/tests/archives/archive_base_test.py
+++ b/tests/archives/archive_base_test.py
@@ -101,10 +101,12 @@ def test_stats_dtype(dtype):
     assert isinstance(data.archive_with_elite.stats.obj_mean, dtype)
 
 
-def test_stats_multiple_add(add_mode):
+@pytest.mark.parametrize("qd_score_offset", [0.0, -1.0])
+def test_stats_multiple_add(add_mode, qd_score_offset):
     archive = GridArchive(solution_dim=3,
                           dims=[10, 20],
-                          ranges=[(-1, 1), (-2, 2)])
+                          ranges=[(-1, 1), (-2, 2)],
+                          qd_score_offset=qd_score_offset)
     if add_mode == "single":
         archive.add_single([1, 2, 3], 1.0, [0, 0])
         archive.add_single([1, 2, 3], 2.0, [0.25, 0.25])
@@ -117,16 +119,23 @@ def test_stats_multiple_add(add_mode):
 
     assert archive.stats.num_elites == 3
     assert np.isclose(archive.stats.coverage, 3 / 200)
-    assert np.isclose(archive.stats.qd_score, 6.0)
-    assert np.isclose(archive.stats.norm_qd_score, 6.0 / 200)
+    if qd_score_offset == 0.0:
+        assert np.isclose(archive.stats.qd_score, 6.0)
+        assert np.isclose(archive.stats.norm_qd_score, 6.0 / 200)
+    else:
+        # -1 is subtracted from every objective.
+        assert np.isclose(archive.stats.qd_score, 9.0)
+        assert np.isclose(archive.stats.norm_qd_score, 9.0 / 200)
     assert np.isclose(archive.stats.obj_max, 3.0)
     assert np.isclose(archive.stats.obj_mean, 2.0)
 
 
-def test_stats_add_and_overwrite(add_mode):
+@pytest.mark.parametrize("qd_score_offset", [0.0, -1.0])
+def test_stats_add_and_overwrite(add_mode, qd_score_offset):
     archive = GridArchive(solution_dim=3,
                           dims=[10, 20],
-                          ranges=[(-1, 1), (-2, 2)])
+                          ranges=[(-1, 1), (-2, 2)],
+                          qd_score_offset=qd_score_offset)
     if add_mode == "single":
         archive.add_single([1, 2, 3], 1.0, [0, 0])
         archive.add_single([1, 2, 3], 2.0, [0.25, 0.25])
@@ -141,8 +150,13 @@ def test_stats_add_and_overwrite(add_mode):
 
     assert archive.stats.num_elites == 3
     assert np.isclose(archive.stats.coverage, 3 / 200)
-    assert np.isclose(archive.stats.qd_score, 9.0)
-    assert np.isclose(archive.stats.norm_qd_score, 9.0 / 200)
+    if qd_score_offset == 0.0:
+        assert np.isclose(archive.stats.qd_score, 9.0)
+        assert np.isclose(archive.stats.norm_qd_score, 9.0 / 200)
+    else:
+        # -1 is subtracted from every objective.
+        assert np.isclose(archive.stats.qd_score, 13.0)
+        assert np.isclose(archive.stats.norm_qd_score, 13.0 / 200)
     assert np.isclose(archive.stats.obj_max, 5.0)
     assert np.isclose(archive.stats.obj_mean, 3.0)
 
@@ -245,6 +259,10 @@ def test_learning_rate_correct(data):
 
 def test_threshold_min_correct(data):
     assert data.archive.threshold_min == -np.inf  # Default value.
+
+
+def test_qd_score_offset_correct(data):
+    assert data.archive.qd_score_offset == 0.0  # Default value.
 
 
 def test_basic_stats(data):

--- a/tests/archives/archive_base_test.py
+++ b/tests/archives/archive_base_test.py
@@ -155,8 +155,8 @@ def test_stats_add_and_overwrite(add_mode, qd_score_offset):
         assert np.isclose(archive.stats.norm_qd_score, 9.0 / 200)
     else:
         # -1 is subtracted from every objective.
-        assert np.isclose(archive.stats.qd_score, 13.0)
-        assert np.isclose(archive.stats.norm_qd_score, 13.0 / 200)
+        assert np.isclose(archive.stats.qd_score, 12.0)
+        assert np.isclose(archive.stats.norm_qd_score, 12.0 / 200)
     assert np.isclose(archive.stats.obj_max, 5.0)
     assert np.isclose(archive.stats.obj_mean, 3.0)
 


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the PR's purpose here. -->

There are many archives which have negative objective values, thus making it useful to have a QD score which normalizes the objective values before summing them. This PR addresses that.

This feature will also be useful in the lunar lander tutorial, where we have negative objective values.

## TODO

<!-- Notable points that this PR has either accomplished or will accomplish. -->

## Questions

<!-- Any concerns or points of confusion? -->

## Status

- [x] I have read the guidelines in [CONTRIBUTING.md](https://github.com/icaros-usc/pyribs/blob/master/CONTRIBUTING.md)
- [x] I have formatted my code using `yapf`
- [x] I have tested my code by running `pytest`
- [x] I have linted my code with `pylint`
- [x] I have added a one-line description of my change to the changelog in `HISTORY.md`
- [x] This PR is ready to go
