### PR TITLE
Make ArrayStore fields be valid identifiers

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -10,7 +10,7 @@
   ({pr}`397`)
 - **Backwards-incompatible:** Rename `measure_*` columns to `measures_*` in
   `as_pandas` ({pr}`396`)
-- Add ArrayStore data structure ({pr}`395`)
+- Add ArrayStore data structure ({pr}`395`, {pr}`398`)
 - Add GradientOperatorEmitter to support OMG-MEGA and OG-MAP-Elites ({pr}`348`)
 
 #### Improvements

--- a/ribs/archives/_array_store.py
+++ b/ribs/archives/_array_store.py
@@ -82,7 +82,8 @@ class ArrayStore:
             dtype)``. For instance, ``{"objective": ((), np.float32),
             "measures": ((10,), np.float32)}`` will create an "objective" field
             with shape ``(capacity,)`` and a "measures" field with shape
-            ``(capacity, 10)``.
+            ``(capacity, 10)``. Note that field names must be valid Python
+            identifiers.
         capacity (int): Total possible entries in the store.
 
     Attributes:
@@ -101,8 +102,10 @@ class ArrayStore:
         _fields (dict): Holds all the arrays with their data.
 
     Raises:
-        ValueError: One of the fields in ``field_desc`` has an invalid name
-            (currently, "index" is the only invalid name).
+        ValueError: One of the fields in ``field_desc`` has a reserved name
+            (currently, "index" is the only reserved name).
+        ValueError: One of the fields in ``field_desc`` has a name that is not a
+            valid Python identifier.
     """
 
     def __init__(self, field_desc, capacity):
@@ -117,7 +120,10 @@ class ArrayStore:
         self._fields = {}
         for name, (field_shape, dtype) in field_desc.items():
             if name == "index":
-                raise ValueError(f"`{name}` is an invalid field name.")
+                raise ValueError(f"`{name}` is a reserved field name.")
+            if not name.isidentifier():
+                raise ValueError(
+                    f"Field names must be valid identifiers: `{name}`")
 
             if isinstance(field_shape, (int, np.integer)):
                 field_shape = (field_shape,)

--- a/tests/archives/array_store_test.py
+++ b/tests/archives/array_store_test.py
@@ -7,11 +7,22 @@ from ribs.archives import ArrayStore
 # pylint: disable = redefined-outer-name
 
 
-def test_init_invalid_field():
+def test_init_reserved_field():
     with pytest.raises(ValueError):
         ArrayStore(
             {
                 "index": ((), np.float32),
+            },
+            10,
+        )
+
+
+def test_init_invalid_field():
+    with pytest.raises(ValueError):
+        ArrayStore(
+            {
+                # The space makes this an invalid identifier.
+                "foo bar": ((), np.float32),
             },
             10,
         )


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the PR's purpose here. -->

Although we mostly use the field names as dict keys, which can take on any value, it may be useful in the future to be able to use fields as identifiers. For example, if we are using kwargs, it makes sense to be able to pass in a field name as `f(field1=[...])`, which is not possible if `field1` is an invalid identifier like `field foo` (note the space).

## TODO

<!-- Notable points that this PR has either accomplished or will accomplish. -->

- [x] Add check
- [x] Add test

## Questions

<!-- Any concerns or points of confusion? -->

## Status

- [x] I have read the guidelines in
      [CONTRIBUTING.md](https://github.com/icaros-usc/pyribs/blob/master/CONTRIBUTING.md)
- [x] I have formatted my code using `yapf`
- [x] I have tested my code by running `pytest`
- [x] I have linted my code with `pylint`
- [x] I have added a one-line description of my change to the changelog in
      `HISTORY.md`
- [x] This PR is ready to go
