### PR TITLE
Facilitate linking to latest version of documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -211,6 +211,12 @@ particularly relevant when linking to arXiv papers.
 ### Deploying
 
 1. Create a PR into master after doing the following:
+   1. Switch tutorial links from latest to stable with:
+      ```bash
+      make tutorial_links
+      ```
+      See [#300](https://github.com/icaros-usc/pyribs/pull/300) for why we do
+      this.
    1. Update the version with `bump2version` by running the following for minor
       versions:
       ```bash
@@ -238,5 +244,12 @@ particularly relevant when linking to arXiv papers.
 1. Check that the version was deployed to PyPI. If it failed, delete the tag,
    make appropriate fixes, and repeat steps 2 and 3.
 1. Write up the release on GitHub, and attach it to the tag.
+1. Submit another PR which reverts the changes to the tutorial links.
+   Specifically, while on master, make sure your workspace is clean, then revert
+   the changes with:
+   ```bash
+   git checkout HEAD~ tutorials/
+   ```
+   And commit the result.
 
 Our deployment process may change in the future as pyribs becomes more complex.

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -98,6 +98,7 @@
 
 #### Documentation
 
+- Facilitate linking to latest version of documentation (#300)
 - Update lunar lander tutorial with v0.5.0 features (#292)
 - Improve tutorial and example overviews (#291)
 - Move tutorials out of examples folder (#290)

--- a/Makefile
+++ b/Makefile
@@ -91,6 +91,9 @@ release: dist ## package and upload a release
 	twine upload dist/*
 .PHONY: release
 
+tutorial_links:
+	find tutorials -type f -name *.ipynb -exec sed -i 's/docs\.pyribs\.org\/en\/latest/docs\.pyribs\.org\/en\/stable/g' {} \;
+
 dist: clean ## builds source and wheel package
 	python setup.py sdist
 	python setup.py bdist_wheel

--- a/tutorials/lunar_lander.ipynb
+++ b/tutorials/lunar_lander.ipynb
@@ -127,7 +127,7 @@
     "\n",
     "Though these trajectories look different, they all achieve good performance (200+), leading to an important insight: there are characteristics of a lunar lander that are not necessarily important for performance, but nonetheless determine the behavior of the lander. In quality diversity (QD) terms, we call these measures. In this tutorial, we will search for policies that yield different trajectories using the pyribs implementation of the QD algorithm [CMA-ME](https://arxiv.org/abs/1912.02400).\n",
     "\n",
-    "**_By the way: Recent work introduced [CMA-MAE](https://arxiv.org/abs/2205.10752), an algorithm which builds on CMA-ME and achieves higher performance in a variety of domains. Once you finish this tutorial, be sure to check out the [followup tutorial](https://docs.pyribs.org/en/stable/tutorials/lunar_lander_mae.html) to learn about CMA-MAE._**"
+    "**_By the way: Recent work introduced [CMA-MAE](https://arxiv.org/abs/2205.10752), an algorithm which builds on CMA-ME and achieves higher performance in a variety of domains. Once you finish this tutorial, be sure to check out the [followup tutorial](https://docs.pyribs.org/en/latest/tutorials/lunar_lander_mae.html) to learn about CMA-MAE._**"
    ]
   },
   {
@@ -318,7 +318,7 @@
    "source": [
     "### GridArchive\n",
     "\n",
-    "First, the [`GridArchive`](https://docs.pyribs.org/en/stable/api/ribs.archives.GridArchive.html) stores solutions (i.e. models for our policy) in a rectangular grid. Each dimension of the `GridArchive` corresponds to a dimension in measure space that is segmented into equally sized cells. As we have two measure functions for our lunar lander, we have two dimensions in the `GridArchive`. The first dimension is the impact $x$-position, which ranges from -1 to 1, and the second is the impact $y$-velocity, which ranges from -3 (smashing into the ground) to 0 (gently touching down). We divide both dimensions into 50 cells.\n",
+    "First, the [`GridArchive`](https://docs.pyribs.org/en/latest/api/ribs.archives.GridArchive.html) stores solutions (i.e. models for our policy) in a rectangular grid. Each dimension of the `GridArchive` corresponds to a dimension in measure space that is segmented into equally sized cells. As we have two measure functions for our lunar lander, we have two dimensions in the `GridArchive`. The first dimension is the impact $x$-position, which ranges from -1 to 1, and the second is the impact $y$-velocity, which ranges from -3 (smashing into the ground) to 0 (gently touching down). We divide both dimensions into 50 cells.\n",
     "\n",
     "We additionally specify the dimensionality of solutions which will be stored in the archive. While each model is a 2D matrix, pyribs archives only allow 1D arrays for efficiency; hence, we create an `initial_model` below and retrieve its 1D size with `initial_model.size`."
    ]
@@ -359,7 +359,7 @@
    "source": [
     "### EvolutionStrategyEmitter\n",
     "\n",
-    "Next, the [`EvolutionStrategyEmitter`](https://docs.pyribs.org/en/stable/api/ribs.emitters.EvolutionStrategyEmitter.html) with two-stage improvement ranking (\"2imp\") uses CMA-ES to search for policies that add new entries to the archive or improve existing ones. Since we do not have any prior knowledge of what the model will be, we set the initial model to be the zero vector, and we set the initial step size for CMA-ES to be 1.0, so that initial solutions are sampled from a standard isotropic Gaussian. Furthermore, we use 5 emitters so that the algorithm simultaneously searches several areas of measure space."
+    "Next, the [`EvolutionStrategyEmitter`](https://docs.pyribs.org/en/latest/api/ribs.emitters.EvolutionStrategyEmitter.html) with two-stage improvement ranking (\"2imp\") uses CMA-ES to search for policies that add new entries to the archive or improve existing ones. Since we do not have any prior knowledge of what the model will be, we set the initial model to be the zero vector, and we set the initial step size for CMA-ES to be 1.0, so that initial solutions are sampled from a standard isotropic Gaussian. Furthermore, we use 5 emitters so that the algorithm simultaneously searches several areas of measure space."
    ]
   },
   {
@@ -400,7 +400,7 @@
     ">\n",
     "> During ranking, this two-stage improvement ranker will first sort by `status`, prioritizing new solutions, followed by solutions which improve existing cells, followed by solutions which are not inserted. Within each group, solutions are further ranked by their corresponding `value`. See the archive [add](https://docs.pyribs.org/en/latest/api/ribs.archives.GridArchive.html#ribs.archives.GridArchive.add) method for more information on statuses and values.\n",
     "> \n",
-    "> Additional rankers are available in the [ribs.emitters.rankers](https://docs.pyribs.org/en/stable/api/ribs.emitters.rankers.html) module. These rankers correspond to different emitters described in the CMA-ME paper."
+    "> Additional rankers are available in the [ribs.emitters.rankers](https://docs.pyribs.org/en/latest/api/ribs.emitters.rankers.html) module. These rankers correspond to different emitters described in the CMA-ME paper."
    ]
   },
   {
@@ -411,7 +411,7 @@
    "source": [
     "### Scheduler\n",
     "\n",
-    "Finally, the [`Scheduler`](https://docs.pyribs.org/en/stable/api/ribs.schedulers.Scheduler.html) connects the archive and emitters together."
+    "Finally, the [`Scheduler`](https://docs.pyribs.org/en/latest/api/ribs.schedulers.Scheduler.html) connects the archive and emitters together."
    ]
   },
   {
@@ -435,7 +435,7 @@
    "source": [
     "## QD Search\n",
     "\n",
-    "With the pyribs components defined, we start searching with CMA-ME. This loop should take **2-4 hours** to run. Since we use 5 emitters each with a batch size of 30 and we run 500 iterations, we run 5 x 30 x 500 = 75,000 lunar lander simulations. We also keep track of some logging info via `archive.stats`, which is an [`ArchiveStats`](https://docs.pyribs.org/en/stable/api/ribs.archives.ArchiveStats.html) object."
+    "With the pyribs components defined, we start searching with CMA-ME. This loop should take **2-4 hours** to run. Since we use 5 emitters each with a batch size of 30 and we run 500 iterations, we run 5 x 30 x 500 = 75,000 lunar lander simulations. We also keep track of some logging info via `archive.stats`, which is an [`ArchiveStats`](https://docs.pyribs.org/en/latest/api/ribs.archives.ArchiveStats.html) object."
    ]
   },
   {
@@ -592,7 +592,7 @@
    "source": [
     "## Visualizing the Archive\n",
     "\n",
-    "Using [`grid_archive_heatmap`](https://docs.pyribs.org/en/stable/api/ribs.visualize.grid_archive_heatmap.html) from the [`ribs.visualize`](https://docs.pyribs.org/en/stable/api/ribs.visualize.html) module, we can view a heatmap of the archive. The heatmap shows the measures for which CMA-ME found a solution. The color of each cell shows the objective value of the solution."
+    "Using [`grid_archive_heatmap`](https://docs.pyribs.org/en/latest/api/ribs.visualize.grid_archive_heatmap.html) from the [`ribs.visualize`](https://docs.pyribs.org/en/latest/api/ribs.visualize.html) module, we can view a heatmap of the archive. The heatmap shows the measures for which CMA-ME found a solution. The color of each cell shows the objective value of the solution."
    ]
   },
   {
@@ -711,13 +711,13 @@
    },
    "source": [
     "\n",
-    "We can retrieve policies with measures that are close to a query with the [`retrieve_single`](https://docs.pyribs.org/en/stable/api/ribs.archives.GridArchive.html#ribs.archives.GridArchive.retrieve_single) method. This method will look up the cell corresponding to the queried measures. Then, the method will check if there is an elite in that cell, and return the elite if it exists (the method does not check neighboring cells for elites). The returned elite may not have the exact measures requested because the elite only has to be in the same cell as the queried measures.\n",
+    "We can retrieve policies with measures that are close to a query with the [`retrieve_single`](https://docs.pyribs.org/en/latest/api/ribs.archives.GridArchive.html#ribs.archives.GridArchive.retrieve_single) method. This method will look up the cell corresponding to the queried measures. Then, the method will check if there is an elite in that cell, and return the elite if it exists (the method does not check neighboring cells for elites). The returned elite may not have the exact measures requested because the elite only has to be in the same cell as the queried measures.\n",
     "\n",
     "Below, we first retrieve a policy that impacted the ground on the left (approximately -0.4) with low velocity (approximately -0.10) by querying for `[-0.4, 0.10]`.\n",
     "\n",
     "**Note: Batch and Single Methods**\n",
     "\n",
-    "> `retrieve_single` returns an [Elite](https://docs.pyribs.org/en/stable/api/ribs.archives.Elite.html) object given a single `measures` array. Meanwhile, the [`retrieve`](https://docs.pyribs.org/en/stable/api/ribs.archives.GridArchive.html#ribs.archives.GridArchive.retrieve) method takes in a _batch_ of measures (named `measures_batch`) and returns an [EliteBatch](https://docs.pyribs.org/en/stable/api/ribs.archives.EliteBatch.html) object. Several archive methods in pyribs follow a similar pattern of having a batch and single version, e.g., [`add`](https://docs.pyribs.org/en/stable/api/ribs.archives.GridArchive.html#ribs.archives.GridArchive.add) and [`add_single`](https://docs.pyribs.org/en/stable/api/ribs.archives.GridArchive.html#ribs.archives.GridArchive.add_single)."
+    "> `retrieve_single` returns an [Elite](https://docs.pyribs.org/en/latest/api/ribs.archives.Elite.html) object given a single `measures` array. Meanwhile, the [`retrieve`](https://docs.pyribs.org/en/latest/api/ribs.archives.GridArchive.html#ribs.archives.GridArchive.retrieve) method takes in a _batch_ of measures (named `measures_batch`) and returns an [EliteBatch](https://docs.pyribs.org/en/latest/api/ribs.archives.EliteBatch.html) object. Several archive methods in pyribs follow a similar pattern of having a batch and single version, e.g., [`add`](https://docs.pyribs.org/en/latest/api/ribs.archives.GridArchive.html#ribs.archives.GridArchive.add) and [`add_single`](https://docs.pyribs.org/en/latest/api/ribs.archives.GridArchive.html#ribs.archives.GridArchive.add_single)."
    ]
   },
   {
@@ -846,7 +846,7 @@
     "id": "MZLDoutPFKhu"
    },
    "source": [
-    "As the archive has ~2500 solutions, we cannot view them all, but we can filter for high-performing solutions. We first retrieve the archive's elites with the [`as_pandas`](https://docs.pyribs.org/en/stable/api/ribs.archives.GridArchive.html#ribs.archives.GridArchive.as_pandas) method. Then, we choose solutions that scored above 200 because 200 is the [threshold for the problem to be considered solved](https://gymnasium.farama.org/environments/box2d/lunar_lander/). Note that many solutions that are considered solved do not land on the landing pad."
+    "As the archive has ~2500 solutions, we cannot view them all, but we can filter for high-performing solutions. We first retrieve the archive's elites with the [`as_pandas`](https://docs.pyribs.org/en/latest/api/ribs.archives.GridArchive.html#ribs.archives.GridArchive.as_pandas) method. Then, we choose solutions that scored above 200 because 200 is the [threshold for the problem to be considered solved](https://gymnasium.farama.org/environments/box2d/lunar_lander/). Note that many solutions that are considered solved do not land on the landing pad."
    ]
   },
   {
@@ -867,7 +867,7 @@
     "id": "0_RYE1rTFKhu"
    },
    "source": [
-    "Below we visualize several of these high-performing solutions. The `iterelites` method is available because `as_pandas` returns an [`ArchiveDataFrame`](https://docs.pyribs.org/en/stable/api/ribs.archives.ArchiveDataFrame.html), a subclass of the Pandas DataFrame specialized for pyribs. `iterelites` iterates over the entries in the DataFrame and returns them as [`Elite`](https://docs.pyribs.org/en/stable/api/ribs.archives.Elite.html) objects."
+    "Below we visualize several of these high-performing solutions. The `iterelites` method is available because `as_pandas` returns an [`ArchiveDataFrame`](https://docs.pyribs.org/en/latest/api/ribs.archives.ArchiveDataFrame.html), a subclass of the Pandas DataFrame specialized for pyribs. `iterelites` iterates over the entries in the DataFrame and returns them as [`Elite`](https://docs.pyribs.org/en/latest/api/ribs.archives.Elite.html) objects."
    ]
   },
   {
@@ -940,7 +940,7 @@
     "id": "P3cQJ2ctOBG5"
    },
    "source": [
-    "And finally, the [`best_elite`](https://docs.pyribs.org/en/stable/api/ribs.archives.GridArchive.html#ribs.archives.GridArchive.best_elite) property is the [`Elite`](https://docs.pyribs.org/en/stable/api/ribs.archives.Elite.html) which has the highest performance in the archive."
+    "And finally, the [`best_elite`](https://docs.pyribs.org/en/latest/api/ribs.archives.GridArchive.html#ribs.archives.GridArchive.best_elite) property is the [`Elite`](https://docs.pyribs.org/en/latest/api/ribs.archives.Elite.html) which has the highest performance in the archive."
    ]
   },
   {
@@ -993,9 +993,9 @@
     "- Try different terrains by changing the seed. For instance, if the environment has valleys, can the lander learn to go into this valley and glide back up?\n",
     "- Use other gym environments. What measures could you use in an environment like `BipedalWalker-v2`?\n",
     "\n",
-    "Finally, to learn about an algorithm which performs even better on this problem and other QD problems, check out the [Lunar Lander CMA-MAE tutorial](https://docs.pyribs.org/en/stable/tutorials/lunar_lander_mae.html).\n",
+    "Finally, to learn about an algorithm which performs even better on this problem and other QD problems, check out the [Lunar Lander CMA-MAE tutorial](https://docs.pyribs.org/en/latest/tutorials/lunar_lander_mae.html).\n",
     "\n",
-    "And for a version of this tutorial that uses [Dask](https://dask.org) to parallelize evaluations and thus speed things up, refer to the [Lunar Lander example](https://docs.pyribs.org/en/stable/examples/lunar_lander.html)."
+    "And for a version of this tutorial that uses [Dask](https://dask.org) to parallelize evaluations and thus speed things up, refer to the [Lunar Lander example](https://docs.pyribs.org/en/latest/examples/lunar_lander.html)."
    ]
   },
   {


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the PR's purpose here. -->

Previously, I used links to `stable` for documentation links in the notebook. However, it is better to use `latest` since this notebook will appear in the following places:

* GitHub, where it is on master branch and thus should reference the master branch documentation
* Colab, when opened from the latest version

At the same time, we need a version of the notebook with stable links for when users open from the stable version. This requires a script which will replace the links before documentation deployment.

Options for the script include:

* Integrate with Sphinx since that is what ReadTheDocs calls -- this involves making a callback like the following in `conf.py`
  ```
  def replace_notebook_links(app, docname, source):
      """Replaces "latest" links with "stable" links in notebooks if building the
      stable version.
  
      See https://www.sphinx-doc.org/en/master/extdev/appapi.html#event-source-read
      """
  
  
  def setup(app):
      app.connect("source-read", replace_notebook_links)
  ```
  This fails for Google Colab links opened from the stable version of the documentation -- it will reference a GitHub notebook which still has "latest" links.
* Modify the deployment to include replacing the links on the GitHub version for the release only. This makes the deployment process more complicated as we also have to revert the changes after the release.
* Deploy to somewhere else and open the notebook from there instead. One problem is that we're using GitHub as a CDN, but Colab would not allow opening from an arbitrary URL (i.e. it must be a GitHub link). Thus, we will modify the deployment.

## TODO

<!-- Notable points that this PR has either accomplished or will accomplish. -->

## Questions

<!-- Any concerns or points of confusion? -->

## Status

- [x] I have read the guidelines in [CONTRIBUTING.md](https://github.com/icaros-usc/pyribs/blob/master/CONTRIBUTING.md)
- [x] I have formatted my code using `yapf`
- [x] I have tested my code by running `pytest`
- [x] I have linted my code with `pylint`
- [x] I have added a one-line description of my change to the changelog in `HISTORY.md`
- [x] This PR is ready to go
