### PR TITLE
Make ArrayStore data methods more flexible

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -10,7 +10,7 @@
   ({pr}`397`)
 - **Backwards-incompatible:** Rename `measure_*` columns to `measures_*` in
   `as_pandas` ({pr}`396`)
-- Add ArrayStore data structure ({pr}`395`, {pr}`398`, {pr}`400`)
+- Add ArrayStore data structure ({pr}`395`, {pr}`398`, {pr}`400`, {pr}`402`)
 - Add GradientOperatorEmitter to support OMG-MEGA and OG-MAP-Elites ({pr}`348`)
 
 #### Improvements
@@ -18,7 +18,7 @@
 - Use chunk computation in CVT brute force calculation to reduce memory usage
   ({pr}`394`)
 - Test pyribs installation in tutorials ({pr}`384`)
-- Add cron job for testing installation ({pr}`389`)
+- Add cron job for testing installation ({pr}`389`, {pr}`401`)
 - Fix broken cross-refs in docs ({pr}`393`)
 
 ## 0.6.3

--- a/ribs/archives/_array_store.py
+++ b/ribs/archives/_array_store.py
@@ -1,6 +1,5 @@
 """Provides ArrayStore."""
 import itertools
-from collections import OrderedDict
 from enum import IntEnum
 
 import numpy as np
@@ -174,7 +173,7 @@ class ArrayStore:
             self._props["occupied_list"][:self._props["n_occupied"]])
 
     def retrieve(self, indices, fields=None, return_type="dict"):
-        """Collects the data at the given indices.
+        """Collects data at the given indices.
 
         Args:
             indices (array-like): List of indices at which to collect data.
@@ -191,40 +190,65 @@ class ArrayStore:
               in, have an associated data entry. For instance, if ``indices`` is
               ``[0, 1, 2]`` and only index 2 has data, then ``occupied`` will be
               ``[False, False, True]``.
+
+              Note that if a given index is not marked as occupied, it can have
+              any data value associated with it. For instance, if index 1 was
+              not occupied, then the 6.0 returned in the ``dict`` example below
+              should be ignored.
+
             - **data**: The data at the given indices. This can take the
               following forms, depending on the ``return_type`` argument:
 
-                - ``return_type="dict"``: Dict mapping from the field name to
-                  the field data at the given indices. For instance, if we have
-                  an ``objective`` field and request data at indices ``[4, 1,
-                  0]``, we would get ``data`` that looks like ``{"objective":
-                  [1.5, 6.0, 2.3], "index": [4, 1, 0]}``. Observe that we also
-                  return the indices as an ``index'' entry in the dict. The keys
-                  in this dict can be modified using the ``fields`` arg;
-                  duplicate keys will be ignored since the dict stores unique
-                  keys.
+              - ``return_type="dict"``: Dict mapping from the field name to the
+                field data at the given indices. For instance, if we have an
+                ``objective`` field and request data at indices ``[4, 1, 0]``,
+                we would get ``data`` that looks like ``{"objective": [1.5, 6.0,
+                2.3], "index": [4, 1, 0]}``. Observe that we also return the
+                indices as an ``index`` entry in the dict. The keys in this dict
+                can be modified using the ``fields`` arg; duplicate keys will be
+                ignored since the dict stores unique keys.
 
-                  Note that if a given index is not marked as occupied, it can
-                  have any data value associated with it. For instance, if index
-                  1 was not occupied, then the 6.0 returned above should be
-                  ignored.
+              - ``return_type="tuple"``: Tuple of arrays matching the order
+                given in ``fields``. For instance, if ``fields`` was
+                ``["objective", "measures"]``, we would receive a tuple of
+                ``(objective_arr, measures_arr)``. In this case, the results
+                from ``retrieve`` could be unpacked as::
 
-                - ``return_type="tuple"``: Tuple of arrays matching the order
-                  given in ``fields``. For instance, if ``fields`` was
-                  ``["objective", "measures"]``, we would receive a tuple of
-                  ``(objective_arr, measures_arr)``. In this case, the results
-                  from ``retrieve`` could be unpacked as::
+                    occupied, (objective, measures) = store.retrieve(...)
 
-                      occupied, (objective, measures) = store.retrieve(...)
+                Unlike with the ``dict`` return type, duplicate fields will show
+                up as duplicate entries in the tuple, e.g.,
+                ``fields=["objective", "objective"]`` will result in two
+                objective arrays being returned.
 
