### PR TITLE
Use setdefault to handle default kwargs more cleanly

### DIFF
--- a/ribs/archives/_cvt_archive.py
+++ b/ribs/archives/_cvt_archive.py
@@ -142,16 +142,16 @@ class CVTArchive(ArchiveBase):
         # particularly if they want higher quality clusters.
         self._k_means_kwargs = ({} if k_means_kwargs is None else
                                 k_means_kwargs.copy())
-        if "n_init" not in self._k_means_kwargs:
+        self._k_means_kwargs.setdefault(
             # Only run one iter to be fast.
-            self._k_means_kwargs["n_init"] = 1
-        if "init" not in self._k_means_kwargs:
-            # The default, "k-means++", takes very long to init.
-            self._k_means_kwargs["init"] = "random"
-        if "algorithm" not in self._k_means_kwargs:
-            self._k_means_kwargs["algorithm"] = "lloyd"
-        if "random_state" not in self._k_means_kwargs:
-            self._k_means_kwargs["random_state"] = seed
+            "n_init",
+            1)
+        self._k_means_kwargs.setdefault(
+            # The default "k-means++" takes very long to init.
+            "init",
+            "random")
+        self._k_means_kwargs.setdefault("algorithm", "lloyd")
+        self._k_means_kwargs.setdefault("random_state", seed)
 
         self._use_kd_tree = use_kd_tree
         self._centroid_kd_tree = None

--- a/ribs/visualize/_parallel_axes_plot.py
+++ b/ribs/visualize/_parallel_axes_plot.py
@@ -203,11 +203,9 @@ def parallel_axes_plot(archive,
     mappable = ScalarMappable(cmap=cmap)
     mappable.set_clim(vmin, vmax)
 
-    # Default colorbar settings.
+    # Add default colorbar settings.
     cbar_kwargs = {} if cbar_kwargs is None else cbar_kwargs.copy()
-    if "orientation" not in cbar_kwargs:
-        cbar_kwargs["orientation"] = "horizontal"
-    if "pad" not in cbar_kwargs:
-        cbar_kwargs["pad"] = 0.1
+    cbar_kwargs.setdefault("orientation", "horizontal")
+    cbar_kwargs.setdefault("pad", 0.1)
 
     set_cbar(mappable, host_ax, cbar, cbar_kwargs)


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the PR's purpose here. -->

Using setdefault is shorter than checking "if X not in kwargs..."

## TODO

<!-- Notable points that this PR has either accomplished or will accomplish. -->

## Questions

<!-- Any concerns or points of confusion? -->

## Status

- [x] I have read the guidelines in
      [CONTRIBUTING.md](https://github.com/icaros-usc/pyribs/blob/master/CONTRIBUTING.md)
- [x] I have formatted my code using `yapf`
- [x] I have tested my code by running `pytest`
- [x] I have linted my code with `pylint`
- [N/A] I have added a one-line description of my change to the changelog in
      `HISTORY.md`
- [x] This PR is ready to go
