### PR TITLE
Include threshold in `archive.best_elite`

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,6 +6,7 @@
 
 #### API
 
+- Include threshold in `archive.best_elite` ({pr}`408`)
 - **Backwards-incompatible:** Replace Elite and EliteBatch with dicts
   ({pr}`397`)
 - **Backwards-incompatible:** Rename `measure_*` columns to `measures_*` in

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,7 +6,7 @@
 
 #### API
 
-- Include threshold in `archive.best_elite` ({pr}`408`)
+- Include threshold in `archive.best_elite` ({pr}`409`)
 - **Backwards-incompatible:** Replace Elite and EliteBatch with dicts
   ({pr}`397`)
 - **Backwards-incompatible:** Rename `measure_*` columns to `measures_*` in

--- a/ribs/archives/_archive_base.py
+++ b/ribs/archives/_archive_base.py
@@ -164,6 +164,11 @@ class ArchiveBase(ABC):  # pylint: disable = too-many-instance-attributes
             the *threshold* of the cell they are being inserted into, not the
             *objective* of the elite currently in the cell. See :pr:`314` for
             more info.
+
+        .. note::
+            The best elite will contain a "threshold" key. This threshold is the
+            threshold of the best elite's cell after the best elite was inserted
+            into the archive.
         """
         return self._best_elite
 

--- a/ribs/archives/_archive_base.py
+++ b/ribs/archives/_archive_base.py
@@ -268,7 +268,6 @@ class ArchiveBase(ABC):  # pylint: disable = too-many-instance-attributes
                 new_best_elite["objective"] > self._stats.obj_max):
             # Convert batched values to single values.
             new_best_elite = {k: v[0] for k, v in new_best_elite.items()}
-            new_best_elite.pop("threshold")
 
             new_obj_max = new_best_elite["objective"]
             self._best_elite = new_best_elite

--- a/tests/archives/archive_base_test.py
+++ b/tests/archives/archive_base_test.py
@@ -175,9 +175,14 @@ def test_best_elite(add_mode):
     else:
         archive.add([[1, 2, 3]], [1.0], [[0, 0]])
 
+    assert archive.best_elite.keys() == {
+        "solution", "objective", "measures", "metadata", "threshold", "index"
+    }
+
     assert archive.best_elite["solution"].shape == (3,)
     assert archive.best_elite["objective"].shape == ()
     assert archive.best_elite["measures"].shape == (2,)
+    assert archive.best_elite["threshold"].shape == ()
     # Seem to be spurious pylint warnings.
     # pylint: disable-next=use-implicit-booleaness-not-comparison,comparison-with-callable
     assert archive.stats.obj_max.shape == ()
@@ -185,6 +190,7 @@ def test_best_elite(add_mode):
     assert np.isclose(archive.best_elite["solution"], [1, 2, 3]).all()
     assert np.isclose(archive.best_elite["objective"], 1.0)
     assert np.isclose(archive.best_elite["measures"], [0, 0]).all()
+    assert np.isclose(archive.best_elite["threshold"], 1.0).all()
     assert np.isclose(archive.stats.obj_max, 1.0)
 
     # Add an elite into the same cell as the previous elite -- best_elite should
@@ -197,6 +203,7 @@ def test_best_elite(add_mode):
     assert np.isclose(archive.best_elite["solution"], [4, 5, 6]).all()
     assert np.isclose(archive.best_elite["objective"], 2.0).all()
     assert np.isclose(archive.best_elite["measures"], [0, 0]).all()
+    assert np.isclose(archive.best_elite["threshold"], 2.0).all()
     assert np.isclose(archive.stats.obj_max, 2.0)
 
 


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the PR's purpose here. -->

Previously, we popped the threshold from best_elite to maintain backwards compatibility. This PR adds the threshold back so that best_elite aligns with the other archive methods.

## TODO

<!-- Notable points that this PR has either accomplished or will accomplish. -->

- [x] Make tighter tests for best_elite
- [x] Add threshold back to best_elite (i.e., no longer pop it)

## Questions

<!-- Any concerns or points of confusion? -->

## Status

- [x] I have read the guidelines in
      [CONTRIBUTING.md](https://github.com/icaros-usc/pyribs/blob/master/CONTRIBUTING.md)
- [x] I have formatted my code using `yapf`
- [x] I have tested my code by running `pytest`
- [x] I have linted my code with `pylint`
- [x] I have added a one-line description of my change to the changelog in
      `HISTORY.md`
- [x] This PR is ready to go
