### PR TITLE
Schedulers warn if no solutions are inserted into archive

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,7 +6,7 @@
 
 #### API
 
-- Warn users when no solutions are inserted into archive (#320)
+- Schedulers warn if no solutions are inserted into archive (#320)
 - Implement `BanditScheduler` (#299)
 - **Backwards-incompatible:** Implement Scalable CMA-ES Optimizers (#274, #288)
 - Make ribs.emitters.opt public (#281)

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,6 +6,7 @@
 
 #### API
 
+- Warn users when no solutions are inserted into archive (#320)
 - Implement `BanditScheduler` (#299)
 - **Backwards-incompatible:** Implement Scalable CMA-ES Optimizers (#274, #288)
 - Make ribs.emitters.opt public (#281)

--- a/ribs/schedulers/_bandit_scheduler.py
+++ b/ribs/schedulers/_bandit_scheduler.py
@@ -34,7 +34,7 @@ class BanditScheduler:
             emitter_pool will be activated.
         num_active (int): The number of active emitters at a time. Active
             emitters are used when calling ask-tell.
-        zeta (float): Hyperparamter of UBC1 that balances the trade-off between
+        zeta (float): Hyperparamter of UCB1 that balances the trade-off between
             the accuracy and the uncertainty of the emitters. Increasing this
             parameter will emphasize the uncertainty of the emitters. Refer to
             the original paper for more information.

--- a/ribs/schedulers/_scheduler.py
+++ b/ribs/schedulers/_scheduler.py
@@ -1,4 +1,6 @@
 """Provides the Scheduler."""
+import warnings
+
 import numpy as np
 
 
@@ -192,6 +194,12 @@ class Scheduler:
                 "(this is the number of solutions output by ask()) but "
                 f"has length {len(array)}")
 
+    EMPTY_WARNING = (
+        "`{name}` was empty and is still empty after adding solutions. "
+        "One potential cause is that `threshold_min` is too high in this "
+        "archive, i.e., solutions are not being inserted because their "
+        "objective value does not exceed `threshold_min`.")
+
     def _tell_internal(self,
                        objective_batch,
                        measures_batch,
@@ -207,6 +215,9 @@ class Scheduler:
         self._check_length("objective_batch", objective_batch)
         self._check_length("measures_batch", measures_batch)
         self._check_length("metadata_batch", metadata_batch)
+
+        archive_empty_before = self.archive.empty
+        result_archive_empty_before = self.result_archive.empty
 
         # Add solutions to the archive.
         if self._add_mode == "batch":
@@ -238,6 +249,12 @@ class Scheduler:
                                                     measure, metadata)
             status_batch = np.asarray(status_batch)
             value_batch = np.asarray(value_batch)
+
+        # Warn the user if nothing was inserted into the archives.
+        if archive_empty_before and self.archive.empty:
+            warnings.warn(self.EMPTY_WARNING.format(name="archive"))
+        if result_archive_empty_before and self.result_archive.empty:
+            warnings.warn(self.EMPTY_WARNING.format(name="result_archive"))
 
         return (
             objective_batch,

--- a/ribs/schedulers/_scheduler.py
+++ b/ribs/schedulers/_scheduler.py
@@ -195,7 +195,7 @@ class Scheduler:
                 f"has length {len(array)}")
 
     EMPTY_WARNING = (
-        "`{name}` was empty and is still empty after adding solutions. "
+        "`{name}` was empty before and is still empty after adding solutions. "
         "One potential cause is that `threshold_min` is too high in this "
         "archive, i.e., solutions are not being inserted because their "
         "objective value does not exceed `threshold_min`.")
@@ -217,7 +217,8 @@ class Scheduler:
         self._check_length("metadata_batch", metadata_batch)
 
         archive_empty_before = self.archive.empty
-        result_archive_empty_before = self.result_archive.empty
+        if self._result_archive is not None:
+            result_archive_empty_before = self.result_archive.empty
 
         # Add solutions to the archive.
         if self._add_mode == "batch":
@@ -253,8 +254,9 @@ class Scheduler:
         # Warn the user if nothing was inserted into the archives.
         if archive_empty_before and self.archive.empty:
             warnings.warn(self.EMPTY_WARNING.format(name="archive"))
-        if result_archive_empty_before and self.result_archive.empty:
-            warnings.warn(self.EMPTY_WARNING.format(name="result_archive"))
+        if self._result_archive is not None:
+            if result_archive_empty_before and self.result_archive.empty:
+                warnings.warn(self.EMPTY_WARNING.format(name="result_archive"))
 
         return (
             objective_batch,

--- a/ribs/schedulers/_scheduler.py
+++ b/ribs/schedulers/_scheduler.py
@@ -195,7 +195,8 @@ class Scheduler:
                 f"has length {len(array)}")
 
     EMPTY_WARNING = (
-        "`{name}` was empty before and is still empty after adding solutions. "
+        "`{name}` was empty before adding solutions, and it is still empty "
+        "after adding solutions. "
         "One potential cause is that `threshold_min` is too high in this "
         "archive, i.e., solutions are not being inserted because their "
         "objective value does not exceed `threshold_min`.")

--- a/ribs/schedulers/_scheduler.py
+++ b/ribs/schedulers/_scheduler.py
@@ -219,6 +219,8 @@ class Scheduler:
 
         archive_empty_before = self.archive.empty
         if self._result_archive is not None:
+            # Check self._result_archive here since self.result_archive is a
+            # property that always provides a proper archive.
             result_archive_empty_before = self.result_archive.empty
 
         # Add solutions to the archive.

--- a/tests/schedulers/scheduler_test.py
+++ b/tests/schedulers/scheduler_test.py
@@ -71,6 +71,46 @@ def test_ask_fails_when_called_twice(scheduler_fixture):
         scheduler.ask()
 
 
+def test_warn_nothing_added_to_archive():
+    archive = GridArchive(solution_dim=2,
+                          dims=[100, 100],
+                          ranges=[(-1, 1), (-1, 1)],
+                          threshold_min=1.0)
+    emitters = [GaussianEmitter(archive, sigma=1, x0=[0.0, 0.0], batch_size=4)]
+    scheduler = Scheduler(archive, emitters)
+
+    _ = scheduler.ask()
+    with pytest.warns(UserWarning):
+        scheduler.tell(
+            # All objectives are below threshold_min of 1.0.
+            objective_batch=np.zeros(4),
+            # Arbitrary measures.
+            measures_batch=np.linspace(-1, 1, 4 * 2).reshape((4, 2)),
+        )
+
+
+def test_warn_nothing_added_to_result_archive():
+    archive = GridArchive(solution_dim=2,
+                          dims=[100, 100],
+                          ranges=[(-1, 1), (-1, 1)],
+                          threshold_min=-np.inf)
+    result_archive = GridArchive(solution_dim=2,
+                                 dims=[100, 100],
+                                 ranges=[(-1, 1), (-1, 1)],
+                                 threshold_min=10.0)
+    emitters = [GaussianEmitter(archive, sigma=1, x0=[0.0, 0.0], batch_size=4)]
+    scheduler = Scheduler(archive, emitters, result_archive=result_archive)
+
+    _ = scheduler.ask()
+    with pytest.warns(UserWarning):
+        scheduler.tell(
+            # All objectives are below threshold_min of 1.0.
+            objective_batch=np.zeros(4),
+            # Arbitrary measures.
+            measures_batch=np.linspace(-1, 1, 4 * 2).reshape((4, 2)),
+        )
+
+
 @pytest.mark.parametrize("tell_metadata", [True, False],
                          ids=["metadata", "no_metadata"])
 def test_tell_inserts_solutions_into_archive(add_mode, tell_metadata):


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the PR's purpose here. -->

Solutions may not be inserted into the archive if the threshold_min is too high. This can lead to unexpected behavior. For instance, GaussianEmitter with an initial set of solutions will keep producing that same set of solutions, and archive metrics like `obj_max` will be `None`. We shouldn't throw an error when this happens as users may decide they want this, but a warning is nice.

## TODO

<!-- Notable points that this PR has either accomplished or will accomplish. -->

- [x] Warn in Scheduler
- [x] Warn in BanditScheduler
- [x] Test Scheduler warning
- [x] Test BanditScheduler warning

## Questions

<!-- Any concerns or points of confusion? -->

## Status

- [x] I have read the guidelines in [CONTRIBUTING.md](https://github.com/icaros-usc/pyribs/blob/master/CONTRIBUTING.md)
- [x] I have formatted my code using `yapf`
- [x] I have tested my code by running `pytest`
- [x] I have linted my code with `pylint`
- [x] I have added a one-line description of my change to the changelog in `HISTORY.md`
- [x] This PR is ready to go
