### PR TITLE
Return occupied booleans in retrieve

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,6 +6,7 @@
 
 #### API
 
+- **Backwards-incompatible:** Return occupied booleans in retrieve ({pr}`414`)
 - **Backwards-incompatible:** Deprecate `as_pandas` in favor of
   `data(return_type="pandas")` ({pr}`408`)
 - **Backwards-incompatible:** Replace ArchiveDataFrame batch methods with

--- a/ribs/archives/_archive_base.py
+++ b/ribs/archives/_archive_base.py
@@ -580,7 +580,7 @@ class ArchiveBase(ABC):
             else:  # Floating-point and other fields.
                 fill_val = np.nan
 
-            data[unoccupied] = fill_val
+            arr[unoccupied] = fill_val
 
         return occupied, data
 

--- a/ribs/archives/_archive_base.py
+++ b/ribs/archives/_archive_base.py
@@ -521,7 +521,7 @@ class ArchiveBase(ABC):
         outputs the batched data for the elites::
 
             occupied, elites = archive.retrieve(...)
-            elites["solution"]  # Shape: (len(measures_batch), solution_dim)
+            elites["solution"]  # Shape: (batch_size, solution_dim)
             elites["objective"]
             elites["measures"]
             elites["index"]

--- a/tests/archives/archive_base_test.py
+++ b/tests/archives/archive_base_test.py
@@ -345,6 +345,7 @@ def test_retrieve_gets_correct_elite(data):
     assert np.all(elites["solution"][0] == data.solution)
     assert elites["objective"][0] == data.objective
     assert np.all(elites["measures"][0] == data.measures)
+    assert elites["threshold"][0] == data.objective
     # Avoid checking elites["index"] since the meaning varies by archive.
     assert elites["metadata"][0] == data.metadata
 
@@ -355,6 +356,7 @@ def test_retrieve_empty_values(data):
     assert np.all(np.isnan(elites["solution"][0]))
     assert np.isnan(elites["objective"])
     assert np.all(np.isnan(elites["measures"][0]))
+    assert np.isnan(elites["threshold"])
     assert elites["index"][0] == -1
     assert elites["metadata"][0] is None
 
@@ -370,6 +372,7 @@ def test_retrieve_single_gets_correct_elite(data):
     assert np.all(elite["solution"] == data.solution)
     assert elite["objective"] == data.objective
     assert np.all(elite["measures"] == data.measures)
+    assert elite["threshold"] == data.objective
     # Avoid checking elite["index"] since the meaning varies by archive.
     assert elite["metadata"] == data.metadata
 
@@ -380,6 +383,7 @@ def test_retrieve_single_empty_values(data):
     assert np.all(np.isnan(elite["solution"]))
     assert np.isnan(elite["objective"])
     assert np.all(np.isnan(elite["measures"]))
+    assert np.isnan(elite["threshold"])
     assert elite["index"] == -1
     assert elite["metadata"] is None
 

--- a/tests/archives/archive_base_test.py
+++ b/tests/archives/archive_base_test.py
@@ -340,7 +340,8 @@ def test_basic_stats(data):
 
 
 def test_retrieve_gets_correct_elite(data):
-    elites = data.archive_with_elite.retrieve([data.measures])
+    occupied, elites = data.archive_with_elite.retrieve([data.measures])
+    assert occupied[0]
     assert np.all(elites["solution"][0] == data.solution)
     assert elites["objective"][0] == data.objective
     assert np.all(elites["measures"][0] == data.measures)
@@ -349,7 +350,8 @@ def test_retrieve_gets_correct_elite(data):
 
 
 def test_retrieve_empty_values(data):
-    elites = data.archive.retrieve([data.measures])
+    occupied, elites = data.archive.retrieve([data.measures])
+    assert not occupied[0]
     assert np.all(np.isnan(elites["solution"][0]))
     assert np.isnan(elites["objective"])
     assert np.all(np.isnan(elites["measures"][0]))
@@ -363,7 +365,8 @@ def test_retrieve_wrong_shape(data):
 
 
 def test_retrieve_single_gets_correct_elite(data):
-    elite = data.archive_with_elite.retrieve_single(data.measures)
+    occupied, elite = data.archive_with_elite.retrieve_single(data.measures)
+    assert occupied
     assert np.all(elite["solution"] == data.solution)
     assert elite["objective"] == data.objective
     assert np.all(elite["measures"] == data.measures)
@@ -372,7 +375,8 @@ def test_retrieve_single_gets_correct_elite(data):
 
 
 def test_retrieve_single_empty_values(data):
-    elite = data.archive.retrieve_single(data.measures)
+    occupied, elite = data.archive.retrieve_single(data.measures)
+    assert not occupied
     assert np.all(np.isnan(elite["solution"]))
     assert np.isnan(elite["objective"])
     assert np.all(np.isnan(elite["measures"]))

