### PR TITLE
Remove README from docs exclude patterns as it does not help

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -111,7 +111,7 @@ language = "en"
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This patterns also effect to html_static_path and html_extra_path
-exclude_patterns = ["_build", "Thumbs.db", ".DS_Store", "README.md"]
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 
 # The name of the Pygments (syntax highlighting) style to use.
 #  pygments_style = "sphinx"


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the PR's purpose here. -->

We keep getting warnings like:
```
...../docs/tutorials/README.md: WARNING: document isn't included in any toctree
```
because README.md is in `docs/tutorials` due to symlinking but we do not want it in the documentation. We tried to change this in #316 but the warning still shows up. Since it does not break the build, we will leave this warning as is.

## TODO

<!-- Notable points that this PR has either accomplished or will accomplish. -->

## Questions

<!-- Any concerns or points of confusion? -->

## Status

- [x] I have read the guidelines in [CONTRIBUTING.md](https://github.com/icaros-usc/pyribs/blob/master/CONTRIBUTING.md)
- [x] I have formatted my code using `yapf`
- [x] I have tested my code by running `pytest`
- [x] I have linted my code with `pylint`
- [ ] ~I have added a one-line description of my change to the changelog in `HISTORY.md`~
- [x] This PR is ready to go
