### PR TITLE
Use chunk computation in CVT brute force calculation to reduce memory usage

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -56,7 +56,7 @@ confidence=
 # --enable=similarities". If you want to run only the classes checker, but have
 # no Warning level messages displayed, use"--disable=all --enable=classes
 # --disable=W"
-disable=suppressed-message,arguments-differ,wildcard-import,locally-disabled,duplicate-code
+disable=suppressed-message,arguments-differ,wildcard-import,locally-disabled,duplicate-code,no-else-return
 
 
 [REPORTS]

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,6 +4,8 @@
 
 ### Changelog
 
+- Added chunk computation in CVT brute force calculation
+
 #### API
 
 - Add GradientOperatorEmitter to support OMG-MEGA and OG-MAP-Elites ({pr}`348`)

--- a/ribs/archives/_cvt_archive.py
+++ b/ribs/archives/_cvt_archive.py
@@ -118,6 +118,8 @@ class CVTArchive(ArchiveBase):
                  dtype=np.float64,
                  samples=100_000,
                  custom_centroids=None,
+                 chunk_size=10,
+                 chunk_distances=False,
                  k_means_kwargs=None,
                  use_kd_tree=True,
                  ckdtree_kwargs=None):
@@ -157,6 +159,8 @@ class CVTArchive(ArchiveBase):
         self._centroid_kd_tree = None
         self._ckdtree_kwargs = ({} if ckdtree_kwargs is None else
                                 ckdtree_kwargs.copy())
+        self.chunk_size = chunk_size
+        self.chunk_distances = chunk_distances
 
         if custom_centroids is None:
             if not isinstance(samples, int):
@@ -260,12 +264,30 @@ class CVTArchive(ArchiveBase):
             _, indices = self._centroid_kd_tree.query(measures_batch)
             return indices.astype(np.int32)
 
+        expanded_dims = np.expand_dims(measures_batch, axis=1)
+        if self.chunk_distances:  # Compute indices chunks at a time
+            distances = np.sum(np.square(
+                expanded_dims[0:min(len(measures_batch), self.chunk_size)] -
+                self.centroids),
+                               axis=2)
+            indicies = np.argmin(distances, axis=1).astype(np.int32)
+            for i in range(
+                    2,
+                    len(measures_batch) // self.chunk_size +
+                    len(measures_batch) % self.chunk_size + 1):
+                l = (i - 1) * self.chunk_size
+                r = min(len(measures_batch), i * self.chunk_size)
+                current_batch = expanded_dims[l:r] - self.centroids
+                current_res = np.argmin(np.sum(np.square(current_batch),
+                                               axis=2),
+                                        axis=1).astype(np.int32)
+                indicies = np.concatenate((indicies, current_res))
+            return indicies
+
         # Brute force distance calculation -- start by taking the difference
         # between each measure i and all the centroids.
-        distances = np.expand_dims(measures_batch, axis=1) - self.centroids
-
+        distances = expanded_dims - self.centroids
         # Compute the total squared distance -- no need to compute actual
         # distance with a sqrt.
         distances = np.sum(np.square(distances), axis=2)
-
         return np.argmin(distances, axis=1).astype(np.int32)

--- a/ribs/archives/_cvt_archive.py
+++ b/ribs/archives/_cvt_archive.py
@@ -273,7 +273,7 @@ class CVTArchive(ArchiveBase):
                 chunks = np.array_split(
                     expanded_measures,
                     np.ceil(len(expanded_measures) / self._chunk_size))
-                for _, chunk in enumerate(chunks):
+                for chunk in chunks:
                     distances = chunk - self.centroids
                     distances = np.sum(np.square(distances), axis=2)
                     current_res = np.argmin(distances, axis=1).astype(np.int32)

--- a/ribs/archives/_cvt_archive.py
+++ b/ribs/archives/_cvt_archive.py
@@ -270,7 +270,7 @@ class CVTArchive(ArchiveBase):
                 expanded_dims[0:min(len(measures_batch), self.chunk_size)] -
                 self.centroids),
                                axis=2)
