### PR TITLE
Allow using kwargs for colorbar in parallel_axes_plot

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -11,6 +11,8 @@
 - Improve cvt_archive_heatmap flexibility (#354)
 - Speed up 2D cvt_archive_heatmap by order of magnitude (#355)
 - Clip Voronoi regions in cvt_archive_heatmap (#356)
+- **Backwards-incompatible:** Allow using kwargs for colorbar in
+  parallel_axes_plot (#358)
 
 #### Documentation
 

--- a/ribs/visualize/_parallel_axes_plot.py
+++ b/ribs/visualize/_parallel_axes_plot.py
@@ -4,7 +4,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 from matplotlib.cm import ScalarMappable
 
-from ribs.visualize._utils import retrieve_cmap
+from ribs.visualize._utils import retrieve_cmap, set_cbar
 
 # Matplotlib functions tend to have a ton of args.
 # pylint: disable = too-many-arguments
@@ -20,8 +20,8 @@ def parallel_axes_plot(archive,
                        vmin=None,
                        vmax=None,
                        sort_archive=False,
-                       cbar_orientation='horizontal',
-                       cbar_pad=0.1):
+                       cbar="auto",
+                       cbar_kwargs=None):
     """Visualizes archive elites in measure space with a parallel axes plot.
 
     This visualization is meant to show the coverage of the measure space at a
@@ -104,22 +104,21 @@ def parallel_axes_plot(archive,
             elites.
 
             .. warning:: This may be slow for large archives.
-        cbar_orientation (str): The orientation of the colorbar. Use either
-            ``'vertical'`` or ``'horizontal'``
-        cbar_pad (float): The amount of padding to use for the colorbar.
+        cbar ('auto', None, matplotlib.axes.Axes): By default, this is set to
+            ``'auto'`` which displays the colorbar on the archive's current
+            :class:`~matplotlib.axes.Axes`. If ``None``, then colorbar is not
+            displayed. If this is an :class:`~matplotlib.axes.Axes`, displays
+            the colorbar on the specified Axes.
+        cbar_kwargs (dict): Additional kwargs to pass to
+            :func:`~matplotlib.pyplot.colorbar`. By default, we set
+            "orientation" to "horizontal" and "pad" to 0.1.
 
     Raises:
-        ValueError: ``cbar_orientation`` has an invalid value.
         ValueError: The measures provided do not exist in the archive.
         TypeError: ``measure_order`` is not a list of all ints or all tuples.
     """
     # Try getting the colormap early in case it fails.
     cmap = retrieve_cmap(cmap)
-
-    # Check that the orientation input is correct.
-    if cbar_orientation not in ['vertical', 'horizontal']:
-        raise ValueError("cbar_orientation must be 'vertical' or 'horizontal' "
-                         f"but is '{cbar_orientation}'")
 
     # If there is no order specified, plot in increasing numerical order.
     if measure_order is None:
@@ -204,7 +203,12 @@ def parallel_axes_plot(archive,
     # Create a colorbar.
     mappable = ScalarMappable(cmap=cmap)
     mappable.set_clim(vmin, vmax)
-    host_ax.figure.colorbar(mappable,
-                            ax=host_ax,
-                            pad=cbar_pad,
-                            orientation=cbar_orientation)
+
+    # Default colorbar settings.
+    cbar_kwargs = {} if cbar_kwargs is None else cbar_kwargs.copy()
+    if "orientation" not in cbar_kwargs:
+        cbar_kwargs["orientation"] = "horizontal"
+    if "pad" not in cbar_kwargs:
+        cbar_kwargs["pad"] = 0.1
+
+    set_cbar(mappable, host_ax, cbar, cbar_kwargs)

--- a/ribs/visualize/_parallel_axes_plot.py
+++ b/ribs/visualize/_parallel_axes_plot.py
@@ -99,9 +99,8 @@ def parallel_axes_plot(archive,
             the minimum objective value in the archive is used.
         vmax (float): Maximum objective value to use in the plot. If ``None``,
             the maximum objective value in the archive is used.
-        sort_archive (boolean): If ``True``, sorts the archive so that the
-            highest performing elites are plotted on top of lower performing
-            elites.
+        sort_archive (bool): If ``True``, sorts the archive so that the highest
+            performing elites are plotted on top of lower performing elites.
 
             .. warning:: This may be slow for large archives.
         cbar ('auto', None, matplotlib.axes.Axes): By default, this is set to

--- a/tests/visualize/visualize_test.py
+++ b/tests/visualize/visualize_test.py
@@ -850,4 +850,5 @@ def test_parallel_axes_3d_sorted(three_d_grid_archive):
                   extensions=["png"])
 def test_parallel_axes_3d_vertical_cbar(three_d_grid_archive):
     plt.figure(figsize=(8, 6))
-    parallel_axes_plot(three_d_grid_archive, cbar_orientation='vertical')
+    parallel_axes_plot(three_d_grid_archive,
+                       cbar_kwargs={"orientation": "vertical"})


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the PR's purpose here. -->

This PR makes the colorbar usage more consistent with the other visualization methods. We now have a `cbar` arg which determines whether the colorbar is plotted. We also have a `cbar_kwargs` arg which allows configuration of the colorbar. The `cbar_kwargs` has sensible defaults for `orientation` and `pad`.

## TODO

<!-- Notable points that this PR has either accomplished or will accomplish. -->

- [x] Add `cbar` and `cbar_kwargs` args to parallel_axes_plot
- [x] Remove `cbar_pad` and `cbar_orientation` args
- [x] Update tests

## Questions

<!-- Any concerns or points of confusion? -->

## Status

- [x] I have read the guidelines in
      [CONTRIBUTING.md](https://github.com/icaros-usc/pyribs/blob/master/CONTRIBUTING.md)
- [x] I have formatted my code using `yapf`
- [x] I have tested my code by running `pytest`
- [x] I have linted my code with `pylint`
- [x] I have added a one-line description of my change to the changelog in
      `HISTORY.md`
- [x] This PR is ready to go
