### PR TITLE
Add GitHub link roles in documentation

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,24 +6,24 @@
 
 #### API
 
-- Drop Python 3.7 support and upgrade dependencies (#350)
-- Add visualization of QDax repertoires (#353)
-- Improve cvt_archive_heatmap flexibility (#354)
-- Speed up 2D cvt_archive_heatmap by order of magnitude (#355)
-- Clip Voronoi regions in cvt_archive_heatmap (#356)
+- Drop Python 3.7 support and upgrade dependencies ({pr}`350`)
+- Add visualization of QDax repertoires ({pr}`353`)
+- Improve cvt_archive_heatmap flexibility ({pr}`354`)
+- Speed up 2D cvt_archive_heatmap by order of magnitude ({pr}`355`)
+- Clip Voronoi regions in cvt_archive_heatmap ({pr}`356`)
 - **Backwards-incompatible:** Allow using kwargs for colorbar in
-  parallel_axes_plot (#358)
+  parallel_axes_plot ({pr}`358`)
   - Removes cbar_orientaton and cbar_pad args for parallel_axes_plot
 
 #### Documentation
 
-- Use dask instead of multiprocessing for lunar lander tutorial (#346)
-- pip install swig before gymnasium[box2d] in lunar lander tutorial (#346)
+- Use dask instead of multiprocessing for lunar lander tutorial ({pr}`346`)
+- pip install swig before gymnasium[box2d] in lunar lander tutorial ({pr}`346`)
 
 #### Improvements
 
-- Improve developer workflow with pre-commit (#351)
-- Refactor visualize module into multiple files (#357)
+- Improve developer workflow with pre-commit ({pr}`351`)
+- Refactor visualize module into multiple files ({pr}`357`)
 
 ## 0.5.2
 
@@ -36,20 +36,20 @@ schedulers.
 
 #### API
 
-- Support Python 3.11 (#342)
-- Check that emitters passed in are lists/iterables in scheduler (#341)
-- Fix Matplotlib `get_cmap` deprecation (#340)
+- Support Python 3.11 ({pr}`342`)
+- Check that emitters passed in are lists/iterables in scheduler ({pr}`341`)
+- Fix Matplotlib `get_cmap` deprecation ({pr}`340`)
 - **Backwards-incompatible:** Default `plot_centroids` to False when plotting
-  (#339)
-- Raise error messages when `ask` is called without `ask_dqd` (#338)
+  ({pr}`339`)
+- Raise error messages when `ask` is called without `ask_dqd` ({pr}`338`)
 
 #### Documentation
 
-- Add BibTex citation for GECCO 2023 (#337)
+- Add BibTex citation for GECCO 2023 ({pr}`337`)
 
 #### Improvements
 
-- Update distribution dependencies (#344)
+- Update distribution dependencies ({pr}`344`)
 
 ## 0.5.1
 
@@ -65,86 +65,90 @@ https://docs.pyribs.org/en/stable/whats-new.html
 
 #### API
 
-- Schedulers warn if no solutions are inserted into archive (#320)
-- Implement `BanditScheduler` (#299)
-- **Backwards-incompatible:** Implement Scalable CMA-ES Optimizers (#274, #288)
-- Make ribs.emitters.opt public (#281)
-- Add normalized QD score to ArchiveStats (#276)
-- **Backwards-incompatible:** Make ArchiveStats a dataclass (#275)
+- Schedulers warn if no solutions are inserted into archive ({pr}`320`)
+- Implement `BanditScheduler` ({pr}`299`)
+- **Backwards-incompatible:** Implement Scalable CMA-ES Optimizers ({pr}`274`,
+  {pr}`288`)
+- Make ribs.emitters.opt public ({pr}`281`)
+- Add normalized QD score to ArchiveStats ({pr}`276`)
+- **Backwards-incompatible:** Make ArchiveStats a dataclass ({pr}`275`)
 - **Backwards-incompatible:** Add shape checks to `tell()` and `tell_dqd()`
-  methods (#269)
-- Add method for computing CQD score in archives (#252)
+  methods ({pr}`269`)
+- Add method for computing CQD score in archives ({pr}`252`)
 - **Backwards-incompatible:** Deprecate positional arguments in constructors
-  (#261)
+  ({pr}`261`)
 - **Backwards-incompatible:** Allow custom initialization in Gaussian and
-  IsoLine emitters (#259, #265)
-- Implement CMA-MAE archive thresholds (#256, #260, #314)
-  - Revive the old implementation of `add_single` removed in (#221)
+  IsoLine emitters ({pr}`259`, {pr}`265`)
+- Implement CMA-MAE archive thresholds ({pr}`256`, {pr}`260`, {pr}`314`)
+  - Revive the old implementation of `add_single` removed in ({pr}`221`)
   - Add separate tests for `add_single` and `add` with single solution
-- Fix all examples and tutorials (#253)
+- Fix all examples and tutorials ({pr}`253`)
 - Add restart timer to `EvolutionStrategyEmitter` and
-  `GradientArborescenceEmitter`(#255)
-- Rename fields and update documentation (#249, #250)
+  `GradientArborescenceEmitter`({pr}`255`)
+- Rename fields and update documentation ({pr}`249`, {pr}`250`)
   - **Backwards-incompatible:** rename `Optimizer` to `Scheduler`
   - **Backwards-incompatible:** rename `objective_value` to `objective`
   - **Backwards-incompatible:** rename `behavior_value`/`bcs` to `measures`
   - **Backwards-incompatible:** `behavior_dim` in archives is now `measure_dim`
   - Rename `n_solutions` to `batch_size` in `Scheduler`.
-- Add `GradientArborescenceEmitter`, which is used to implement CMA-MEGA (#240,
-  #263, #264, #282, #321)
+- Add `GradientArborescenceEmitter`, which is used to implement CMA-MEGA
+  ({pr}`240`, {pr}`263`, {pr}`264`, {pr}`282`, {pr}`321`)
 - Update emitter `tell()` docstrings to no longer say "Inserts entries into
-  archive" (#247)
-- Expose `emitter.restarts` as a property (#248)
-- Specify that `x0` is 1D for all emitters (#244)
-- Add `best_elite` property for archives (#237)
+  archive" ({pr}`247`)
+- Expose `emitter.restarts` as a property ({pr}`248`)
+- Specify that `x0` is 1D for all emitters ({pr}`244`)
+- Add `best_elite` property for archives ({pr}`237`)
 - Rename methods in ArchiveDataFrame and rename as_pandas behavior columns
-  (#236)
-- Re-run CVTArchive benchmarks and update CVTArchive (#235, #329)
+  ({pr}`236`)
+- Re-run CVTArchive benchmarks and update CVTArchive ({pr}`235`, {pr}`329`)
   - **Backwards-incompatible:** `use_kd_tree` now defaults to True since the k-D
     tree is always faster than brute force in benchmarks.
-- Allow adding solutions one at a time in optimizer (#233)
-- Minimize numba usage (#232)
-- **Backwards-incompatible:** Implement batch addition in archives (#221, #242)
+- Allow adding solutions one at a time in optimizer ({pr}`233`)
+- Minimize numba usage ({pr}`232`)
+- **Backwards-incompatible:** Implement batch addition in archives ({pr}`221`,
+  {pr}`242`)
   - `add` now adds a batch of solutions to the archive
   - `add_single` adds a single solution
-- `emitter.tell` now takes in `status_batch` and `value_batch` (#227)
-- Make epsilon configurable in archives (#226)
-- **Backwards-incompatible:** Remove ribs.factory (#225, #228)
+- `emitter.tell` now takes in `status_batch` and `value_batch` ({pr}`227`)
+- Make epsilon configurable in archives ({pr}`226`)
+- **Backwards-incompatible:** Remove ribs.factory ({pr}`225`, {pr}`228`)
 - **Backwards-incompatible:** Replaced `ImprovementEmitter`,
   `RandomDirectionEmitter`, and `OptimizingEmitter` with
-  `EvolutionStrategyEmitter` (#220, #223, #278)
-- Raise ValueError for incorrect array shapes in archive methods (#219)
+  `EvolutionStrategyEmitter` ({pr}`220`, {pr}`223`, {pr}`278`)
+- Raise ValueError for incorrect array shapes in archive methods ({pr}`219`)
 - Introduced the Ranker object, which is responsible for ranking the solutions
-  based on different objectives (#209, #222, #245)
+  based on different objectives ({pr}`209`, {pr}`222`, {pr}`245`)
 - Add index_of_single method for getting index of measures for one solution
-  (#214)
+  ({pr}`214`)
 - **Backwards-incompatible:** Replace elite_with_behavior with retrieve and
-  retrieve_single in archives (#213, #215, #295)
+  retrieve_single in archives ({pr}`213`, {pr}`215`, {pr}`295`)
 - **Backwards-incompatible:** Replace get_index with batched index_of method in
-  archives (#208)
+  archives ({pr}`208`)
   - Also added `grid_to_int_index` and `int_to_grid_index` methods for
     `GridArchive` and `SlidingBoundariesArchive`
 - **Backwards-incompatible:** Made it such that each archive is initialized
   fully in its constructor instead of needing a separate
-  .initialize(solution_dim) call (#200)
+  .initialize(solution_dim) call ({pr}`200`)
 - **Backwards-incompatible:** Add `sigma`, `sigma0` options to
-  `gaussian_emitter` and `iso_line_emitter` (#199)
+  `gaussian_emitter` and `iso_line_emitter` ({pr}`199`)
   - `gaussian_emitter` constructor requires `sigma`; `sigma0` is optional.
   - `iso_line_emitter` constructor takes in optional parameter `sigma0`.
 - **Backwards-incompatible:** Add `cbar`, `aspect` options for
-  `cvt_archive_heatmap` (#197)
+  `cvt_archive_heatmap` ({pr}`197`)
 - **Backwards-incompatible:** Add `aspect` option to `grid_archive_heatmap` +
-  support for 1D heatmaps (#196)
+  support for 1D heatmaps ({pr}`196`)
   - `square` option no longer works
-- **Backwards-incompatible:** Add `cbar` option to `grid_archive_heatmap` (#193)
+- **Backwards-incompatible:** Add `cbar` option to `grid_archive_heatmap`
+  ({pr}`193`)
 - **Backwards-incompatible:** Replace `get_random_elite()` with batched
-  `sample_elites()` method (#192)
-- **Backwards-incompatible:** Add EliteBatch and rename fields in Elite (#191)
+  `sample_elites()` method ({pr}`192`)
+- **Backwards-incompatible:** Add EliteBatch and rename fields in Elite
+  ({pr}`191`)
 - **Backwards-incompatible:** Rename bins to cells for consistency with
-  literature (#189)
+  literature ({pr}`189`)
   - Archive constructors now take in `cells` argument instead of `bins`
   - Archive now have a `cells` property rather than a `bins` property
-- **Backwards-incompatible:** Only use integer indices in archives (#185)
+- **Backwards-incompatible:** Only use integer indices in archives ({pr}`185`)
   - `ArchiveBase`
     - Replaced `storage_dims` (tuple of int) with `storage_dim` (int)
     - `_occupied_indices` is now a fixed-size array with `_num_occupied`
@@ -154,35 +158,35 @@ https://docs.pyribs.org/en/stable/whats-new.html
 
 #### Bugs
 
-- Fix boundary lines in sliding boundaries archive heatmap (#271)
-- Fix negative eigenvalue in CMA-ES covariance matrix (#285)
+- Fix boundary lines in sliding boundaries archive heatmap ({pr}`271`)
+- Fix negative eigenvalue in CMA-ES covariance matrix ({pr}`285`)
 
 #### Documentation
 
-- Speed up lunar lander tutorial (#319)
-- Add DQDTutorial (#267)
-- Remove examples extra in favor of individual example deps (#306)
-- Facilitate linking to latest version of documentation (#300)
-- Update lunar lander tutorial with v0.5.0 features (#292)
-- Improve tutorial and example overviews (#291)
-- Move tutorials out of examples folder (#290)
-- Update lunar lander to use Gymnasium (#289)
-- Add CMA-MAE tutorial (#273, #284)
-- Update README (#279)
-- Add sphinx-codeautolink to docs (#206, #280)
-- Fix documentation rendering issues on ReadTheDocs (#205)
-- Fix typos and formatting in docstrings of `ribs/visualize.py` (#203)
-- Add in-comment type hint rich linking (#204)
-- Upgrade Sphinx dependencies (#202)
+- Speed up lunar lander tutorial ({pr}`319`)
+- Add DQDTutorial ({pr}`267`)
+- Remove examples extra in favor of individual example deps ({pr}`306`)
+- Facilitate linking to latest version of documentation ({pr}`300`)
+- Update lunar lander tutorial with v0.5.0 features ({pr}`292`)
+- Improve tutorial and example overviews ({pr}`291`)
+- Move tutorials out of examples folder ({pr}`290`)
+- Update lunar lander to use Gymnasium ({pr}`289`)
+- Add CMA-MAE tutorial ({pr}`273`, {pr}`284`)
+- Update README ({pr}`279`)
+- Add sphinx-codeautolink to docs ({pr}`206`, {pr}`280`)
+- Fix documentation rendering issues on ReadTheDocs ({pr}`205`)
+- Fix typos and formatting in docstrings of `ribs/visualize.py` ({pr}`203`)
+- Add in-comment type hint rich linking ({pr}`204`)
+- Upgrade Sphinx dependencies ({pr}`202`)
 
 #### Improvements
 
-- Move threadpoolctl from optimizer to CMA-ES (#241)
-- Remove unnecessary emitter benchmarks (#231)
-- Build docs during CI/CD workflow (#211)
-- Drop Python 3.6 and add Python 3.10 support (#181)
-- Add procedure for updating changelog (#182)
-- Add 'visualize' extra (#183, #184, #302)
+- Move threadpoolctl from optimizer to CMA-ES ({pr}`241`)
+- Remove unnecessary emitter benchmarks ({pr}`231`)
+- Build docs during CI/CD workflow ({pr}`211`)
+- Drop Python 3.6 and add Python 3.10 support ({pr}`181`)
+- Add procedure for updating changelog ({pr}`182`)
+- Add 'visualize' extra ({pr}`183`, {pr}`184`, {pr}`302`)
 
 ## 0.4.0 (2021-07-19)
 
@@ -193,47 +197,47 @@ To learn about this release, see our blog post: https://pyribs.org/blog/0-4-0
 #### API
 
 - Add ribs.visualize.parallel_axes_plot for analyzing archives with
-  high-dimensional BCs (#92)
+  high-dimensional BCs ({pr}`92`)
 - **Backwards-incompatible:** Reduce attributes and parameters in EmitterBase to
-  make it easier to extend (#101)
+  make it easier to extend ({pr}`101`)
 - In Optimizer, support emitters that return any number of solutions in ask()
-  (#101)
-- **Backwards-incompatible:** Store metadata in archives as described in #87
-  (#103, #114, #115, #119)
+  ({pr}`101`)
+- **Backwards-incompatible:** Store metadata in archives as described in
+  {pr}`87` ({pr}`103`, {pr}`114`, {pr}`115`, {pr}`119`)
 - **Backwards-incompatible:** Rename "index" to "index_0" in
-  CVTArchive.as_pandas for API consistency (#113)
+  CVTArchive.as_pandas for API consistency ({pr}`113`)
 - **Backwards-incompatible:** Make index_of() public in archives to emphasize
-  each index's meaning (#128)
+  each index's meaning ({pr}`128`)
 - **Backwards-incompatible:** Add index to get_random_elite() and
-  elite_with_behavior() in archives (#129)
-- Add clear() method to archive (#140, #146)
-- Represent archive elites with an Elite namedtuple (#142)
-- Add len and iter methods to archives (#151, #152)
-- Add statistics to archives (#100, #157)
-- Improve manipulation of elites by modifying as_pandas (#123, #149, #153, #158,
-  #168)
-- Add checks for optimizer array and list shapes (#166)
+  elite_with_behavior() in archives ({pr}`129`)
+- Add clear() method to archive ({pr}`140`, {pr}`146`)
+- Represent archive elites with an Elite namedtuple ({pr}`142`)
+- Add len and iter methods to archives ({pr}`151`, {pr}`152`)
+- Add statistics to archives ({pr}`100`, {pr}`157`)
+- Improve manipulation of elites by modifying as_pandas ({pr}`123`, {pr}`149`,
+  {pr}`153`, {pr}`158`, {pr}`168`)
+- Add checks for optimizer array and list shapes ({pr}`166`)
 
 #### Documentation
 
-- Add bibtex citations for tutorials (#122)
-- Remove network training from Fooling MNIST tutorial (#161)
-- Fix video display for lunar lander in Colab (#163)
-- Fix Colab links in stable docs (#164)
+- Add bibtex citations for tutorials ({pr}`122`)
+- Remove network training from Fooling MNIST tutorial ({pr}`161`)
+- Fix video display for lunar lander in Colab ({pr}`163`)
+- Fix Colab links in stable docs ({pr}`164`)
 
 #### Improvements
 
-- Add support for Python 3.9 (#84)
-- Test with pinned versions (#110)
-- Increase minimum required versions for scipy and numba (#110)
-- Refactor as_pandas tests (#114)
-- Expand CI/CD to test examples and tutorials (#117)
-- Tidy up existing tests (#120, #127)
-- Fix vocab in various areas (#138)
-- Fix dependency issues in tests (#139)
-- Remove tox from CI (#143)
-- Replace "entry" with "elite" in tests (#144)
-- Use new archive API in ribs.visualize implementation (#155)
+- Add support for Python 3.9 ({pr}`84`)
+- Test with pinned versions ({pr}`110`)
+- Increase minimum required versions for scipy and numba ({pr}`110`)
+- Refactor as_pandas tests ({pr}`114`)
+- Expand CI/CD to test examples and tutorials ({pr}`117`)
+- Tidy up existing tests ({pr}`120`, {pr}`127`)
+- Fix vocab in various areas ({pr}`138`)
+- Fix dependency issues in tests ({pr}`139`)
+- Remove tox from CI ({pr}`143`)
+- Replace "entry" with "elite" in tests ({pr}`144`)
+- Use new archive API in ribs.visualize implementation ({pr}`155`)
 
 ## 0.3.1 (2021-03-05)
 
@@ -244,9 +248,10 @@ rigorous use.
 ### Changelog
 
 - Move SlidingBoundariesArchive out of experimental by adding tests and fixing
-  bugs (#93)
-- Added nicer figures to the Sphere example with `grid_archive_heatmap` (#86)
-- Added testing for Windows and MacOS (#83)
+  bugs ({pr}`93`)
+- Added nicer figures to the Sphere example with `grid_archive_heatmap`
+  ({pr}`86`)
+- Added testing for Windows and MacOS ({pr}`83`)
 - Fixed package metadata e.g. description
 
 ## 0.3.0 (2021-02-05)
@@ -256,20 +261,21 @@ library and added new tutorials and examples to our documentation.
 
 ### Changelog
 
-- Added a Lunar Lander example that extends the lunar lander tutorial (#70)
-- Added New Tutorial: Illuminating the Latent Space of an MNIST GAN (#78)
+- Added a Lunar Lander example that extends the lunar lander tutorial ({pr}`70`)
+- Added New Tutorial: Illuminating the Latent Space of an MNIST GAN ({pr}`78`)
 - GridArchive: Added a boundaries attribute with the upper and lower bounds of
-  each dimension's bins (#76)
-- Fixed a bug where CMA-ME emitters do not work with float32 archives (#74)
+  each dimension's bins ({pr}`76`)
+- Fixed a bug where CMA-ME emitters do not work with float32 archives ({pr}`74`)
 - Fixed a bug where Optimizer is able to take in non-unique emitter instances
-  (#75)
-- Fixed a bug where GridArchive failed for float32 due to a small epsilon (#81)
-- Fix issues with bounds in the SlidingBoundaryArchive (#77)
-- Added clearer error messages for archives (#82)
-- Modified the Python requirements to allow any version above 3.6.0 (#68)
+  ({pr}`75`)
+- Fixed a bug where GridArchive failed for float32 due to a small epsilon
+  ({pr}`81`)
+- Fix issues with bounds in the SlidingBoundaryArchive ({pr}`77`)
+- Added clearer error messages for archives ({pr}`82`)
+- Modified the Python requirements to allow any version above 3.6.0 ({pr}`68`)
 - The wheel is now fixed so that it only supports py3 rather than py2 and py3
-  (#68)
-- Miscellaneous documentation fixes (#71)
+  ({pr}`68`)
+- Miscellaneous documentation fixes ({pr}`71`)
 
 ## 0.2.0 (2021-01-29)
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -24,6 +24,7 @@
 
 - Improve developer workflow with pre-commit ({pr}`351`)
 - Refactor visualize module into multiple files ({pr}`357`)
+- Add GitHub link roles in documentation ({pr}`361`)
 
 ## 0.5.2
 

--- a/docs/_ext/github_links.py
+++ b/docs/_ext/github_links.py
@@ -1,0 +1,92 @@
+"""Extension for adding links to GitHub issues and PRs.
+
+Two new Sphinx roles are provided -- :issue: and :pr:. For instance, you can use
+:issue:`123` and :pr:`123` to refer to issue 123 and PR 123, respectively.
+
+The link to the GitHub repo must be configured with the github_repo_url config
+in conf.py.
+
+References:
+- https://doughellmann.com/posts/defining-custom-roles-in-sphinx/
+- https://www.sphinx-doc.org/en/master/development/tutorials/helloworld.html
+"""
+from docutils import nodes, utils
+from docutils.parsers.rst.roles import set_classes
+
+
+def make_link_node(rawtext, app, link_type, slug, options):
+    """Creates a link to a GitHub resource.
+
+    Args:
+        rawtext: Text being replaced with link node.
+        app: Sphinx application context
+        link_type: Link type ("issue", "pull")
+        slug: ID of the thing to link to
+        options: Options dictionary passed to role func.
+    """
+    try:
+        base = app.config.github_repo_url
+        if not base:
+            raise AttributeError
+    except AttributeError as e:
+        raise ValueError(
+            "github_repo_url configuration value is not set") from e
+
+    slash = '/' if base[-1] != '/' else ''
+    ref = f"{base}{slash}{link_type}/{slug}/"
+    set_classes(options)
+    node = nodes.reference(rawtext,
+                           f"#{utils.unescape(slug)}",
+                           refuri=ref,
+                           **options)
+    return node
+
+
+def github_link_role(
+        name,
+        rawtext,
+        text,
+        lineno,
+        inliner,
+        options=None,
+        content=(),  # pylint: disable = unused-argument
+):
+    """Link to a GitHub issue or pull request.
+
+    Returns 2-part tuple containing list of nodes to insert into the document
+    and a list of system messages. Both are allowed to be empty.
+
+    Args:
+        name: The role name used in the document.
+        rawtext: The entire markup snippet, with role.
+        text: The text marked with the role.
+        lineno: The line number where rawtext appears in the input.
+        inliner: The inliner instance that called us.
+        options: Directive options for customization.
+        content: The directive content for customization.
+    """
+    options = options or {}
+
+    try:
+        issue_num = int(text)
+        if issue_num <= 0:
+            raise ValueError
+    except ValueError:
+        msg = inliner.reporter.error(
+            "GitHub issue number must be a number greater than or equal to 1; "
+            f"'{text}' is invalid.",
+            line=lineno)
+        prb = inliner.problematic(rawtext, rawtext, msg)
+        return [prb], [msg]
+
+    app = inliner.document.settings.env.app
+    link_type = {"issue": "issue", "pr": "pull"}[name]
+    node = make_link_node(rawtext, app, link_type, str(issue_num), options)
+    return [node], []
+
+
+def setup(app):
+    """Install the plugin."""
+    app.add_role("issue", github_link_role)
+    app.add_role("pr", github_link_role)
+    app.add_config_value("github_repo_url", None, "env")

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,7 +26,8 @@ import sphinx_material
 
 import ribs
 
-sys.path.insert(0, os.path.abspath(".."))
+sys.path.insert(0, os.path.abspath(".."))  # Detect ribs.
+sys.path.append(os.path.abspath("./_ext"))  # Detect extensions.
 
 DEV_MODE = os.environ.get("DOCS_MODE", "regular") == "dev"
 READTHEDOCS_VERSION = os.environ.get("READTHEDOCS_VERSION", "stable")
@@ -54,6 +55,7 @@ extensions = [
     "sphinx_toolbox.more_autodoc.autonamedtuple",
     "sphinx_autodoc_typehints",
     "sphinx_codeautolink",
+    "github_links",
 ]
 
 # Napoleon
@@ -119,6 +121,8 @@ exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 # If true, `todo` and `todoList` produce output, else they produce nothing.
 todo_include_todos = False
 
+github_repo_url = "https://github.com/icaros-usc/pyribs/"
+
 # -- Options for HTML output -------------------------------------------
 
 html_show_sourcelink = True
@@ -137,7 +141,7 @@ html_theme_options = {
     "nav_title": "pyribs",
     "base_url": (f"https://docs.pyribs.org/{READTHEDOCS_LANGUAGE}/"
                  f"{READTHEDOCS_VERSION}/"),
-    "repo_url": "https://github.com/icaros-usc/pyribs/",
+    "repo_url": github_repo_url,
     "repo_name": "pyribs",
     "google_analytics_account": None,
     "html_minify": not DEV_MODE,

--- a/ribs/archives/_archive_base.py
+++ b/ribs/archives/_archive_base.py
@@ -284,8 +284,8 @@ class ArchiveBase(ABC):  # pylint: disable = too-many-instance-attributes
             replaced with an elite with a lower objective value. This can happen
             because in non-elitist archives, new solutions only need to exceed
             the *threshold* of the cell they are being inserted into, not the
-            *objective* of the elite currently in the cell. See `#314
-            <https://github.com/icaros-usc/pyribs/pull/314>`_ for more info.
+            *objective* of the elite currently in the cell. See :pr:`314` for
+            more info.
         """
         return self._best_elite
 

--- a/ribs/archives/_archive_stats.py
+++ b/ribs/archives/_archive_stats.py
@@ -39,8 +39,8 @@ class ArchiveStats:
     #:     replaced with an elite with a lower objective value. This can happen
     #:     because in non-elitist archives, new solutions only need to exceed
     #:     the *threshold* of the cell they are being inserted into, not the
-    #:     *objective* of the elite currently in the cell. See `#314
-    #:     <https://github.com/icaros-usc/pyribs/pull/314>`_ for more info.
+    #:     *objective* of the elite currently in the cell. See :pr:`314` for
+    #:     more info.
     obj_max: np.floating
 
     #: Mean objective value of the elites in the archive. None if there are no

--- a/ribs/archives/_cvt_archive.py
+++ b/ribs/archives/_cvt_archive.py
@@ -54,7 +54,7 @@ class CVTArchive(ArchiveBase):
         the ``learning_rate`` and ``threshold_min`` parameters.
 
     .. note:: For more information on our choice of k-D tree implementation, see
-        `#38 <https://github.com/icaros-usc/pyribs/issues/38>`_.
+        :pr:`38`.
 
     Args:
         solution_dim (int): Dimension of the solution space.

--- a/ribs/visualize/_cvt_archive_heatmap.py
+++ b/ribs/visualize/_cvt_archive_heatmap.py
@@ -106,8 +106,7 @@ def cvt_archive_heatmap(archive,
             bounds. Passing `clip=True` will clip the heatmap such that these
             "outer edge" polygons are within the archive bounds. An arbitrary
             polygon can also be passed in to clip the heatmap to a custom shape.
-            See `#356 <https://github.com/icaros-usc/pyribs/pull/356>`_ for more
-            info.
+            See :pr:`356` for more info.
         plot_centroids (bool): Whether to plot the cluster centroids.
         plot_samples (bool): Whether to plot the samples used when generating
             the clusters.


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the PR's purpose here. -->

Adds two Sphinx roles to make it easier to link to GitHub PRs and issues in the documentation. Examples are:

```
:pr:`123` -> Links to PR 123
:issue:`123` -> Links to issue 123
```

References:
- https://doughellmann.com/posts/defining-custom-roles-in-sphinx/
- https://www.sphinx-doc.org/en/master/development/tutorials/helloworld.html

## TODO

<!-- Notable points that this PR has either accomplished or will accomplish. -->

- [x] Create extension
- [x] Replace links in history
- [x] Replace links in rest of code

## Questions

<!-- Any concerns or points of confusion? -->

## Status

- [x] I have read the guidelines in
      [CONTRIBUTING.md](https://github.com/icaros-usc/pyribs/blob/master/CONTRIBUTING.md)
- [x] I have formatted my code using `yapf`
- [x] I have tested my code by running `pytest`
- [x] I have linted my code with `pylint`
- [x] I have added a one-line description of my change to the changelog in
      `HISTORY.md`
- [x] This PR is ready to go