-                  Unlike with the ``dict`` return type, duplicate fields will
-                  show up as duplicate entries in the tuple, e.g.,
-                  ``fields=["objective", "objective"]`` will result in two
-                  objective arrays being returned.
+                By default, (i.e., when ``fields=None``), the fields in the
+                tuple will be ordered according to the ``field_desc`` argument
+                in the constructor, along with ``index`` as the last field.
 
-                  By default, (i.e., when ``fields=None``), the fields in the
-                  tuple will be ordered according to the ``field_desc`` argument
-                  in the constructor, along with ``index`` as the last field.
+              - ``return_type="pandas"``: A :class:`pandas.DataFrame` with the
+                following columns (by default):
+
+                - For fields that are scalars, a single column with the field
+                  name. For example, ``objective'' would have a single column
+                  called ``objective``.
+                - For fields that are 1D arrays, multiple columns with the name
+                  suffixed by its index. For instance, if we have a ``measures``
+                  field of length 10, we create 10 columns with names
+                  ``measures_0``, ``measures_1``, ..., ``measures_9``. We do not
+                  currently support fields with >1D data.
+                - 1 column of integers (``np.int32``) for the index, named
+                  ``index``.
+
+                In short, the dataframe might look like this:
+
+                +-----------+------------+------+-------+
+                | objective | measures_0 | ...  | index |
+                +===========+============+======+=======+
+                |           |            | ...  |       |
+                +-----------+------------+------+-------+
+
+                Like the other return types, the columns can be adjusted with
+                the ``fields`` parameter.
 
             All data returned by this method will be a readonly copy, i.e., the
             data will not update as the store changes.
@@ -236,7 +260,7 @@ class ArrayStore:
         indices = np.asarray(indices, dtype=np.int32)
         occupied = readonly(self._props["occupied"][indices])
 
-        if return_type == "dict":
+        if return_type in ("dict", "pandas"):
             data = {}
         elif return_type == "tuple":
             data = []
@@ -259,11 +283,38 @@ class ArrayStore:
                 data[name] = arr
             elif return_type == "tuple":
                 data.append(arr)
+            elif return_type == "pandas":
+                if len(arr.shape) == 1:  # Scalar entries.
+                    data[name] = arr
+                elif len(arr.shape) == 2:  # 1D array entries.
+                    for i in range(arr.shape[1]):
+                        data[f"{name}_{i}"] = arr[:, i]
+                else:
+                    raise ValueError(
+                        f"Field `{name}` has shape {arr.shape[1:]} -- "
+                        "cannot convert fields with shape >1D to Pandas")
 
         if return_type == "tuple":
             data = tuple(data)
+        elif return_type == "pandas":
+            # Data above are already copied, so no need to copy again.
+            data = DataFrame(data, copy=False)
 
         return occupied, data
