### PR TITLE
Import ribs[visualize] in tutorials that need it

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -125,6 +125,9 @@ the repo. To create a tutorial:
    dependencies.
    - Installation cells tend to produce a lot of output. Make sure to clear this
      output in Jupyter lab so that it does not clutter the documentation.
+   - Choose your ribs extra carefully -- in particular, if you use
+     `ribs.visualize` in the tutorial, make sure to use
+     `%pip install ribs[visualize]`.
 1. Before the main loop of the QD algorithm, include a line like
    `total_itrs = 500` (any other integer will work). This line will be replaced
    during testing (see `tests/tutorials.sh`) in order to test that the notebook

--- a/tutorials/lsi_mnist.ipynb
+++ b/tutorials/lsi_mnist.ipynb
@@ -34,7 +34,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%pip install ribs torch torchvision numpy matplotlib tqdm"
+    "%pip install ribs[visualize] torch torchvision numpy matplotlib tqdm"
    ]
   },
   {

--- a/tutorials/tom_cruise_dqd.ipynb
+++ b/tutorials/tom_cruise_dqd.ipynb
@@ -98,7 +98,7 @@
    "source": [
     "# PyTorch, CLIP, pyribs, and others. ninja is needed for PyTorch C++ extensions\n",
     "# for StyleGAN2.\n",
-    "%pip install torch torchvision git+https://github.com/openai/CLIP ribs ninja einops tqdm\n",
+    "%pip install torch torchvision git+https://github.com/openai/CLIP ribs[visualize] ninja einops tqdm\n",
     "\n",
     "# StyleGAN2 - note that StyleGAN2 is not a Python package, so it cannot be\n",
     "# installed with pip.\n",

--- a/tutorials/tom_cruise_dqd.ipynb
+++ b/tutorials/tom_cruise_dqd.ipynb
@@ -96,9 +96,9 @@
    },
    "outputs": [],
    "source": [
-    "# PyTorch, CLIP, pyribs, and others. ninja is needed for PyTorch C++ extensions\n",
+    "# Pyribs, PyTorch, CLIP, and others. ninja is needed for PyTorch C++ extensions\n",
     "# for StyleGAN2.\n",
-    "%pip install torch torchvision git+https://github.com/openai/CLIP ribs[visualize] ninja einops tqdm\n",
+    "%pip install ribs[visualize] torch torchvision git+https://github.com/openai/CLIP ninja einops tqdm\n",
     "\n",
     "# StyleGAN2 - note that StyleGAN2 is not a Python package, so it cannot be\n",
     "# installed with pip.\n",


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the PR's purpose here. -->

Since the visualize extra is installed in the CI for the tutorials, we did not detect bugs where the tutorials needed ribs[visualize] but only installed ribs. This PR adds ribs[visualize] to the tutorials that need it and also makes a note in the "Adding a Tutorial" section of CONTRIBUTING.md.

## TODO

<!-- Notable points that this PR has either accomplished or will accomplish. -->

## Questions

<!-- Any concerns or points of confusion? -->

## Status

- [x] I have read the guidelines in
      [CONTRIBUTING.md](https://github.com/icaros-usc/pyribs/blob/master/CONTRIBUTING.md)
- [x] I have formatted my code using `yapf`
- [x] I have tested my code by running `pytest`
- [x] I have linted my code with `pylint`
- [x] I have added a one-line description of my change to the changelog in
      `HISTORY.md`
- [x] This PR is ready to go
