### PR TITLE
Remove readonly restriction on ArrayStore data

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -11,7 +11,7 @@
 - **Backwards-incompatible:** Rename `measure_*` columns to `measures_*` in
   `as_pandas` ({pr}`396`)
 - Add ArrayStore data structure ({pr}`395`, {pr}`398`, {pr}`400`, {pr}`402`,
-  {pr}`403`, {pr}`404`, {pr}`405`)
+  {pr}`403`, {pr}`404`, {pr}`406`)
 - Add GradientOperatorEmitter to support OMG-MEGA and OG-MAP-Elites ({pr}`348`)
 
 #### Improvements

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -11,7 +11,7 @@
 - **Backwards-incompatible:** Rename `measure_*` columns to `measures_*` in
   `as_pandas` ({pr}`396`)
 - Add ArrayStore data structure ({pr}`395`, {pr}`398`, {pr}`400`, {pr}`402`,
-  {pr}`403`, {pr}`404`)
+  {pr}`403`, {pr}`404`, {pr}`405`)
 - Add GradientOperatorEmitter to support OMG-MEGA and OG-MAP-Elites ({pr}`348`)
 
 #### Improvements

--- a/ribs/archives/_array_store.py
+++ b/ribs/archives/_array_store.py
@@ -274,15 +274,15 @@ class ArrayStore:
                 Like the other return types, the columns can be adjusted with
                 the ``fields`` parameter.
 
-            All data returned by this method will be a readonly copy, i.e., the
-            data will not update as the store changes.
+            All data returned by this method will be a copy, i.e., the data will
+            not update as the store changes.
 
         Raises:
             ValueError: Invalid field name provided.
             ValueError: Invalid return_type provided.
         """
         indices = np.asarray(indices, dtype=np.int32)
-        occupied = readonly(self._props["occupied"][indices])
+        occupied = self._props["occupied"][indices]  # Induces copy.
 
         if return_type in ("dict", "pandas"):
             data = {}
@@ -299,9 +299,9 @@ class ArrayStore:
             # Note that fancy indexing with indices already creates a copy, so
             # only `indices` needs to be copied explicitly.
             if name == "index":
-                arr = readonly(np.copy(indices))
+                arr = np.copy(indices)
             elif name in self._fields:
-                arr = readonly(self._fields[name][indices])
+                arr = self._fields[name][indices]  # Induces copy.
             else:
                 raise ValueError(f"`{name}` is not a field in this ArrayStore.")
 


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the PR's purpose here. -->

Since methods like retrieve() already return copies, there is no need to make the copies be readonly.

## TODO

<!-- Notable points that this PR has either accomplished or will accomplish. -->

## Questions

<!-- Any concerns or points of confusion? -->

## Status

- [x] I have read the guidelines in
      [CONTRIBUTING.md](https://github.com/icaros-usc/pyribs/blob/master/CONTRIBUTING.md)
- [x] I have formatted my code using `yapf`
- [x] I have tested my code by running `pytest`
- [x] I have linted my code with `pylint`
- [x] I have added a one-line description of my change to the changelog in
      `HISTORY.md`
- [x] This PR is ready to go
