### PR TITLE
Replace np.product with np.prod due to deprecation

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -12,6 +12,14 @@
 
 - Test pyribs installation in tutorials ({pr}`384`)
 
+## 0.6.3
+
+### Changelog
+
+#### Improvements
+
+- Replace np.product with np.prod due to deprecation ({pr}`385`)
+
 ## 0.6.2
 
 Small patch release due to installation issues in our tutorials.

--- a/ribs/archives/_grid_archive.py
+++ b/ribs/archives/_grid_archive.py
@@ -76,7 +76,7 @@ class GridArchive(ArchiveBase):
         ArchiveBase.__init__(
             self,
             solution_dim=solution_dim,
-            cells=np.product(self._dims),
+            cells=np.prod(self._dims),
             measure_dim=len(self._dims),
             learning_rate=learning_rate,
             threshold_min=threshold_min,

--- a/ribs/archives/_sliding_boundaries_archive.py
+++ b/ribs/archives/_sliding_boundaries_archive.py
@@ -162,7 +162,7 @@ class SlidingBoundariesArchive(ArchiveBase):
         ArchiveBase.__init__(
             self,
             solution_dim=solution_dim,
-            cells=np.product(self._dims),
+            cells=np.prod(self._dims),
             measure_dim=len(self._dims),
             qd_score_offset=qd_score_offset,
             seed=seed,


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the PR's purpose here. -->

`np.product` is deprecated in numpy 1.25.0 -- see https://github.com/numpy/numpy/pull/23314

This PR replaces our calls to `np.product` with `np.prod`.

## TODO

<!-- Notable points that this PR has either accomplished or will accomplish. -->

## Questions

<!-- Any concerns or points of confusion? -->

## Status

- [x] I have read the guidelines in
      [CONTRIBUTING.md](https://github.com/icaros-usc/pyribs/blob/master/CONTRIBUTING.md)
- [x] I have formatted my code using `yapf`
- [x] I have tested my code by running `pytest`
- [x] I have linted my code with `pylint`
- [x] I have added a one-line description of my change to the changelog in
      `HISTORY.md`
- [x] This PR is ready to go