-            indicies = np.argmin(distances, axis=1).astype(np.int32)
+            indices = np.argmin(distances, axis=1).astype(np.int32)
             for i in range(
                     2,
                     len(measures_batch) // self.chunk_size +
@@ -281,8 +281,8 @@ class CVTArchive(ArchiveBase):
                 current_res = np.argmin(np.sum(np.square(current_batch),
                                                axis=2),
                                         axis=1).astype(np.int32)
-                indicies = np.concatenate((indicies, current_res))
-            return indicies
+                indices = np.concatenate((indices, current_res))
+            return indices
 
         # Brute force distance calculation -- start by taking the difference
         # between each measure i and all the centroids.

--- a/ribs/archives/_cvt_archive.py
+++ b/ribs/archives/_cvt_archive.py
@@ -280,12 +280,10 @@ class CVTArchive(ArchiveBase):
                     indices.append(current_res)
                 return np.concatenate(tuple(indices))
             else:
-                # Brute force distance calculation --
-                # start by taking the difference
-                # between each measure i and all the centroids.
+                # Brute force distance calculation -- start by taking the
+                # difference between each measure i and all the centroids.
                 distances = expanded_measures - self.centroids
-                # Compute the total squared distance --
-                # no need to compute actual
-                # distance with a sqrt.
+                # Compute the total squared distance -- no need to compute
+                # actual distance with a sqrt.
                 distances = np.sum(np.square(distances), axis=2)
                 return np.argmin(distances, axis=1).astype(np.int32)

--- a/ribs/archives/_cvt_archive.py
+++ b/ribs/archives/_cvt_archive.py
@@ -269,22 +269,14 @@ class CVTArchive(ArchiveBase):
             if self._chunk_size is not None and \
             self._chunk_size < measures_batch.shape[
                     0]:  # Compute indices chunks at a time
-                distances = np.sum(
-                    np.square(expanded_measures[0:min(len(measures_batch), self.
-                                                      _chunk_size)] -
-                              self.centroids),
-                    axis=2)
-                indices = [np.argmin(distances, axis=1).astype(np.int32)]
-                for i in range(
-                        2,
-                        np.ceil(len(measures_batch) /
-                                self._chunk_size).astype(int) + 1):
-                    l = (i - 1) * self._chunk_size
-                    r = min(len(measures_batch), i * self._chunk_size)
-                    current_batch = expanded_measures[l:r] - self.centroids
-                    current_res = np.argmin(np.sum(np.square(current_batch),
-                                                   axis=2),
-                                            axis=1).astype(np.int32)
+                indices = []
+                chunks = np.array_split(
+                    expanded_measures,
+                    np.ceil(len(expanded_measures) / self._chunk_size))
+                for _, chunk in enumerate(chunks):
+                    distances = chunk - self.centroids
+                    distances = np.sum(np.square(distances), axis=2)
+                    current_res = np.argmin(distances, axis=1).astype(np.int32)
                     indices.append(current_res)
                 return np.concatenate(tuple(indices))
             else:

--- a/tests/archives/cvt_archive_test.py
+++ b/tests/archives/cvt_archive_test.py
@@ -140,13 +140,18 @@ def test_add_single_without_overwrite(data, add_mode):
 
 def test_chunked_calculation_short():
     """Testing accuracy of chunked computation"""
+    centroids = [[0.09918738, -0.94488177], [-0.39361034, -0.09300422],
+                 [0.02364325, 0.90092739], [0.65540519, -0.18160173],
+                 [-0.71168077, 0.89729889], [0.50702622, 0.07628663],
+                 [-0.34053657, 0.57685741], [-0.73191661, -0.19377403],
+                 [-0.3763371, -0.1533471], [-0.59308952, -0.47537332]]
+
     archive = CVTArchive(solution_dim=0,
                          cells=10,
                          ranges=[(-1, 1), (-1, 1)],
                          samples=10,
-                         chunk_size=1000,
-                         chunk_distances=False,
-                         seed=1,
+                         chunk_size=2,
+                         custom_centroids=centroids,
                          use_kd_tree=False)
     measure_batch = [[-1, -1], [-.75, -.75], [-.5, -.5], [-.25, -.25], [0, 0],
                      [.25, .25], [.5, .5], [.75, .75], [1, 1]]
@@ -155,21 +160,3 @@ def test_chunked_calculation_short():
 
     for i, c in enumerate(closest_centroids):
         assert c == correct_centroids[i]
-
-
-def test_chunked_calculation_long():  # index_of crashes on input of len 1e8
-    """Testing OOM on chunked computation"""
-    archive = CVTArchive(solution_dim=0,
-                         cells=10,
-                         ranges=[(-1, 1), (-1, 1)],
-                         samples=10,
-                         chunk_size=100000,
-                         chunk_distances=True,
-                         use_kd_tree=False)
-
-    rng = np.random.default_rng()
-    measure_batch = rng.uniform(-1, 1, size=(100000000, 2))
-    measure_batch = [tuple(row) for row in measure_batch]
-    print("Length: ", len(measure_batch))
-    archive.index_of(measure_batch)
-    print("Finished")

--- a/tests/archives/cvt_archive_test.py
+++ b/tests/archives/cvt_archive_test.py
@@ -155,5 +155,4 @@ def test_chunked_calculation_short():
     closest_centroids = archive.index_of(measure_batch)
     correct_centroids = [0, 0, 1, 2, 3, 4, 5, 6, 7, 8]
 
-    for i, c in enumerate(closest_centroids):
-        assert c == correct_centroids[i]
+    assert np.all(closest_centroids == correct_centroids)

--- a/tests/archives/cvt_archive_test.py
+++ b/tests/archives/cvt_archive_test.py
@@ -140,23 +140,20 @@ def test_add_single_without_overwrite(data, add_mode):
 
 def test_chunked_calculation_short():
     """Testing accuracy of chunked computation"""
-    centroids = [[0.09918738, -0.94488177], [-0.39361034, -0.09300422],
-                 [0.02364325, 0.90092739], [0.65540519, -0.18160173],
-                 [-0.71168077, 0.89729889], [0.50702622, 0.07628663],
-                 [-0.34053657, 0.57685741], [-0.73191661, -0.19377403],
-                 [-0.3763371, -0.1533471], [-0.59308952, -0.47537332]]
+    centroids = [[-1, 1], [0, 1], [1, 1], [-1, 0], [0, 0], [1, 0], [-1, -1],
+                 [0, -1], [1, -1]]
 
     archive = CVTArchive(solution_dim=0,
-                         cells=10,
+                         cells=9,
                          ranges=[(-1, 1), (-1, 1)],
                          samples=10,
                          chunk_size=2,
                          custom_centroids=centroids,
                          use_kd_tree=False)
-    measure_batch = [[-1, -1], [-.75, -.75], [-.5, -.5], [-.25, -.25], [0, 0],
-                     [.25, .25], [.5, .5], [.75, .75], [1, 1]]
+    measure_batch = [[-1, 1], [-1, .9], [-.1, 1], [.9, .9], [-.9, 0], [.1, 0],
+                     [1, 0], [-1, -.9], [.1, -.9], [.9, -.9]]
     closest_centroids = archive.index_of(measure_batch)
-    correct_centroids = [9, 9, 9, 8, 1, 5, 5, 5, 2]
+    correct_centroids = [0, 0, 1, 2, 3, 4, 5, 6, 7, 8]
 
     for i, c in enumerate(closest_centroids):
         assert c == correct_centroids[i]


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the PR's purpose here. -->

Added chunking calculation option to CVT Archive

## TODO

<!-- Notable points that this PR has either accomplished or will accomplish. -->

- CVTArchive brute force calculation fails (OOM) for 1e8 inputs or more whereas chunking succeeds

## Questions

<!-- Any concerns or points of confusion? -->

## Status

- [x] I have read the guidelines in
      [CONTRIBUTING.md](https://github.com/icaros-usc/pyribs/blob/master/CONTRIBUTING.md)
- [x] I have formatted my code using `yapf`
- [x] I have tested my code by running `pytest`
- [x] I have linted my code with `pylint`
- [x] I have added a one-line description of my change to the changelog in
      `HISTORY.md`
- [x] This PR is ready to go
