### PR TITLE
Simplify DQD tutorial imports

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -21,6 +21,7 @@
 - Use dask instead of multiprocessing for lunar lander tutorial ({pr}`346`)
 - pip install swig before gymnasium[box2d] in lunar lander tutorial ({pr}`346`)
 - Fix lunar lander dependency issues ({pr}`366`, {pr}`377`)
+- Simplify DQD tutorial imports ({pr}`369`)
 
 #### Improvements
 

--- a/tutorials/tom_cruise_dqd.ipynb
+++ b/tutorials/tom_cruise_dqd.ipynb
@@ -96,24 +96,18 @@
    },
    "outputs": [],
    "source": [
-    "# PyTorch\n",
-    "%pip install --upgrade torch==1.9.1+cu111 torchvision==0.10.1+cu111 -f https://download.pytorch.org/whl/torch_stable.html\n",
+    "# PyTorch, CLIP, pyribs, and others. ninja is needed for PyTorch C++ extensions\n",
+    "# for StyleGAN2.\n",
+    "%pip install torch torchvision git+https://github.com/openai/CLIP ribs ninja einops\n",
     "\n",
-    "# CLIP\n",
-    "!git clone https://github.com/openai/CLIP\n",
-    "%pip install -e ./CLIP\n",
-    "\n",
-    "# StyleGAN\n",
+    "# StyleGAN2 - note that StyleGAN2 is not a Python package, so it cannot be\n",
+    "# installed with pip.\n",
     "!git clone https://github.com/NVlabs/stylegan2-ada-pytorch.git\n",
-    "!curl -LO 'https://api.ngc.nvidia.com/v2/models/nvidia/research/stylegan2/versions/1/files/stylegan2-ffhq-256x256.pkl'\n",
-    "\n",
-    "# pyribs and others\n",
-    "%pip install ribs einops ninja timm\n",
-    "\n",
-    "# Add libraries to the system path.\n",
     "import sys\n",
-    "sys.path.append(\"./CLIP\")\n",
-    "sys.path.append(\"./stylegan2-ada-pytorch\")"
+    "sys.path.append(\"./stylegan2-ada-pytorch\")\n",
+    "\n",
+    "# Download StyleGAN2 model.\n",
+    "!curl -LO 'https://api.ngc.nvidia.com/v2/models/nvidia/research/stylegan2/versions/1/files/stylegan2-ffhq-256x256.pkl'"
    ]
   },
   {
@@ -1090,7 +1084,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.13"
+   "version": "3.8.17"
   },
   "vscode": {
    "interpreter": {


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the PR's purpose here. -->

The imports for the DQD tutorial had some redundancies and unnecessary parts; for instance, CLIP could be installed directly with pip instead of cloning and then installing.

## TODO

<!-- Notable points that this PR has either accomplished or will accomplish. -->

## Questions

<!-- Any concerns or points of confusion? -->

## Status

- [x] I have read the guidelines in
      [CONTRIBUTING.md](https://github.com/icaros-usc/pyribs/blob/master/CONTRIBUTING.md)
- [x] I have formatted my code using `yapf`
- [x] I have tested my code by running `pytest`
- [x] I have linted my code with `pylint`
- [x] I have added a one-line description of my change to the changelog in
      `HISTORY.md`
- [x] This PR is ready to go
