### PR TITLE
Split tutorial CI into multiple jobs

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -120,8 +120,19 @@ jobs:
         run: pip install .[visualize]
       - name: Test Examples
         run: bash tests/examples.sh
+  tutorials_list:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - id: set-matrix
+        run: |
+          echo "matrix={\"tutorial\": [\"tutorials/arm_repertoire.ipynb\", \"tutorials/lunar_lander.ipynb\"]}" >> $GITHUB_OUTPUT
   tutorials:
     runs-on: ubuntu-latest
+    needs: tutorials_list
+    strategy:
+      matrix: ${{ fromJSON(needs.tutorials_list.outputs.matrix) }}
     steps:
       # SWIG should not be installed so that we can test that lunar lander is
       # installing SWIG properly. See https://github.com/icaros-usc/pyribs/pull/366
@@ -135,7 +146,7 @@ jobs:
       - name: Install deps
         run: pip install .[visualize] jupyter nbconvert
       - name: Test Tutorials
-        run: bash tests/tutorials.sh
+        run: bash tests/tutorials.sh ${{ matrix.tutorial }}
   docs:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -127,7 +127,11 @@ jobs:
     steps:
       - id: set-matrix
         run: |
-          echo "matrix={\"tutorial\": [\"tutorials/arm_repertoire.ipynb\", \"tutorials/lunar_lander.ipynb\"]}" >> $GITHUB_OUTPUT
+          TUTORIALS=($(ls tutorials/*.ipynb tutorials/*/*.ipynb))
+          JSON_LIST=""
+          for x in "${TUTORIALS[@]}"; do JSON_LIST="$JSON_LIST\"$x\","; done
+          JSON_LIST=${JSON_LIST%","}  # Remove extra comma.
+          echo "matrix={\"tutorial\": [$JSON_LIST]}" >> $GITHUB_OUTPUT
   tutorials:
     runs-on: ubuntu-latest
     needs: tutorials_list

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -41,10 +41,18 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ["3.8", "3.9", "3.10", "3.11"]
         exclude:
-          # To cut down on runtime since Mac seems to take the longest.
+          # Avoid these jobs since they tend to take longer.
+          - os: macos-latest
+            python-version: "3.8"
           - os: macos-latest
             python-version: "3.9"
           - os: macos-latest
+            python-version: "3.10"
+          - os: windows-latest
+            python-version: "3.8"
+          - os: windows-latest
+            python-version: "3.9"
+          - os: windows-latest
             python-version: "3.10"
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -133,6 +133,7 @@ jobs:
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
+      - uses: actions/checkout@v4
       - id: set-matrix
         run: |
           TUTORIALS=($(ls tutorials/*.ipynb tutorials/*/*.ipynb))

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -39,21 +39,7 @@ jobs:
       max-parallel: 12 # All in parallel.
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
-        exclude:
-          # Avoid these jobs since they tend to take longer.
-          - os: macos-latest
-            python-version: "3.8"
-          - os: macos-latest
-            python-version: "3.9"
-          - os: macos-latest
-            python-version: "3.10"
-          - os: windows-latest
-            python-version: "3.8"
-          - os: windows-latest
-            python-version: "3.9"
-          - os: windows-latest
-            python-version: "3.10"
+        python-version: ["3.11"]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -36,6 +36,7 @@
 - Add GitHub link roles in documentation ({pr}`361`)
 - Refactor argument validation utilities ({pr}`365`)
 - Use Conda envs in all CI jobs ({pr}`368`)
+- Split tutorial CI into multiple jobs ({pr}`375`)
 
 ## 0.5.2
 

--- a/tutorials/cma_mae.ipynb
+++ b/tutorials/cma_mae.ipynb
@@ -99,7 +99,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%pip install ribs[visualize]"
+    "%pip install ribs[visualize] tqdm"
    ]
   },
   {
@@ -873,7 +873,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.13"
+   "version": "3.8.17"
   }
  },
  "nbformat": 4,

--- a/tutorials/fooling_mnist.ipynb
+++ b/tutorials/fooling_mnist.ipynb
@@ -30,7 +30,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%pip install ribs torch"
+    "%pip install ribs torch tqdm"
    ]
   },
   {
@@ -363,7 +363,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.13"
+   "version": "3.8.17"
   }
  },
  "nbformat": 4,

--- a/tutorials/lsi_mnist.ipynb
+++ b/tutorials/lsi_mnist.ipynb
@@ -34,7 +34,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%pip install ribs torch torchvision numpy matplotlib"
+    "%pip install ribs torch torchvision numpy matplotlib tqdm"
    ]
   },
   {
@@ -696,7 +696,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.13"
+   "version": "3.8.17"
   }
  },
  "nbformat": 4,

--- a/tutorials/tom_cruise_dqd.ipynb
+++ b/tutorials/tom_cruise_dqd.ipynb
@@ -98,7 +98,7 @@
    "source": [
     "# PyTorch, CLIP, pyribs, and others. ninja is needed for PyTorch C++ extensions\n",
     "# for StyleGAN2.\n",
-    "%pip install torch torchvision git+https://github.com/openai/CLIP ribs ninja einops\n",
+    "%pip install torch torchvision git+https://github.com/openai/CLIP ribs ninja einops tqdm\n",
     "\n",
     "# StyleGAN2 - note that StyleGAN2 is not a Python package, so it cannot be\n",
     "# installed with pip.\n",


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the PR's purpose here. -->

Tutorials tend to take a lot of time. Splitting the CI into multiple jobs, one per tutorial, should make this faster. This also makes it easier to catch dependency errors in the tutorials; for instance, this PR revealed two tutorials were missing tqdm installation.

Since this does introduce many more jobs, we also cut back on regular test jobs, only running on 3.11 instead of 3.8-3.11. We do this as several other jobs like pin and benchmarks already run on Python 3.8, so it is less essential to test on 3.8 again. Furthermore, we have never found errors in only the intermediate versions (between lowest supported and highest supported).

## TODO

<!-- Notable points that this PR has either accomplished or will accomplish. -->

## Questions

<!-- Any concerns or points of confusion? -->

## Status

- [x] I have read the guidelines in
      [CONTRIBUTING.md](https://github.com/icaros-usc/pyribs/blob/master/CONTRIBUTING.md)
- [x] I have formatted my code using `yapf`
- [x] I have tested my code by running `pytest`
- [x] I have linted my code with `pylint`
- [x] I have added a one-line description of my change to the changelog in
      `HISTORY.md`
- [x] This PR is ready to go
