### PR TITLE
Remove examples extra in favor of individual example deps

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -100,7 +100,7 @@ jobs:
       - name: Upgrade pip
         run: python -m pip install --upgrade pip
       - name: Install deps
-        run: pip install .[visualize,examples]
+        run: pip install .[visualize]
       - name: Test Examples
         run: bash tests/examples.sh
   tutorials:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -180,11 +180,12 @@ Examples are created in Python scripts stored under `examples/` in the repo, and
 their source is shown in the docs. To create an example:
 
 1. Write the Python script and save it under `examples/`.
+1. Add any dependencies at the top of the script with a `pip install` command
+   (see existing examples for a sample of how to do this).
 1. Add a shell command to `tests/examples.sh` that calls the script with
-   parameters that will make it run as quickly as possible. In the future, this
-   will help us ensure that the script has basic correctness.
-1. Add any dependencies needed to run the example into the `examples` extra in
-   `setup.py` (under `extras_require`).
+   parameters that will make it run as quickly as possible. This helps us ensure
+   that the script has basic correctness. Also call the `install_deps` function
+   on the script file before running the script.
 1. Add a Markdown file in the `docs/examples` directory with the same name as
    the Python file -- if the example is `examples/foobar.py`, the Markdown file
    will be `docs/examples/foobar.md`.

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -99,6 +99,7 @@
 
 #### Documentation
 
