### PR TITLE
Add cron job for testing installation

### DIFF
--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -3,8 +3,8 @@ name: Install
 
 on:
   schedule:
-    # Every day at 2AM UTC (6PM PST, 7PM PDT)
-    - cron: "0 2 * * *"
+    # Every day at 7PM UTC (11AM PST, 12PM PDT)
+    - cron: "0 19 * * *"
   push:
     branches:
       - schedule-install
@@ -23,14 +23,15 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ["3.11"]
+        command: ["pip install ribs[all]", "conda install pyribs-all"]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
       - uses: conda-incubator/setup-miniconda@v2
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Install core deps
-        run: pip install ribs[all]
-      - name: Test install
+      - name: Install pyribs
+        run: ${{ matrix.command }}
+      - name: Try importing ribs
         run: |
           python -c "import ribs; import ribs.visualize; print(ribs.__version__)"

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -23,7 +23,8 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ["3.11"]
-        command: ["pip install ribs[all]", "conda install pyribs-all"]
+        command:
+          ["pip install ribs[all]", "conda install -c conda-forge pyribs-all"]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -3,9 +3,10 @@ name: Install
 
 on:
   schedule:
-    # Every day at 7PM UTC (11AM PST, 12PM PDT)
+    # Every day at 7PM UTC (11AM PST, 12PM PDT).
     - cron: "0 19 * * *"
   push:
+    # Push to the schedule-install branch to test this cron job.
     branches:
       - schedule-install
 

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -5,6 +5,9 @@ on:
   schedule:
     # Every day at 2AM UTC (6PM PST, 7PM PDT)
     - cron: "0 2 * * *"
+  push:
+    branches:
+      - schedule-install
 
 defaults:
   run:

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -1,0 +1,33 @@
+# Test installation from vendors like PyPI and Conda.
+name: Install
+
+on:
+  schedule:
+    # Every day at 2AM UTC (6PM PST, 7PM PDT)
+    - cron: "0 2 * * *"
+
+defaults:
+  run:
+    # The default shell must be set like this so that bash will source the
+    # profile, which contains settings initialized by Conda:
+    # https://github.com/marketplace/actions/setup-miniconda#important
+    shell: bash -el {0}
+
+jobs:
+  test:
+    strategy:
+      max-parallel: 12 # All in parallel.
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: ["3.11"]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: conda-incubator/setup-miniconda@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install core deps
+        run: pip install ribs[all]
+      - name: Test install
+        run: |
+          python -c "import ribs; import ribs.visualize; print(ribs.__version__)"

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -11,6 +11,7 @@
 #### Improvements
 
 - Test pyribs installation in tutorials ({pr}`384`)
+- Add cron job for testing installation ({pr}`389`)
 
 ## 0.6.3
 


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the PR's purpose here. -->

To increase confidence in our installation process, this PR adds a job that installs pyribs from PyPI on a daily basis. The time chosen is 19:00 UTC, which is 11AM PST or 12PM PDT (daylight savings time dictates which one applies).

This job can also be triggered by pushing to the `schedule-install` branch.

## TODO

<!-- Notable points that this PR has either accomplished or will accomplish. -->

- [x] Test job

## Questions

<!-- Any concerns or points of confusion? -->

## Status

- [x] I have read the guidelines in
      [CONTRIBUTING.md](https://github.com/icaros-usc/pyribs/blob/master/CONTRIBUTING.md)
- [x] I have formatted my code using `yapf`
- [x] I have tested my code by running `pytest`
- [x] I have linted my code with `pylint`
- [x] I have added a one-line description of my change to the changelog in
      `HISTORY.md`
- [x] This PR is ready to go
