### PR TITLE
Speed up 2D cvt_archive_heatmap by order of magnitude

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -9,6 +9,7 @@
 - Drop Python 3.7 support and upgrade dependencies (#350)
 - Add visualization of QDax repertoires (#353)
 - Improve cvt_archive_heatmap flexibility (#354)
+- Speed up 2D cvt_archive_heatmap by order of magnitude (#355)
 
 #### Documentation
 

--- a/ribs/visualize.py
+++ b/ribs/visualize.py
@@ -434,7 +434,7 @@ def cvt_archive_heatmap(archive,
     # the cmap. Shape (sum(facecolor_cmap_mask),)
     facecolor_objs = []
 
-    # Cycle through the regions to collect patches and facecolors.
+    # Cycle through the regions to set up polygon vertices and facecolors.
     for region, objective in zip(vor.regions, region_obj):
         # Checking for -1 is O(n), but n is typically small.
         #

--- a/tests/visualize/visualize_test.py
+++ b/tests/visualize/visualize_test.py
@@ -26,7 +26,8 @@ from ribs.visualize import (cvt_archive_heatmap, grid_archive_heatmap,
 # pylint: disable = redefined-outer-name
 
 # Tolerance for root mean square difference between the pixels of the images,
-# where 255 is the max value.
+# where 255 is the max value. We only have tolerance for `cvt_archive_heatmap`
+# since it is a bit more finicky than the other plots.
 CVT_IMAGE_TOLERANCE = 0.1
 
 

--- a/tests/visualize/visualize_test.py
+++ b/tests/visualize/visualize_test.py
@@ -25,6 +25,10 @@ from ribs.visualize import (cvt_archive_heatmap, grid_archive_heatmap,
 
 # pylint: disable = redefined-outer-name
 
+# Tolerance for root mean square difference between the pixels of the images,
+# where 255 is the max value.
+CVT_IMAGE_TOLERANCE = 0.1
+
 
 @pytest.fixture(autouse=True)
 def clean_matplotlib():
@@ -379,7 +383,8 @@ def test_heatmap_archive__grid_custom_cbar_axis(grid_archive):
 
 @image_comparison(baseline_images=["cvt_archive_heatmap"],
                   remove_text=False,
-                  extensions=["png"])
+                  extensions=["png"],
+                  tol=CVT_IMAGE_TOLERANCE)
 def test_heatmap_archive__cvt(cvt_archive):
     plt.figure(figsize=(8, 6))
     cvt_archive_heatmap(cvt_archive)
@@ -403,7 +408,8 @@ def test_heatmap_with_custom_axis__grid(grid_archive):
 
 @image_comparison(baseline_images=["cvt_archive_heatmap"],
                   remove_text=False,
-                  extensions=["png"])
+                  extensions=["png"],
+                  tol=CVT_IMAGE_TOLERANCE)
 def test_heatmap_with_custom_axis__cvt(cvt_archive):
     _, ax = plt.subplots(figsize=(8, 6))
     cvt_archive_heatmap(cvt_archive, ax=ax)
@@ -427,7 +433,8 @@ def test_heatmap_long__grid(long_grid_archive):
 
 @image_comparison(baseline_images=["cvt_archive_heatmap_long"],
                   remove_text=False,
-                  extensions=["png"])
+                  extensions=["png"],
+                  tol=CVT_IMAGE_TOLERANCE)
 def test_heatmap_long__cvt(long_cvt_archive):
     plt.figure(figsize=(8, 6))
     cvt_archive_heatmap(long_cvt_archive)
@@ -451,7 +458,8 @@ def test_heatmap_long_square__grid(long_grid_archive):
 
 @image_comparison(baseline_images=["cvt_archive_heatmap_long_square"],
                   remove_text=False,
-                  extensions=["png"])
+                  extensions=["png"],
+                  tol=CVT_IMAGE_TOLERANCE)
 def test_heatmap_long_square__cvt(long_cvt_archive):
     plt.figure(figsize=(8, 6))
     cvt_archive_heatmap(long_cvt_archive, aspect="equal")
@@ -475,7 +483,8 @@ def test_heatmap_long_transpose__grid(long_grid_archive):
 
 @image_comparison(baseline_images=["cvt_archive_heatmap_long_transpose"],
                   remove_text=False,
-                  extensions=["png"])
+                  extensions=["png"],
+                  tol=CVT_IMAGE_TOLERANCE)
 def test_heatmap_long_transpose__cvt(long_cvt_archive):
     plt.figure(figsize=(8, 6))
     cvt_archive_heatmap(long_cvt_archive, transpose_measures=True)
@@ -502,7 +511,8 @@ def test_heatmap_with_limits__grid(grid_archive):
 
 @image_comparison(baseline_images=["cvt_archive_heatmap_with_limits"],
                   remove_text=False,
-                  extensions=["png"])
+                  extensions=["png"],
+                  tol=CVT_IMAGE_TOLERANCE)
 def test_heatmap_with_limits__cvt(cvt_archive):
     plt.figure(figsize=(8, 6))
     cvt_archive_heatmap(cvt_archive, vmin=-1.0, vmax=-0.5)
@@ -527,7 +537,8 @@ def test_heatmap_listed_cmap__grid(grid_archive):
 
 @image_comparison(baseline_images=["cvt_archive_heatmap_with_listed_cmap"],
                   remove_text=False,
-                  extensions=["png"])
+                  extensions=["png"],
+                  tol=CVT_IMAGE_TOLERANCE)
 def test_heatmap_listed_cmap__cvt(cvt_archive):
     plt.figure(figsize=(8, 6))
     cvt_archive_heatmap(cvt_archive, cmap=[[1, 0, 0], [0, 1, 0], [0, 0, 1]])