--- a/tutorials/arm_repertoire.ipynb
+++ b/tutorials/arm_repertoire.ipynb
@@ -449,9 +449,10 @@
     }
    ],
    "source": [
-    "elite = archive.retrieve_single([0, 0])\n",
+    "occupied, elite = archive.retrieve_single([0, 0])\n",
     "_, ax = plt.subplots()\n",
-    "if elite[\"solution\"] is not None:  # This is None if there is no solution for [0,0].\n",
+    "# `occupied` indicates if there was an elite in the corresponding cell.\n",
+    "if occupied:\n",
     "    visualize(elite[\"solution\"], link_lengths, elite[\"objective\"], ax)"
    ]
   },

--- a/tutorials/lunar_lander.ipynb
+++ b/tutorials/lunar_lander.ipynb
@@ -746,7 +746,6 @@
     "id": "t2QPnuqgFKhr"
    },
    "source": [
-    "\n",
     "We can retrieve policies with measures that are close to a query with the [`retrieve_single`](https://docs.pyribs.org/en/latest/api/ribs.archives.GridArchive.html#ribs.archives.GridArchive.retrieve_single) method. This method will look up the cell corresponding to the queried measures. Then, the method will check if there is an elite in that cell, and return the elite if it exists (the method does not check neighboring cells for elites). The returned elite may not have the exact measures requested because the elite only has to be in the same cell as the queried measures.\n",
     "\n",
     "Below, we first retrieve a policy that impacted the ground on the left (approximately -0.4) with low velocity (approximately -0.10) by querying for `[-0.4, -0.10]`."
@@ -789,10 +788,9 @@
     }
    ],
    "source": [
-    "elite = archive.retrieve_single([-0.4, -0.10])\n",
-    "# NaN objective indicates the solution could not be retrieved because there was\n",
-    "# no elite in the corresponding cell.\n",
-    "if not np.isnan(elite[\"objective\"]):\n",
+    "occupied, elite = archive.retrieve_single([-0.4, -0.10])\n",
+    "# `occupied` indicates if there was an elite in the corresponding cell.\n",
+    "if occupied:\n",
     "    print(f\"Objective: {elite['objective']}\")\n",
     "    print(f\"Measures: (x-pos: {elite['measures'][0]}, y-vel: {elite['measures'][1]})\")\n",
     "    display_video(elite[\"solution\"])"
@@ -848,8 +846,8 @@
     }
    ],
    "source": [
-    "elite = archive.retrieve_single([0.6, -0.10])\n",
-    "if not np.isnan(elite[\"objective\"]):\n",
+    "occupied, elite = archive.retrieve_single([0.6, -0.10])\n",
+    "if occupied:\n",
     "    print(f\"Objective: {elite['objective']}\")\n",
     "    print(f\"Measures: (x-pos: {elite['measures'][0]}, y-vel: {elite['measures'][1]})\")\n",
     "    display_video(elite[\"solution\"])"
@@ -901,8 +899,8 @@
     }
    ],
    "source": [
-    "elite = archive.retrieve_single([0.0, -0.10])\n",
-    "if not np.isnan(elite[\"objective\"]):\n",
+    "occupied, elite = archive.retrieve_single([0.0, -0.10])\n",
+    "if occupied:\n",
     "    print(f\"Objective: {elite['objective']}\")\n",
     "    print(f\"Measures: (x-pos: {elite['measures'][0]}, y-vel: {elite['measures'][1]})\")\n",
     "    display_video(elite[\"solution\"])"


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the PR's purpose here. -->

Previously, we relied on sentinel values to indicate whether a given cell was occupied. Since it is entirely possible that users want to use these sentinel values in their fields, we now return a separate `occupied` array that indicates which cells are occupied.

Considerations:
- Chose not to support additional return types like tuple and pandas for now, as such flexibility is less essential in `retrieve`, and this feature can be added fairly easily later on
- We still set the sentinel values depending on the field type since it may be confusing to see arbitrary values for a given field without seeing the occupied array.
- the `threshold` field is now included in outputs from `retrieve()`

## TODO

<!-- Notable points that this PR has either accomplished or will accomplish. -->

- [x] Implement new retrieve and retrieve_single methods
- [x] Fix tests
- [x] Fix usage in tutorials

## Questions

<!-- Any concerns or points of confusion? -->

## Status

- [x] I have read the guidelines in
      [CONTRIBUTING.md](https://github.com/icaros-usc/pyribs/blob/master/CONTRIBUTING.md)
- [x] I have formatted my code using `yapf`
- [x] I have tested my code by running `pytest`
- [x] I have linted my code with `pylint`
- [x] I have added a one-line description of my change to the changelog in
      `HISTORY.md`
- [x] This PR is ready to go
