### PR TITLE
Fix number of emitters for CMA-MAEGA

### DIFF
--- a/examples/sphere.py
+++ b/examples/sphere.py
@@ -536,7 +536,7 @@ CONFIG = {
                 "restart_rule": "basic",
                 "bounds": None
             },
-            "num_emitters": 15
+            "num_emitters": 1
         }],
         "scheduler": {
             "class": Scheduler,


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the PR's purpose here. -->

Default CMA-MAEGA uses one emitter, not 15.

## TODO

<!-- Notable points that this PR has either accomplished or will accomplish. -->

## Questions

<!-- Any concerns or points of confusion? -->

## Status

- [x] I have read the guidelines in [CONTRIBUTING.md](https://github.com/icaros-usc/pyribs/blob/master/CONTRIBUTING.md)
- [x] I have formatted my code using `yapf`
- [x] I have tested my code by running `pytest`
- [x] I have linted my code with `pylint`
- [x] I have added a one-line description of my change to the changelog in `HISTORY.md`
- [x] This PR is ready to go
