### PR TITLE
Remove GradientArborescenceEmitter bounds

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -31,7 +31,7 @@
   - **Backwards-incompatible:** `behavior_dim` in archives is now `measure_dim`
   - Rename `n_solutions` to `batch_size` in `Scheduler`.
 - Add `GradientArborescenceEmitter`, which is used to implement CMA-MEGA (#240,
-  #263, #264, #282)
+  #263, #264, #282, #321)
 - Update emitter `tell()` docstrings to no longer say "Inserts entries into
   archive" (#247)
 - Expose `emitter.restarts` as a property (#248)

--- a/examples/sphere.py
+++ b/examples/sphere.py
@@ -444,8 +444,7 @@ CONFIG = {
                 "sigma0": 10.0,
                 "lr": 1.0,
                 "grad_opt": "gradient_ascent",
-                "selection_rule": "mu",
-                "bounds": None
+                "selection_rule": "mu"
             },
             "num_emitters": 1
         }],
@@ -473,8 +472,7 @@ CONFIG = {
                 "sigma0": 10.0,
                 "lr": 0.002,
                 "grad_opt": "adam",
-                "selection_rule": "mu",
-                "bounds": None
+                "selection_rule": "mu"
             },
             "num_emitters": 1
         }],
@@ -533,8 +531,7 @@ CONFIG = {
                 "lr": 1.0,
                 "ranker": "imp",
                 "grad_opt": "gradient_ascent",
-                "restart_rule": "basic",
-                "bounds": None
+                "restart_rule": "basic"
             },
             "num_emitters": 15
         }],

--- a/ribs/emitters/_gradient_arborescence_emitter.py
+++ b/ribs/emitters/_gradient_arborescence_emitter.py
@@ -39,10 +39,17 @@ class GradientArborescenceEmitter(EmitterBase):
     :math:`\\boldsymbol{\\mu}` and :math:`\\boldsymbol{\\Sigma}` are updated
     with an ES (the default ES is CMA-ES).
 
-    Note that unlike non-gradient emitters, GradientArborescenceEmitter requires
-    calling :meth:`ask_dqd` and :meth:`tell_dqd` (in this order) before calling
-    :meth:`ask` and :meth:`tell` to communicate the gradient information to the
-    emitter.
+    .. note::
+
+        Unlike non-gradient emitters, GradientArborescenceEmitter requires
+        calling :meth:`ask_dqd` and :meth:`tell_dqd` (in this order) before
+        calling :meth:`ask` and :meth:`tell` to communicate the gradient
+        information to the emitter.
+
+    .. note::
+
+        This emitter does not support solution space bounds, as bounding
+        solutions for DQD algorithms such as CMA-MEGA is still an open problem.
 
     Args:
         archive (ribs.archives.ArchiveBase): An archive to use when creating and
@@ -92,15 +99,6 @@ class GradientArborescenceEmitter(EmitterBase):
             optimizer.
         normalize_grad (bool): If true (default), then gradient infomation will
             be normalized. Otherwise, it will not be normalized.
-        bounds (None or array-like): Bounds of the solution space. As suggested
-            in `Biedrzycki 2020
-            <https://www.sciencedirect.com/science/article/abs/pii/S2210650219301622>`_,
-            solutions are resampled until they fall within these bounds.  Pass
-            None to indicate there are no bounds. Alternatively, pass an
-            array-like to specify the bounds for each dim. Each element in this
-            array-like can be None to indicate no bound, or a tuple of
-            ``(lower_bound, upper_bound)``, where ``lower_bound`` or
-            ``upper_bound`` may be None to indicate no bound.
         batch_size (int): Number of solutions to return in :meth:`ask`. If not
             passed in, a batch size will be automatically calculated using the
             default CMA-ES rules. Note that `batch_size` **does not** include
@@ -116,7 +114,6 @@ class GradientArborescenceEmitter(EmitterBase):
             avoid a fixed seed.
     Raises:
         ValueError: There is an error in x0 or initial_solutions.
