### PR TITLE
Support single fields in ArrayStore.retrieve

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -12,7 +12,7 @@
 - **Backwards-incompatible:** Rename `measure_*` columns to `measures_*` in
   `as_pandas` ({pr}`396`)
 - Add ArrayStore data structure ({pr}`395`, {pr}`398`, {pr}`400`, {pr}`402`,
-  {pr}`403`, {pr}`404`, {pr}`406`, {pr}`407`)
+  {pr}`403`, {pr}`404`, {pr}`406`, {pr}`407`, {pr}`411`)
 - Add GradientOperatorEmitter to support OMG-MEGA and OG-MAP-Elites ({pr}`348`)
 
 #### Improvements

--- a/tests/archives/array_store_test.py
+++ b/tests/archives/array_store_test.py
@@ -309,6 +309,24 @@ def test_retrieve_custom_fields(store, return_type):
         assert np.all(df["objective"] == [2.0, 1.0])
 
 
+def test_retrieve_single_field(store):
+    store.add(
+        [3, 5],
+        {
+            "objective": [1.0, 2.0],
+            "measures": [[1.0, 2.0], [3.0, 4.0]],
+            "solution": [np.zeros(10), np.ones(10)],
+        },
+        {},  # Empty extra_args.
+        [],  # Empty transforms.
+    )
+
+    occupied, data = store.retrieve([5, 3], fields="objective")
+
+    assert np.all(occupied == [True, True])
+    assert np.all(data == [2.0, 1.0])
+
+
 def test_add_simple_transform(store):
 
     def obj_meas(indices, new_data, add_info, extra_args, occupied, cur_data):


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the PR's purpose here. -->

This adds a shortcut whereby a single array can be retrieved from an ArrayStore. For instance, `occupied, objective = store.retrieve("objective")`. This call also extends to the data method, e.g., `objective = store.retrieve("objective")`.

## TODO

<!-- Notable points that this PR has either accomplished or will accomplish. -->

## Questions

<!-- Any concerns or points of confusion? -->

## Status

- [x] I have read the guidelines in
      [CONTRIBUTING.md](https://github.com/icaros-usc/pyribs/blob/master/CONTRIBUTING.md)
- [x] I have formatted my code using `yapf`
- [x] I have tested my code by running `pytest`
- [x] I have linted my code with `pylint`
- [x] I have added a one-line description of my change to the changelog in
      `HISTORY.md`
- [x] This PR is ready to go