@@ -553,7 +564,8 @@ def test_heatmap_coolwarm_cmap__grid(grid_archive):
 
 @image_comparison(baseline_images=["cvt_archive_heatmap_with_coolwarm_cmap"],
                   remove_text=False,
-                  extensions=["png"])
+                  extensions=["png"],
+                  tol=CVT_IMAGE_TOLERANCE)
 def test_heatmap_coolwarm_cmap__cvt(cvt_archive):
     plt.figure(figsize=(8, 6))
     cvt_archive_heatmap(cvt_archive, cmap="coolwarm")
@@ -614,7 +626,8 @@ def test_sliding_archive_mismatch_xy_with_boundaries():
 
 @image_comparison(baseline_images=["cvt_archive_heatmap_vmin_equals_vmax"],
                   remove_text=False,
-                  extensions=["png"])
+                  extensions=["png"],
+                  tol=CVT_IMAGE_TOLERANCE)
 def test_cvt_archive_heatmap_vmin_equals_vmax(cvt_archive):
     plt.figure(figsize=(8, 6))
     cvt_archive_heatmap(cvt_archive, vmin=-0.5, vmax=-0.5)
@@ -622,7 +635,8 @@ def test_cvt_archive_heatmap_vmin_equals_vmax(cvt_archive):
 
 @image_comparison(baseline_images=["cvt_archive_heatmap_with_centroids"],
                   remove_text=False,
-                  extensions=["png"])
+                  extensions=["png"],
+                  tol=CVT_IMAGE_TOLERANCE)
 def test_cvt_archive_heatmap_with_centroids(cvt_archive):
     plt.figure(figsize=(8, 6))
     cvt_archive_heatmap(cvt_archive, plot_centroids=True)
@@ -630,7 +644,8 @@ def test_cvt_archive_heatmap_with_centroids(cvt_archive):
 
 @image_comparison(baseline_images=["cvt_archive_heatmap_with_samples"],
                   remove_text=False,
-                  extensions=["png"])
+                  extensions=["png"],
+                  tol=CVT_IMAGE_TOLERANCE)
 def test_cvt_archive_heatmap_with_samples(cvt_archive):
     plt.figure(figsize=(8, 6))
     cvt_archive_heatmap(cvt_archive, plot_samples=True)