+
+    def data(self, fields=None, return_type="dict"):
+        """Retrieves data for all entries in the store.
+
+        Equivalent to calling :meth:`retrieve` with :attr:`occupied_list`.
+
+        Args:
+            fields (array-like of str): See :meth:`retrieve`.
+        Returns:
+            dict or tuple: See ``data`` in :meth:`retrieve`. ``occupied`` is not
+                returned since all indices are known to be occupied in this
+                method.
+        """
+        return self.retrieve(self.occupied_list, fields, return_type)[1]
 
     def add(self, indices, new_data, extra_args, transforms):
         """Adds new data to the store at the given indices.
@@ -471,81 +522,3 @@ class ArrayStore:
         store._fields = fields
 
         return store
-
-    def data(self, fields=None, return_type="dict"):
-        """Retrieves data for all entries in the store.
-
-        Equivalent to calling :meth:`retrieve` with :attr:`occupied_list`.
-
-        Args:
-            fields (array-like of str): See :meth:`retrieve`.
-        Returns:
-            dict or tuple: See ``data`` in :meth:`retrieve`. ``occupied`` is not
-                returned since all indices are known to be occupied in this
-                method.
-        """
-        return self.retrieve(self.occupied_list, fields, return_type)[1]
-
-    def as_pandas(self, fields=None):
-        """Creates a DataFrame containing all data entries in the store.
-
-        The returned DataFrame has:
-
-        - For fields that are scalars, a single column with the field name. For
-          example, ``objective'' would have a single column called
-          ``objective``.
-        - For fields that are 1D arrays, multiple columns with the name suffixed
-          by its index. For instance, if we have a ``measures`` field of length
-          10, we create 10 columns with names ``measures_0``, ``measures_1``,
-          ..., ``measures_9``. We do not currently support fields with >1D data.
-        - 1 column of integers (``np.int32``) for the index, named ``index``.
-
-        In short, the dataframe might look like this:
-
-        +-----------+------------+------+-------+
-        | objective | measures_0 | ...  | index |
-        +===========+============+======+=======+
-        |           |            | ...  |       |
-        +-----------+------------+------+-------+
-
-        Args:
-            fields (array-like of str): List of fields to include. By default,
-                all fields will be included. In addition to fields in the store,
-                "index" is also a valid field.
-        Returns:
-            pandas.DataFrame: See above.
-        Raises:
-            ValueError: Invalid field name provided.
-            ValueError: There is a field with >1D data.
-        """
-        data = OrderedDict()
-        indices = self._props["occupied_list"][:self._props["n_occupied"]]
-
-        fields = (itertools.chain(self._fields, ["index"])
-                  if fields is None else fields)
-
-        for name in fields:
-            if name == "index":
-                data[name] = np.copy(indices)
-                continue
-
-            if name not in self._fields:
-                raise ValueError(f"`{name}` is not a field in this ArrayStore.")
-
-            arr = self._fields[name]
-            if len(arr.shape) == 1:  # Scalar entries.
-                data[name] = arr[indices]
-            elif len(arr.shape) == 2:  # 1D array entries.
-                arr = arr[indices]
-                for i in range(arr.shape[1]):
-                    data[f"{name}_{i}"] = arr[:, i]
-            else:
-                raise ValueError(
-                    f"Field `{name}` has shape {arr.shape[1:]} -- "
-                    "cannot convert fields with shape >1D to Pandas")
-
-        return DataFrame(
-            data,
-            copy=False,  # Fancy indexing above copies all fields, and
-            # indices is explicitly copied.
-        )

--- a/ribs/archives/_array_store.py
+++ b/ribs/archives/_array_store.py
@@ -270,6 +270,8 @@ class ArrayStore:
         fields = (itertools.chain(self._fields, ["index"])
                   if fields is None else fields)
         for name in fields:
+            # Collect array data.
+            #
             # Note that fancy indexing with indices already creates a copy, so
             # only `indices` needs to be copied explicitly.
             if name == "index":
@@ -279,6 +281,7 @@ class ArrayStore:
             else:
                 raise ValueError(f"`{name}` is not a field in this ArrayStore.")
 
+            # Accumulate data into the return type.
             if return_type == "dict":
                 data[name] = arr
             elif return_type == "tuple":
@@ -294,6 +297,7 @@ class ArrayStore:
                         f"Field `{name}` has shape {arr.shape[1:]} -- "
                         "cannot convert fields with shape >1D to Pandas")
 
+        # Postprocess return data.
         if return_type == "tuple":
             data = tuple(data)
         elif return_type == "pandas":

--- a/ribs/archives/_array_store.py
+++ b/ribs/archives/_array_store.py
@@ -229,7 +229,7 @@ class ArrayStore:
                 following columns (by default):
 
                 - For fields that are scalars, a single column with the field
-                  name. For example, ``objective'' would have a single column
+                  name. For example, ``objective`` would have a single column
                   called ``objective``.
                 - For fields that are 1D arrays, multiple columns with the name
                   suffixed by its index. For instance, if we have a ``measures``

--- a/tests/archives/array_store_test.py
+++ b/tests/archives/array_store_test.py
@@ -108,11 +108,11 @@ def test_simple_add_retrieve_clear(store):
     occupied, data = store.retrieve([5, 3])
 
     assert np.all(occupied == [True, True])
-    assert data.keys() == set(["index", "objective", "measures", "solution"])
-    assert np.all(data["index"] == [5, 3])
+    assert data.keys() == set(["objective", "measures", "solution", "index"])
     assert np.all(data["objective"] == [2.0, 1.0])
     assert np.all(data["measures"] == [[3.0, 4.0], [1.0, 2.0]])
     assert np.all(data["solution"] == [np.ones(10), np.zeros(10)])
+    assert np.all(data["index"] == [5, 3])
 
     store.clear()
 
@@ -154,10 +154,10 @@ def test_dtypes(store):
 
     # Index is always int32, and other fields were defined as float32 in the
     # `store` fixture.
-    assert data["index"].dtype == np.int32
     assert data["objective"].dtype == np.float32
     assert data["measures"].dtype == np.float32
     assert data["solution"].dtype == np.float32
+    assert data["index"].dtype == np.int32
 
 
 def test_retrieve_duplicate_indices(store):
@@ -175,11 +175,11 @@ def test_retrieve_duplicate_indices(store):
     occupied, data = store.retrieve([3, 3])
 
     assert np.all(occupied == [True, True])
-    assert data.keys() == set(["index", "objective", "measures", "solution"])
-    assert np.all(data["index"] == [3, 3])
+    assert data.keys() == set(["objective", "measures", "solution", "index"])
     assert np.all(data["objective"] == [2.0, 2.0])
     assert np.all(data["measures"] == [[3.0, 4.0], [3.0, 4.0]])
     assert np.all(data["solution"] == [np.ones(10), np.ones(10)])
+    assert np.all(data["index"] == [3, 3])
 
 
 def test_retrieve_invalid_fields(store):
@@ -187,7 +187,12 @@ def test_retrieve_invalid_fields(store):
         store.retrieve([0, 1], fields=["objective", "foo"])
 
 
-def test_retrieve_custom_fields(store):
+def test_retrieve_invalid_return_type(store):
+    with pytest.raises(ValueError):
+        store.retrieve([0, 1], return_type="foo")
+
+
+def test_retrieve_tuple(store):
     store.add(
         [3, 5],
         {
@@ -199,12 +204,42 @@ def test_retrieve_custom_fields(store):
         [],  # Empty transforms.
     )
 
-    occupied, data = store.retrieve([5, 3], fields=["index", "objective"])
+    occupied, (objective, measures, solution,
+               index) = store.retrieve([5, 3], return_type="tuple")
 
     assert np.all(occupied == [True, True])
-    assert data.keys() == set(["index", "objective"])
-    assert np.all(data["index"] == [5, 3])
-    assert np.all(data["objective"] == [2.0, 1.0])
+    assert np.all(objective == [2.0, 1.0])
+    assert np.all(measures == [[3.0, 4.0], [1.0, 2.0]])
+    assert np.all(solution == [np.ones(10), np.zeros(10)])
+    assert np.all(index == [5, 3])
+
+
+@pytest.mark.parametrize("return_type", ["dict", "tuple"])
+def test_retrieve_custom_fields(store, return_type):
+    store.add(
+        [3, 5],
+        {
+            "objective": [1.0, 2.0],
+            "measures": [[1.0, 2.0], [3.0, 4.0]],
+            "solution": [np.zeros(10), np.ones(10)],
+        },
+        {},  # Empty extra_args.
+        [],  # Empty transforms.
+    )
+
+    occupied, data = store.retrieve([5, 3],
+                                    fields=["index", "objective"],
+                                    return_type=return_type)
+
+    if return_type == "dict":
+        assert np.all(occupied == [True, True])
+        assert data.keys() == set(["index", "objective"])
+        assert np.all(data["index"] == [5, 3])
+        assert np.all(data["objective"] == [2.0, 1.0])
+    elif return_type == "tuple":
+        assert np.all(occupied == [True, True])
+        assert np.all(data[0] == [5, 3])
+        assert np.all(data[1] == [2.0, 1.0])
 
 
 def test_add_simple_transform(store):
@@ -235,11 +270,11 @@ def test_add_simple_transform(store):
     occupied, data = store.retrieve([3, 5])
 
     assert np.all(occupied == [True, True])
-    assert data.keys() == set(["index", "objective", "measures", "solution"])
-    assert np.all(data["index"] == [3, 5])
+    assert data.keys() == set(["objective", "measures", "solution", "index"])
     assert np.all(data["objective"] == [10.0, 20.0])
     assert np.all(data["measures"] == [[1.0, 1.0], [2.0, 2.0]])
     assert np.all(data["solution"] == [np.ones(10), 2 * np.ones(10)])
+    assert np.all(data["index"] == [3, 5])
 
 
 def test_add_empty_transform(store):
@@ -355,14 +390,14 @@ def test_from_raw_dict(store):
     occupied, data = new_store.retrieve([5, 3])
 
     assert np.all(occupied == [True, True])
-    assert data.keys() == set(["index", "objective", "measures", "solution"])
-    assert np.all(data["index"] == [5, 3])
+    assert data.keys() == set(["objective", "measures", "solution", "index"])
     assert np.all(data["objective"] == [2.0, 1.0])
     assert np.all(data["measures"] == [[3.0, 4.0], [1.0, 2.0]])
     assert np.all(data["solution"] == [np.ones(10), np.zeros(10)])
+    assert np.all(data["index"] == [5, 3])
 
 
-def test_as_dict(store):
+def test_data(store):
     store.add(
         [3, 5],
         {
@@ -374,17 +409,47 @@ def test_as_dict(store):
         [],  # Empty transforms.
     )
 
-    d = store.as_dict()
+    d = store.data()
 
-    assert d.keys() == set(["index", "objective", "measures", "solution"])
+    assert d.keys() == set(["objective", "measures", "solution", "index"])
     assert all(len(v) == 2 for v in d.values())
 
-    row0 = np.concatenate(([3, 1.0, 1.0, 2.0], np.zeros(10)))
-    row1 = np.concatenate(([5, 2.0, 3.0, 4.0], np.ones(10)))
+    row0 = np.concatenate(([1.0, 1.0, 2.0], np.zeros(10), [3]))
+    row1 = np.concatenate(([2.0, 3.0, 4.0], np.ones(10), [5]))
 
     flat = [
-        np.concatenate(([d["index"][i]], [d["objective"][i]], d["measures"][i],
-                        d["solution"][i])) for i in range(2)
+        np.concatenate(([d["objective"][i]], d["measures"][i], d["solution"][i],
+                        [d["index"][i]])) for i in range(2)
+    ]
+
+    # Either permutation.
+    assert (((flat[0] == row0).all() and (flat[1] == row1).all()) or
+            ((flat[0] == row1).all() and (flat[1] == row0).all()))
+
+
+def test_data_with_tuple_return_type(store):
+    store.add(
+        [3, 5],
+        {
+            "objective": [1.0, 2.0],
+            "measures": [[1.0, 2.0], [3.0, 4.0]],
+            "solution": [np.zeros(10), np.ones(10)],
+        },
+        {},  # Empty extra_args.
+        [],  # Empty transforms.
+    )
+
+    d = store.data(return_type="tuple")
+
+    assert len(d) == 4  # 3 fields and 1 index.
+    assert all(len(v) == 2 for v in d)
+
+    row0 = np.concatenate(([1.0, 1.0, 2.0], np.zeros(10), [3]))
+    row1 = np.concatenate(([2.0, 3.0, 4.0], np.ones(10), [5]))
+
+    flat = [
+        np.concatenate(([d[0][i]], d[1][i], d[2][i], [d[3][i]]))
+        for i in range(2)
     ]
 
     # Either permutation.
@@ -407,7 +472,6 @@ def test_as_pandas(store):
     df = store.as_pandas()
 
     assert (df.columns == [
-        "index",
         "objective",
         "measures_0",
         "measures_1",
@@ -421,12 +485,13 @@ def test_as_pandas(store):
         "solution_7",
         "solution_8",
         "solution_9",
+        "index",
     ]).all()
-    assert (df.dtypes == [np.int32] + [np.float32] * 13).all()
+    assert (df.dtypes == [np.float32] * 13 + [np.int32]).all()
     assert len(df) == 2
 
-    row0 = np.concatenate(([3, 1.0, 1.0, 2.0], np.zeros(10)))
-    row1 = np.concatenate(([5, 2.0, 3.0, 4.0], np.ones(10)))
+    row0 = np.concatenate(([1.0, 1.0, 2.0], np.zeros(10), [3]))
+    row1 = np.concatenate(([2.0, 3.0, 4.0], np.ones(10), [5]))
 
     # Either permutation.
     assert (((df.loc[0] == row0).all() and (df.loc[1] == row1).all()) or
@@ -493,11 +558,11 @@ def test_iteration(store):
 
     for entry in store:
         assert entry.keys() == set(
-            ["index", "objective", "measures", "solution"])
-        assert np.all(entry["index"] == [3])
+            ["objective", "measures", "solution", "index"])
         assert np.all(entry["objective"] == [1.0])
         assert np.all(entry["measures"] == [[1.0, 2.0]])
         assert np.all(entry["solution"] == [np.zeros(10)])
+        assert np.all(entry["index"] == [3])
 
 
 def test_add_during_iteration(store):


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the PR's purpose here. -->

This PR modifies ArrayStore as follows:

- Introduces a tuple return type to the retrieve and as_dict methods
- Renames as_dict to data()
- Removes `as_pandas()` in favor of `data(return_type="pandas")` and `retrieve(return_type="pandas")`

## TODO

<!-- Notable points that this PR has either accomplished or will accomplish. -->

## Questions

<!-- Any concerns or points of confusion? -->

## Status

- [x] I have read the guidelines in
      [CONTRIBUTING.md](https://github.com/icaros-usc/pyribs/blob/master/CONTRIBUTING.md)
- [x] I have formatted my code using `yapf`
- [x] I have tested my code by running `pytest`
- [x] I have linted my code with `pylint`
- [x] I have added a one-line description of my change to the changelog in
      `HISTORY.md`
- [x] This PR is ready to go
