### PR TITLE
Add field_desc property to ArrayStore

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -10,7 +10,8 @@
   ({pr}`397`)
 - **Backwards-incompatible:** Rename `measure_*` columns to `measures_*` in
   `as_pandas` ({pr}`396`)
-- Add ArrayStore data structure ({pr}`395`, {pr}`398`, {pr}`400`, {pr}`402`)
+- Add ArrayStore data structure ({pr}`395`, {pr}`398`, {pr}`400`, {pr}`402`,
+  {pr}`403`)
 - Add GradientOperatorEmitter to support OMG-MEGA and OG-MAP-Elites ({pr}`348`)
 
 #### Improvements

--- a/ribs/archives/_array_store.py
+++ b/ribs/archives/_array_store.py
@@ -1,6 +1,7 @@
 """Provides ArrayStore."""
 import itertools
 from enum import IntEnum
+from functools import cached_property
 
 import numpy as np
 from numpy_groupies import aggregate_nb as aggregate
@@ -171,6 +172,29 @@ class ArrayStore:
         store."""
         return readonly(
             self._props["occupied_list"][:self._props["n_occupied"]])
+
+    @cached_property
+    def field_desc(self):
+        """dict: Description of fields in the array store.
+
+        Example:
+
+            ::
+
+                store.field_desc == {
+                    "objective": ((), np.float32),
+                    "measures": ((10,), np.float32)
+                }
+
+        See the constructor ``field_desc`` parameter for more info. Unlike in
+        the field_desc in the constructor, which accepts ints for 1D field
+        shapes (e.g., ``5``), this field_desc shows 1D field shapes as tuples of
+        1 entry (e.g., ``(5,)``).
+        """
+        return {
+            name: (arr.shape[1:], arr.dtype)
+            for name, arr in self._fields.items()
+        }
 
     def retrieve(self, indices, fields=None, return_type="dict"):
         """Collects data at the given indices.

--- a/tests/archives/array_store_test.py
+++ b/tests/archives/array_store_test.py
@@ -45,6 +45,11 @@ def test_init(shape):
     assert store.capacity == capacity
     assert np.all(~store.occupied)
     assert len(store.occupied_list) == 0
+    assert store.field_desc == {
+        "objective": (shape[0], np.float32),
+        "measures": ((shape[1],), np.float32),
+        "solution": ((shape[2],), np.float32),
+    }
 
 
 @pytest.fixture


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the PR's purpose here. -->

This property is a cached property. It takes some computation, but we only want to do it once since it never changes. Furthermore, we do not want to store it in the constructor since we would then need to worry about it when reconstructing in `from_raw_dict`.

## TODO

<!-- Notable points that this PR has either accomplished or will accomplish. -->

## Questions

<!-- Any concerns or points of confusion? -->

## Status

- [x] I have read the guidelines in
      [CONTRIBUTING.md](https://github.com/icaros-usc/pyribs/blob/master/CONTRIBUTING.md)
- [x] I have formatted my code using `yapf`
- [x] I have tested my code by running `pytest`
- [x] I have linted my code with `pylint`
- [x] I have added a one-line description of my change to the changelog in
      `HISTORY.md`
- [x] This PR is ready to go