@@ -650,7 +665,8 @@ def test_cvt_archive_heatmap_no_samples_error():
 
 @image_comparison(baseline_images=["cvt_archive_heatmap_voronoi_style"],
                   remove_text=False,
-                  extensions=["png"])
+                  extensions=["png"],
+                  tol=CVT_IMAGE_TOLERANCE)
 def test_cvt_archive_heatmap_voronoi_style(cvt_archive):
     plt.figure(figsize=(8, 6))
     cvt_archive_heatmap(cvt_archive, lw=3.0, ec="grey")

--- a/tests/visualize_qdax/visualize_qdax_test.py
+++ b/tests/visualize_qdax/visualize_qdax_test.py
@@ -28,7 +28,8 @@ def clean_matplotlib():
 
 @image_comparison(baseline_images=["qdax_repertoire_heatmap"],
                   remove_text=False,
-                  extensions=["png"])
+                  extensions=["png"],
+                  tol=0.1)  # See CVT_IMAGE_TOLERANCE in visualize_test.py
 def test_qdax_repertoire_heatmap():
     plt.figure(figsize=(8, 6))
 


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the PR's purpose here. -->

Currently, cvt_archive_heatmap plots individual polygons via ax.fill . We can speed this up by instead using a [`PolyCollection`](https://matplotlib.org/stable/api/collections_api.html#matplotlib.collections.PolyCollection) to add all the polygons at once. This is similar to using a `PatchCollection` as shown here: https://matplotlib.org/stable/gallery/shapes_and_collections/patch_collection.html.

Benchmark for plotting a `CVTArchive` with 10,000 cells:

- Before: 14.9 sec
- After: 0.6 sec

I used the following code to benchmark the implementation:

```python
"""Driver for cvt heatmap experiments."""

import time

import fire
import matplotlib.pyplot as plt
import numpy as np

from ribs.archives import CVTArchive
from ribs.visualize import cvt_archive_heatmap


def main(n_cells=10000):
    """Creates the archive and plots it."""
    np.random.seed(42)

    archive = CVTArchive(
        solution_dim=3,
        cells=n_cells,
        ranges=[(-1, 1), (-1, 1)],
        custom_centroids=np.random.uniform(-1, 1, (n_cells, 2)),
    )

    archive.add(
        np.random.uniform(-1, 1, (20000, 3)),
        np.random.standard_normal(20000),
        np.random.uniform(-1, 1, (20000, 2)),
    )

    plt.figure(figsize=(8, 6))

    start_time = time.time()
    cvt_archive_heatmap(archive)
    print("Plot time", time.time() - start_time)

    plt.savefig("cvt.png")


if __name__ == "__main__":
    fire.Fire(main)
```

## TODO

<!-- Notable points that this PR has either accomplished or will accomplish. -->

- [x]  Speed up 2D polygon plotting by using matplotlib PolyCollection — note that I initially used a PatchCollection with individual Polygon patches, but PolyCollection is much faster because we do not have to construct the individual `Polygon` patches in Python.
- [x]  Compute facecolors in a batch instead of individually
- [x]  Fix test errors — it seems the images changed slightly due to the new implementation, so we now allow a slight tolerance for cvt heatmap images

## Questions

<!-- Any concerns or points of confusion? -->

## Status

- [x] I have read the guidelines in
      [CONTRIBUTING.md](https://github.com/icaros-usc/pyribs/blob/master/CONTRIBUTING.md)
- [x] I have formatted my code using `yapf`
- [x] I have tested my code by running `pytest`
- [x] I have linted my code with `pylint`
- [x] I have added a one-line description of my change to the changelog in
      `HISTORY.md`
- [x] This PR is ready to go