-        ValueError: There is an error in the bounds configuration.
         ValueError: If ``restart_rule``, ``selection_rule``, or ``ranker`` is
             invalid.
     """
@@ -135,7 +132,6 @@ class GradientArborescenceEmitter(EmitterBase):
                  es="cma_es",
                  es_kwargs=None,
                  normalize_grad=True,
-                 bounds=None,
                  batch_size=None,
                  epsilon=1e-8,
                  seed=None):
@@ -143,7 +139,7 @@ class GradientArborescenceEmitter(EmitterBase):
             self,
             archive,
             solution_dim=archive.solution_dim,
-            bounds=bounds,
+            bounds=None,
         )
 
         self._epsilon = epsilon

--- a/ribs/emitters/_gradient_arborescence_emitter.py
+++ b/ribs/emitters/_gradient_arborescence_emitter.py
@@ -46,11 +46,6 @@ class GradientArborescenceEmitter(EmitterBase):
         calling :meth:`ask` and :meth:`tell` to communicate the gradient
         information to the emitter.
 
-    .. note::
-
-        This emitter does not support solution space bounds, as bounding
-        solutions for DQD algorithms such as CMA-MEGA is still an open problem.
-
     Args:
         archive (ribs.archives.ArchiveBase): An archive to use when creating and
             inserting solutions. For instance, this can be
@@ -99,6 +94,10 @@ class GradientArborescenceEmitter(EmitterBase):
             optimizer.
         normalize_grad (bool): If true (default), then gradient infomation will
             be normalized. Otherwise, it will not be normalized.
+        bounds: This argument may be used for providing solution space bounds in
+            the future. This emitter does not currently support solution space
+            bounds, as bounding solutions for DQD algorithms such as CMA-MEGA is
+            an open problem. Hence, this argument must be set to None.
         batch_size (int): Number of solutions to return in :meth:`ask`. If not
             passed in, a batch size will be automatically calculated using the
             default CMA-ES rules. Note that `batch_size` **does not** include
@@ -114,6 +113,7 @@ class GradientArborescenceEmitter(EmitterBase):
             avoid a fixed seed.
     Raises:
         ValueError: There is an error in x0 or initial_solutions.
+        ValueError: ``bounds`` is set even though it is not currently supported.
         ValueError: If ``restart_rule``, ``selection_rule``, or ``ranker`` is
             invalid.
     """
@@ -132,14 +132,23 @@ class GradientArborescenceEmitter(EmitterBase):
                  es="cma_es",
                  es_kwargs=None,
                  normalize_grad=True,
+                 bounds=None,
                  batch_size=None,
                  epsilon=1e-8,
                  seed=None):
+
+        if bounds is not None:
+            raise ValueError(
+                "`bounds` must be set to None. The GradientArborescenceEmitter "
+                "does not currently support solution space bounds, as bounding "
+                "solutions for DQD algorithms such as CMA-MEGA is an open "
+                "problem.")
+
         EmitterBase.__init__(
             self,
             archive,
             solution_dim=archive.solution_dim,
-            bounds=None,
+            bounds=bounds,
         )
 
         self._epsilon = epsilon

--- a/tests/emitters/gradient_arborescence_emitter_test.py
+++ b/tests/emitters/gradient_arborescence_emitter_test.py
@@ -44,3 +44,18 @@ def test_dtypes(dtype):
                                           sigma0=1.0,
                                           lr=1.0)
     assert emitter.x0.dtype == dtype
+
+
+def test_bounds_must_be_none():
+    bound = [(-1, 1)]
+    batch_size = 1
+    archive = GridArchive(solution_dim=1, dims=[10], ranges=[(-1.0, 1.0)])
+
+    with pytest.raises(ValueError):
+        GradientArborescenceEmitter(archive,
+                                    x0=np.array([0]),
+                                    sigma0=1.0,
+                                    lr=1.0,
+                                    normalize_grad=False,
+                                    bounds=bound,
+                                    batch_size=batch_size)

--- a/tests/emitters/gradient_arborescence_emitter_test.py
+++ b/tests/emitters/gradient_arborescence_emitter_test.py
@@ -44,39 +44,3 @@ def test_dtypes(dtype):
                                           sigma0=1.0,
                                           lr=1.0)
     assert emitter.x0.dtype == dtype
-
-
-def test_adhere_to_solution_bounds():
-    bound = [(-1, 1)]
-    batch_size = 1
-    archive = GridArchive(solution_dim=1, dims=[10], ranges=[(-1.0, 1.0)])
-    emitter = GradientArborescenceEmitter(archive,
-                                          x0=np.array([0]),
-                                          sigma0=1.0,
-                                          lr=1.0,
-                                          normalize_grad=False,
-                                          bounds=bound,
-                                          batch_size=batch_size)
-
-    # Set jacobian so tell_dqd doesn't crash.
-    jacobian = np.full(
-        (
-            1,  # Only one solution.
-            2,  # Two gradients -- one objective, one measures.
-            1,  # One solution dimension for each gradient.
-        ),
-        2,  # Each value is 2.0.
-    )
-    emitter.tell_dqd(
-        np.zeros((batch_size, archive.solution_dim)),
-        np.zeros(batch_size),
-        np.zeros((batch_size, archive.measure_dim)),
-        jacobian,
-        np.zeros(batch_size),
-        np.zeros(batch_size),
-    )
-
-    # This might take a while because it needs to resample.
-    sol = emitter.ask()
-
-    assert np.all(np.logical_and(sol >= bound[0][0], sol <= bound[0][1]))


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the PR's purpose here. -->

Solution space bounds remain an open problem for DQD algorithms, and it is unclear that our implementation will create the correct behavior. Thus, we are removing the bounds handling for the time being.

## TODO

<!-- Notable points that this PR has either accomplished or will accomplish. -->

## Questions

<!-- Any concerns or points of confusion? -->

## Status

- [x] I have read the guidelines in [CONTRIBUTING.md](https://github.com/icaros-usc/pyribs/blob/master/CONTRIBUTING.md)
- [x] I have formatted my code using `yapf`
- [x] I have tested my code by running `pytest`
- [x] I have linted my code with `pylint`
- [x] I have added a one-line description of my change to the changelog in `HISTORY.md`
- [x] This PR is ready to go