### PR TITLE
Remove checkout from installation CI

### DIFF
--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -28,7 +28,6 @@ jobs:
           ["pip install ribs[all]", "conda install -c conda-forge pyribs-all"]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
       - uses: conda-incubator/setup-miniconda@v2
         with:
           python-version: ${{ matrix.python-version }}


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the PR's purpose here. -->

We do not need to checkout the pyribs repo when testing installation, since we are only accessing PyPI and Conda.

## TODO

<!-- Notable points that this PR has either accomplished or will accomplish. -->

## Questions

<!-- Any concerns or points of confusion? -->

## Status

- [x] I have read the guidelines in
      [CONTRIBUTING.md](https://github.com/icaros-usc/pyribs/blob/master/CONTRIBUTING.md)
- [x] I have formatted my code using `yapf`
- [x] I have tested my code by running `pytest`
- [x] I have linted my code with `pylint`
- [N/A] I have added a one-line description of my change to the changelog in
      `HISTORY.md`
- [x] This PR is ready to go
