### PR TITLE
Test pyribs installation in tutorials

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -143,7 +143,10 @@ jobs:
         with:
           python-version: "3.10"
       - name: Install deps
-        run: pip install .[visualize] jupyter nbconvert
+        run: pip install jupyter nbconvert
+      - name: Replace pyribs installation with local installation
+        run: |
+          sed -ri 's/(\%pip install .*)ribs(.*)/\1.\2/g' ${{ matrix.tutorial }}
       - name: Test Tutorials
         run: bash tests/tutorials.sh ${{ matrix.tutorial }}
   docs:

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -8,6 +8,10 @@
 
 - Add GradientOperatorEmitter to support OMG-MEGA and OG-MAP-Elites ({pr}`348`)
 
+#### Improvements
+
+- Test pyribs installation in tutorials ({pr}`384`)
+
 ## 0.6.2
 
 Small patch release due to installation issues in our tutorials.

--- a/tutorials/fooling_mnist.ipynb
+++ b/tutorials/fooling_mnist.ipynb
@@ -30,7 +30,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%pip install ribs torch tqdm"
+    "%pip install ribs torch tqdm matplotlib"
    ]
   },
   {


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the PR's purpose here. -->

Previously, we always installed `ribs[visualize]` before testing tutorials. This led to uncaught bugs where some tutorials needed `ribs[visualize]` to be installed but did not install it -- namely, since we always installed `ribs[visualize]`, the tutorial could get by without installing `ribs[visualize]`. This led to bugs such as those in #379. To remedy this issue, this PR removes the default installation of `ribs[visualize]` in the tutorial CI.

Instead, the notebook now installs the local copy of pyribs on its own -- we do this by replacing, e.g., `pip install ribs[visualize]` with `pip install .[visualize]`. Note that it is not possible to leave this dependency as is (i.e., `pip install ribs[visualize]`) because the tutorial would pull from PyPI instead of the local copy.

## TODO

<!-- Notable points that this PR has either accomplished or will accomplish. -->

- [x] Fix bug in fooling mnist tutorial caused by matplotlib not being installed

## Questions

## Status

- [x] I have read the guidelines in
      [CONTRIBUTING.md](https://github.com/icaros-usc/pyribs/blob/master/CONTRIBUTING.md)
- [x] I have formatted my code using `yapf`
- [x] I have tested my code by running `pytest`
- [x] I have linted my code with `pylint`
- [x] I have added a one-line description of my change to the changelog in
      `HISTORY.md`
- [x] This PR is ready to go