+- Remove examples extra in favor of individual example deps (#306)
 - Facilitate linking to latest version of documentation (#300)
 - Update lunar lander tutorial with v0.5.0 features (#292)
 - Improve tutorial and example overviews (#291)

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -8,11 +8,8 @@ examples/lunar_lander
 ```
 
 These examples provide single Python files with fewer explanations than
-tutorials. If running locally, install dependencies with:
-
-```bash
-pip install ribs[examples]
-```
+tutorials. If running locally, first install the dependencies listed at the top
+of each file.
 
 Here are the current examples:
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -8,10 +8,8 @@ examples/lunar_lander
 ```
 
 These examples provide single Python files with fewer explanations than
-tutorials. If running locally, first install the dependencies listed at the top
-of each file.
-
-Here are the current examples:
+tutorials. To run each example, first install the dependencies listed at the top
+of each file, then follow the usage instructions. Here are the current examples:
 
 - {doc}`examples/sphere`: Demonstrates how to set up recent QD algorithms and
   apply them to the sphere benchmark function.

--- a/examples/README.md
+++ b/examples/README.md
@@ -3,5 +3,5 @@
 This directory contains examples for using pyribs. Each example has comments on
 usage and additional explanations. For more descriptions of these examples, see
 the [Examples](https://docs.pyribs.org/en/stable/examples.html) page in the
-documentation. To run these examples locally, first install the additional
-dependencies listed at the top of each file.
+documentation. To run these examples, first install the dependencies listed at
+the top of each file.

--- a/examples/README.md
+++ b/examples/README.md
@@ -4,4 +4,4 @@ This directory contains examples for using pyribs. Each example has comments on
 usage and additional explanations. For more descriptions of these examples, see
 the [Examples](https://docs.pyribs.org/en/stable/examples.html) page in the
 documentation. To run these examples locally, first install the additional
-dependencies with `pip install ribs[examples]` or `pip install -e .[examples]`.
+dependencies listed at the top of each file.

--- a/examples/lunar_lander.py
+++ b/examples/lunar_lander.py
@@ -1,5 +1,8 @@
 """Uses CMA-ME to train agents with linear policies in Lunar Lander.
 
+Install the following dependencies before running this example:
+    pip install ribs[visualize] tqdm fire gymnasium[box2d]==0.27.0 "moviepy>=1.0.0" dask>=2.0.0 distributed>=2.0.0 bokeh>=2.0.0
+
 This script uses the same setup as the tutorial, but it also uses Dask to
 parallelize evaluations on a single machine and adds in a CLI. Refer to the
 tutorial here: https://docs.pyribs.org/en/stable/tutorials/lunar_lander.html for

--- a/examples/lunar_lander.py
+++ b/examples/lunar_lander.py
@@ -1,7 +1,7 @@
 """Uses CMA-ME to train agents with linear policies in Lunar Lander.
 
 Install the following dependencies before running this example:
-    pip install ribs[visualize] tqdm fire gymnasium[box2d]==0.27.0 "moviepy>=1.0.0" dask>=2.0.0 distributed>=2.0.0 bokeh>=2.0.0
+    pip install ribs[visualize] tqdm fire gymnasium[box2d]==0.27.0 moviepy>=1.0.0 dask>=2.0.0 distributed>=2.0.0 bokeh>=2.0.0
 
 This script uses the same setup as the tutorial, but it also uses Dask to
 parallelize evaluations on a single machine and adds in a CLI. Refer to the

--- a/examples/sphere.py
+++ b/examples/sphere.py
@@ -1,5 +1,8 @@
 """Runs various QD algorithms on the Sphere function.
 
+Install the following dependencies before running this example:
+    pip install ribs[visualize] tqdm fire
+
 The sphere function in this example is adapted from Section 4 of Fontaine 2020
 (https://arxiv.org/abs/1912.02400). Namely, each solution value is clipped to
 the range [-5.12, 5.12], and the optimum is moved from [0,..] to [0.4 * 5.12 =

--- a/setup.py
+++ b/setup.py
@@ -24,21 +24,11 @@ install_requires = [
 
 extras_require = {
     "visualize": ["matplotlib>=3.0.0",],
-    # Dependencies for examples (NOT tutorials -- tutorial notebooks should
-    # install deps with cell magic and only depend on ribs and ribs[visualize]).
-    "examples": [
+    # All dependencies except for dev. Don't worry if there are duplicate
+    # dependencies, since setuptools automatically handles duplicates.
+    "all": [
+        ### visualize ###
         "matplotlib>=3.0.0",
-        # Strict since different gym may give different results. Note that we
-        # use gymnasium (https://gymnasium.farama.org), the successor to gym.
-        "gymnasium[box2d]==0.27.0",
-        "moviepy>=1.0.0",  # For recording videos in gym.
-        "fire>=0.4.0",
-        "tqdm>=4.0.0",
-
-        # Dask
-        "dask>=2.0.0",
-        "distributed>=2.0.0",
-        "bokeh>=2.0.0",  # Dask dashboard.
     ],
     "dev": [
         "pip>=20.3",
@@ -66,13 +56,6 @@ extras_require = {
         "wheel==0.36.2",
         "twine==1.14.0",
         "check-wheel-contents==0.2.0",
-    ],
-
-    # All dependencies above except dev and examples. Don't worry if there are
-    # duplicate dependencies, since setuptools automatically handles duplicates.
-    "all": [
-        ### visualize ###
-        "matplotlib>=3.0.0",
     ],
 }
 

--- a/tests/examples.sh
+++ b/tests/examples.sh
@@ -4,7 +4,6 @@
 # run.
 #
 # Usage:
-#   pip install .[visualize,examples]
 #   bash tests/examples.sh
 
 set -e  # Exit if any of the commands fail.
@@ -15,11 +14,17 @@ if [ ! -d "${TMPDIR}" ]; then
   mkdir "${TMPDIR}"
 fi
 
+function install_deps() {
+  install_cmd=$(grep "pip install" "$1")
+  $install_cmd
+}
+
 # Single-threaded for consistency.
 export OPENBLAS_NUM_THREADS=1
 export OMP_NUM_THREADS=1
 
 # sphere.py
+install_deps examples/sphere.py
 SPHERE_OUTPUT="${TMPDIR}/sphere_output"
 python examples/sphere.py map_elites --itrs 10 --outdir "${SPHERE_OUTPUT}"
 python examples/sphere.py line_map_elites --itrs 10 --outdir "${SPHERE_OUTPUT}"
@@ -42,6 +47,7 @@ python examples/sphere.py cma_mae --dim 20 --itrs 10 --learning_rate 0.01 --outd
 python examples/sphere.py cma_maega --dim 20 --itrs 10 --learning_rate 0.01 --outdir "${SPHERE_OUTPUT}"
 
 # lunar_lander.py
+install_deps examples/lunar_lander.py
 LUNAR_LANDER_OUTPUT="${TMPDIR}/lunar_lander_output"
 python examples/lunar_lander.py --iterations 5 --outdir "${LUNAR_LANDER_OUTPUT}"
 


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the PR's purpose here. -->

It seems troublesome to have to install dependencies for all examples with `ribs[examples]` when you only want to run a single example. Thus, this PR switches the dependencies to be associated with each script, much like the tutorials.

## TODO

<!-- Notable points that this PR has either accomplished or will accomplish. -->

## Questions

<!-- Any concerns or points of confusion? -->

## Status

- [x] I have read the guidelines in [CONTRIBUTING.md](https://github.com/icaros-usc/pyribs/blob/master/CONTRIBUTING.md)
- [x] I have formatted my code using `yapf`
- [x] I have tested my code by running `pytest`
- [x] I have linted my code with `pylint`
- [x] I have added a one-line description of my change to the changelog in `HISTORY.md`
- [x] This PR is ready to go
