### PR TITLE
Add field_list property to ArrayStore

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -11,7 +11,7 @@
 - **Backwards-incompatible:** Rename `measure_*` columns to `measures_*` in
   `as_pandas` ({pr}`396`)
 - Add ArrayStore data structure ({pr}`395`, {pr}`398`, {pr}`400`, {pr}`402`,
-  {pr}`403`, {pr}`404`, {pr}`406`)
+  {pr}`403`, {pr}`404`, {pr}`406`, {pr}`407`)
 - Add GradientOperatorEmitter to support OMG-MEGA and OG-MAP-Elites ({pr}`348`)
 
 #### Improvements

--- a/ribs/archives/_array_store.py
+++ b/ribs/archives/_array_store.py
@@ -175,7 +175,7 @@ class ArrayStore:
 
     @cached_property
     def field_desc(self):
-        """dict: Description of fields in the array store.
+        """dict: Description of fields in the store.
 
         Example:
 
@@ -189,12 +189,25 @@ class ArrayStore:
         See the constructor ``field_desc`` parameter for more info. Unlike in
         the field_desc in the constructor, which accepts ints for 1D field
         shapes (e.g., ``5``), this field_desc shows 1D field shapes as tuples of
-        1 entry (e.g., ``(5,)``).
+        1 entry (e.g., ``(5,)``). Since dicts in Python are ordered, note that
+        this dict will have the same order as in the constructor.
         """
         return {
             name: (arr.shape[1:], arr.dtype)
             for name, arr in self._fields.items()
         }
+
+    @cached_property
+    def field_list(self):
+        """list: List of fields in the store.
+
+        Example:
+
+            ::
+
+                store.field_list == ["objective", "measures"]
+        """
+        return list(self._fields)
 
     def retrieve(self, indices, fields=None, return_type="dict"):
         """Collects data at the given indices.
@@ -337,10 +350,10 @@ class ArrayStore:
 
         Args:
             fields (array-like of str): See :meth:`retrieve`.
+            return_type (str): See :meth:`retrieve`.
         Returns:
-            dict or tuple: See ``data`` in :meth:`retrieve`. ``occupied`` is not
-                returned since all indices are known to be occupied in this
-                method.
+            See ``data`` in :meth:`retrieve`. ``occupied`` is not returned since
+            all indices are known to be occupied in this method.
         """
         return self.retrieve(self.occupied_list, fields, return_type)[1]
 

--- a/ribs/archives/_array_store.py
+++ b/ribs/archives/_array_store.py
@@ -207,6 +207,8 @@ class ArrayStore:
 
                 store.field_list == ["objective", "measures"]
         """
+        # Python dicts are ordered, so this will follow the same order as in the
+        # constructor.
         return list(self._fields)
 
     def retrieve(self, indices, fields=None, return_type="dict"):

--- a/tests/archives/array_store_test.py
+++ b/tests/archives/array_store_test.py
@@ -52,6 +52,7 @@ def test_init(shape):
         "solution": (
             (shape[2],) if isinstance(shape[2], int) else shape[2], np.float32),
     }
+    assert store.field_list == ["objective", "measures", "solution"]
 
 
 @pytest.fixture


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the PR's purpose here. -->

The field_desc property can provide a bit too much info on the ArrayStore; we may only want to see the list of fields. This PR provides such a property.

## TODO

<!-- Notable points that this PR has either accomplished or will accomplish. -->

- [x] Implement
- [x] Document
- [x] Test

## Questions

<!-- Any concerns or points of confusion? -->

## Status

- [x] I have read the guidelines in
      [CONTRIBUTING.md](https://github.com/icaros-usc/pyribs/blob/master/CONTRIBUTING.md)
- [x] I have formatted my code using `yapf`
- [x] I have tested my code by running `pytest`
- [x] I have linted my code with `pylint`
- [x] I have added a one-line description of my change to the changelog in
      `HISTORY.md`
- [x] This PR is ready to go
