### PR TITLE
Remove `_batch` from archive add() parameter names

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,6 +6,8 @@
 
 #### API
 
+- **Backwards-incompatible:** Remove `_batch` from archive add() parameter names
+  ({pr}`422`)
 - Add Gaussian, IsoLine Operators and Refactor GaussianEmitter/IsoLineEmitter
   ({pr}`418`)
 - **Backwards-incompatible:** Remove metadata in favor of custom fields

--- a/ribs/archives/_archive_base.py
+++ b/ribs/archives/_archive_base.py
@@ -293,7 +293,7 @@ class ArchiveBase(ABC):
             obj_mean=self._objective_sum / self.dtype(len(self)),
         )
 
-    def add(self, solution_batch, objective_batch, measures_batch):
+    def add(self, solution, objective, measures):
         """Inserts a batch of solutions into the archive.
 
         Each solution is only inserted if it has a higher ``objective`` than the
@@ -318,12 +318,12 @@ class ArchiveBase(ABC):
             objective, and measures for solution ``i``.
 
         Args:
-            solution_batch (array-like): (batch_size, :attr:`solution_dim`)
-                array of solution parameters.
-            objective_batch (array-like): (batch_size,) array with objective
-                function evaluations of the solutions.
-            measures_batch (array-like): (batch_size, :attr:`measure_dim`)
-                array with measure space coordinates of all the solutions.
+            solution (array-like): (batch_size, :attr:`solution_dim`) array of
+                solution parameters.
+            objective (array-like): (batch_size,) array with objective function
+                evaluations of the solutions.
+            measures (array-like): (batch_size, :attr:`measure_dim`) array with
+                measure space coordinates of all the solutions.
 
         Returns:
             tuple: 2-element tuple of (status_batch, value_batch) which
@@ -387,9 +387,9 @@ class ArchiveBase(ABC):
             measures_batch,
         ) = validate_batch_args(
             archive=self,
-            solution_batch=solution_batch,
-            objective_batch=objective_batch,
-            measures_batch=measures_batch,
+            solution_batch=solution,
+            objective_batch=objective,
+            measures_batch=measures,
         )
 
         add_info = self._store.add(

--- a/ribs/archives/_sliding_boundaries_archive.py
+++ b/ribs/archives/_sliding_boundaries_archive.py
@@ -384,7 +384,7 @@ class SlidingBoundariesArchive(ArchiveBase):
                                                last_objective, last_measures)
         return status, value
 
-    def add(self, solution_batch, objective_batch, measures_batch):
+    def add(self, solution, objective, measures):
         """Inserts a batch of solutions into the archive.
 
         .. note:: Unlike in other archives, this method (currently) is not truly
@@ -401,9 +401,9 @@ class SlidingBoundariesArchive(ArchiveBase):
             measures_batch,
         ) = validate_batch_args(
             archive=self,
-            solution_batch=solution_batch,
-            objective_batch=objective_batch,
-            measures_batch=measures_batch,
+            solution_batch=solution,
+            objective_batch=objective,
+            measures_batch=measures,
         )
         batch_size = solution_batch.shape[0]
 

--- a/ribs/visualize/_cvt_archive_3d_plot.py
+++ b/ribs/visualize/_cvt_archive_3d_plot.py
@@ -63,9 +63,9 @@ def cvt_archive_3d_plot(
             >>> x = np.random.uniform(-2, 0, 5000)
             >>> y = np.random.uniform(-2, 0, 5000)
             >>> z = np.random.uniform(-2, 0, 5000)
-            >>> archive.add(solution_batch=np.stack((x, y), axis=1),
-            ...             objective_batch=-(x**2 + y**2 + z**2),
-            ...             measures_batch=np.stack((x, y, z), axis=1))
+            >>> archive.add(solution=np.stack((x, y), axis=1),
+            ...             objective=-(x**2 + y**2 + z**2),
+            ...             measures=np.stack((x, y, z), axis=1))
             >>> # Plot the archive.
             >>> plt.figure(figsize=(8, 6))
             >>> cvt_archive_3d_plot(archive)
@@ -88,9 +88,9 @@ def cvt_archive_3d_plot(
             >>> x = np.random.uniform(-2, 0, 5000)
             >>> y = np.random.uniform(-2, 0, 5000)
             >>> z = np.random.uniform(-2, 0, 5000)
-            >>> archive.add(solution_batch=np.stack((x, y), axis=1),
-            ...             objective_batch=-(x**2 + y**2 + z**2),
-            ...             measures_batch=np.stack((x, y, z), axis=1))
+            >>> archive.add(solution=np.stack((x, y), axis=1),
+            ...             objective=-(x**2 + y**2 + z**2),
+            ...             measures=np.stack((x, y, z), axis=1))
             >>> # Plot the archive.
             >>> plt.figure(figsize=(8, 6))
             >>> cvt_archive_3d_plot(archive, cell_alpha=0.1)
@@ -113,9 +113,9 @@ def cvt_archive_3d_plot(
             >>> x = np.random.uniform(-2, 0, 1000)
             >>> y = np.random.uniform(-2, 0, 1000)
             >>> z = np.random.uniform(-2, 0, 1000)
-            >>> archive.add(solution_batch=np.stack((x, y), axis=1),
-            ...             objective_batch=-(x**2 + y**2 + z**2),
-            ...             measures_batch=np.stack((x, y, z), axis=1))
+            >>> archive.add(solution=np.stack((x, y), axis=1),
+            ...             objective=-(x**2 + y**2 + z**2),
+            ...             measures=np.stack((x, y, z), axis=1))
             >>> # Plot the archive.
             >>> plt.figure(figsize=(8, 6))
             >>> cvt_archive_3d_plot(archive, cell_alpha=0.0)
@@ -138,9 +138,9 @@ def cvt_archive_3d_plot(
             >>> x = np.random.uniform(-2, 0, 1000)
             >>> y = np.random.uniform(-2, 0, 1000)
             >>> z = np.random.uniform(-2, 0, 1000)
-            >>> archive.add(solution_batch=np.stack((x, y), axis=1),
-            ...             objective_batch=-(x**2 + y**2 + z**2),
-            ...             measures_batch=np.stack((x, y, z), axis=1))
+            >>> archive.add(solution=np.stack((x, y), axis=1),
+            ...             objective=-(x**2 + y**2 + z**2),
+            ...             measures=np.stack((x, y, z), axis=1))
             >>> # Plot the archive.
             >>> plt.figure(figsize=(8, 6))
             >>> cvt_archive_3d_plot(archive, cell_alpha=0.0, plot_elites=True)

--- a/ribs/visualize/_cvt_archive_heatmap.py
+++ b/ribs/visualize/_cvt_archive_heatmap.py
@@ -61,9 +61,9 @@ def cvt_archive_heatmap(archive,
             ...                      cells=100, ranges=[(-1, 1), (-1, 1)])
             >>> x = np.random.uniform(-1, 1, 10000)
             >>> y = np.random.uniform(-1, 1, 10000)
-            >>> archive.add(solution_batch=np.stack((x, y), axis=1),
-            ...             objective_batch=-(x**2 + y**2),
-            ...             measures_batch=np.stack((x, y), axis=1))
+            >>> archive.add(solution=np.stack((x, y), axis=1),
+            ...             objective=-(x**2 + y**2),
+            ...             measures=np.stack((x, y), axis=1))
             >>> # Plot a heatmap of the archive.
             >>> plt.figure(figsize=(8, 6))
             >>> cvt_archive_heatmap(archive)

--- a/ribs/visualize/_grid_archive_heatmap.py
+++ b/ribs/visualize/_grid_archive_heatmap.py
@@ -49,9 +49,9 @@ def grid_archive_heatmap(archive,
             ...                       ranges=[(-1, 1), (-1, 1)])
             >>> x = np.random.uniform(-1, 1, 10000)
             >>> y = np.random.uniform(-1, 1, 10000)
-            >>> archive.add(solution_batch=np.stack((x, y), axis=1),
-            ...             objective_batch=-(x**2 + y**2),
-            ...             measures_batch=np.stack((x, y), axis=1))
+            >>> archive.add(solution=np.stack((x, y), axis=1),
+            ...             objective=-(x**2 + y**2),
+            ...             measures=np.stack((x, y), axis=1))
             >>> # Plot a heatmap of the archive.
             >>> plt.figure(figsize=(8, 6))
             >>> grid_archive_heatmap(archive)
@@ -73,9 +73,9 @@ def grid_archive_heatmap(archive,
             >>> archive = GridArchive(solution_dim=2,
             ...                       dims=[20], ranges=[(-1, 1)])
             >>> x = np.random.uniform(-1, 1, 1000)
-            >>> archive.add(solution_batch=np.stack((x, x), axis=1),
-            ...             objective_batch=-x**2,
-            ...             measures_batch=x[:, None])
+            >>> archive.add(solution=np.stack((x, x), axis=1),
+            ...             objective=-x**2,
+            ...             measures=x[:, None])
             >>> # Plot a heatmap of the archive.
             >>> plt.figure(figsize=(8, 6))
             >>> grid_archive_heatmap(archive)

--- a/ribs/visualize/_sliding_boundaries_archive_heatmap.py
+++ b/ribs/visualize/_sliding_boundaries_archive_heatmap.py
@@ -45,9 +45,9 @@ def sliding_boundaries_archive_heatmap(archive,
             ...                                    seed=42)
             >>> # Populate the archive with the negative sphere function.
             >>> xy = np.clip(np.random.standard_normal((1000, 2)), -1.5, 1.5)
-            >>> archive.add(solution_batch=xy,
-            ...             objective_batch=-np.sum(xy**2, axis=1),
-            ...             measures_batch=xy)
+            >>> archive.add(solution=xy,
+            ...             objective=-np.sum(xy**2, axis=1),
+            ...             measures=xy)
             >>> # Plot heatmaps of the archive.
             >>> fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(16,6))
             >>> fig.suptitle("Negative sphere function")

--- a/tests/archives/grid_archive_test.py
+++ b/tests/archives/grid_archive_test.py
@@ -285,11 +285,11 @@ def test_add_single_wrong_shapes(data):
 def test_add_batch_all_new(data):
     status_batch, value_batch = data.archive.add(
         # 4 solutions of arbitrary value.
-        solution_batch=[[1, 2, 3]] * 4,
+        solution=[[1, 2, 3]] * 4,
         # The first two solutions end up in separate cells, and the next two end
         # up in the same cell.
-        objective_batch=[0, 0, 0, 1],
-        measures_batch=[[0, 0], [0.25, 0.25], [0.5, 0.5], [0.5, 0.5]],
+        objective=[0, 0, 0, 1],
+        measures=[[0, 0], [0.25, 0.25], [0.5, 0.5], [0.5, 0.5]],
     )
     assert (status_batch == 2).all()
     assert np.isclose(value_batch, [0, 0, 0, 1]).all()
@@ -306,9 +306,9 @@ def test_add_batch_all_new(data):
 
 def test_add_batch_none_inserted(data):
     status_batch, value_batch = data.archive_with_elite.add(
-        solution_batch=[[1, 2, 3]] * 4,
-        objective_batch=[data.objective - 1 for _ in range(4)],
-        measures_batch=[data.measures for _ in range(4)],
+        solution=[[1, 2, 3]] * 4,
+        objective=[data.objective - 1 for _ in range(4)],
+        measures=[data.measures for _ in range(4)],
     )
 
     # All solutions were inserted into the same cell as the elite already in the
@@ -328,9 +328,9 @@ def test_add_batch_none_inserted(data):
 
 def test_add_batch_with_improvement(data):
     status_batch, value_batch = data.archive_with_elite.add(
-        solution_batch=[[1, 2, 3]] * 4,
-        objective_batch=[data.objective + 1 for _ in range(4)],
-        measures_batch=[data.measures for _ in range(4)],
+        solution=[[1, 2, 3]] * 4,
+        objective=[data.objective + 1 for _ in range(4)],
+        measures=[data.measures for _ in range(4)],
     )
 
     # All solutions were inserted into the same cell as the elite already in the
@@ -350,8 +350,8 @@ def test_add_batch_with_improvement(data):
 
 def test_add_batch_mixed_statuses(data):
     status_batch, value_batch = data.archive_with_elite.add(
-        solution_batch=[[1, 2, 3]] * 6,
-        objective_batch=[
+        solution=[[1, 2, 3]] * 6,
+        objective=[
             # Not added.
             data.objective - 1.0,
             # Not added.
@@ -365,7 +365,7 @@ def test_add_batch_mixed_statuses(data):
             # New and added.
             2.0,
         ],
-        measures_batch=[
+        measures=[
             data.measures,
             data.measures,
             data.measures,
@@ -389,13 +389,13 @@ def test_add_batch_mixed_statuses(data):
 
 def test_add_batch_first_solution_wins_in_ties(data):
     status_batch, value_batch = data.archive_with_elite.add(
-        solution_batch=[
+        solution=[
             [1, 2, 3],
             [4, 5, 6],
             [7, 8, 9],
             [10, 11, 12],
         ],
-        objective_batch=[
+        objective=[
             # Ties for improvement.
             data.objective + 1.0,
             data.objective + 1.0,
@@ -403,7 +403,7 @@ def test_add_batch_first_solution_wins_in_ties(data):
             3.0,
             3.0,
         ],
-        measures_batch=[
+        measures=[
             data.measures,
             data.measures,
             [0, 0],
@@ -434,9 +434,9 @@ def test_add_batch_not_inserted_if_below_threshold_min():
     )
 
     status_batch, value_batch = archive.add(
-        solution_batch=[[1, 2, 3]] * 4,
-        objective_batch=[-20.0, -20.0, 10.0, 10.0],
-        measures_batch=[[0.0, 0.0]] * 4,
+        solution=[[1, 2, 3]] * 4,
+        objective=[-20.0, -20.0, 10.0, 10.0],
+        measures=[[0.0, 0.0]] * 4,
     )
 
     # The first two solutions should not have been inserted since they did not
@@ -556,30 +556,30 @@ def test_add_batch_threshold_update_inf_threshold_min():
 def test_add_batch_wrong_shapes(data):
     with pytest.raises(ValueError):
         data.archive.add(
-            solution_batch=[[1, 1]],  # 2D instead of 3D solution.
-            objective_batch=[0],
-            measures_batch=[[0, 0]],
+            solution=[[1, 1]],  # 2D instead of 3D solution.
+            objective=[0],
+            measures=[[0, 0]],
         )
     with pytest.raises(ValueError):
         data.archive.add(
-            solution_batch=[[0, 0, 0]],
-            objective_batch=[[1]],  # Array instead of scalar objective.
-            measures_batch=[[0, 0]],
+            solution=[[0, 0, 0]],
+            objective=[[1]],  # Array instead of scalar objective.
+            measures=[[0, 0]],
         )
     with pytest.raises(ValueError):
         data.archive.add(
-            solution_batch=[[0, 0, 0]],
-            objective_batch=[0],
-            measures_batch=[[1, 1, 1]],  # 3D instead of 2D measures.
+            solution=[[0, 0, 0]],
+            objective=[0],
+            measures=[[1, 1, 1]],  # 3D instead of 2D measures.
         )
 
 
 def test_add_batch_zero_length(data):
     """Nothing should happen when adding a batch with length 0."""
     status_batch, value_batch = data.archive.add(
-        solution_batch=np.ones((0, 3)),
-        objective_batch=np.ones((0,)),
-        measures_batch=np.ones((0, 2)),
+        solution=np.ones((0, 3)),
+        objective=np.ones((0,)),
+        measures=np.ones((0, 2)),
     )
 
     assert len(status_batch) == 0
@@ -590,15 +590,15 @@ def test_add_batch_zero_length(data):
 def test_add_batch_wrong_batch_size(data):
     with pytest.raises(ValueError):
         data.archive.add(
-            solution_batch=[[0, 0, 0]],
-            objective_batch=[1, 1],  # 2 objectives.
-            measures_batch=[[0, 0, 0]],
+            solution=[[0, 0, 0]],
+            objective=[1, 1],  # 2 objectives.
+            measures=[[0, 0, 0]],
         )
     with pytest.raises(ValueError):
         data.archive.add(
-            solution_batch=[[0, 0, 0]],
-            objective_batch=[0, 0, 0],
-            measures_batch=[[1, 1, 1], [1, 1, 1]],  # 2 measures.
+            solution=[[0, 0, 0]],
+            objective=[0, 0, 0],
+            measures=[[1, 1, 1], [1, 1, 1]],  # 2 measures.
         )
 
 

--- a/tests/visualize/conftest.py
+++ b/tests/visualize/conftest.py
@@ -28,9 +28,9 @@ def add_uniform_sphere_1d(archive, x_range):
     """
     x = np.linspace(x_range[0], x_range[1], 100)
     archive.add(
-        solution_batch=x[:, None],
-        objective_batch=-x**2,
-        measures_batch=x[:, None],
+        solution=x[:, None],
+        objective=-x**2,
+        measures=x[:, None],
     )
 
 
@@ -49,9 +49,9 @@ def add_uniform_sphere_2d(archive, x_range, y_range):
     coords = np.stack((xxs, yys), axis=1)
     sphere = xxs**2 + yys**2
     archive.add(
-        solution_batch=coords,
-        objective_batch=-sphere,  # Negative sphere.
-        measures_batch=coords,
+        solution=coords,
+        objective=-sphere,  # Negative sphere.
+        measures=coords,
     )
 
 
@@ -71,7 +71,7 @@ def add_uniform_sphere_3d(archive, x_range, y_range, z_range):
     coords = np.stack((xxs, yys, zzs), axis=1)
     sphere = xxs**2 + yys**2 + zzs**2
     archive.add(
-        solution_batch=coords,
-        objective_batch=-sphere,  # Negative sphere.
-        measures_batch=coords,
+        solution=coords,
+        objective=-sphere,  # Negative sphere.
+        measures=coords,
     )

--- a/tests/visualize/sliding_boundaries_archive_heatmap_test.py
+++ b/tests/visualize/sliding_boundaries_archive_heatmap_test.py
@@ -31,9 +31,9 @@ def add_random_sphere(archive, x_range, y_range):
     )
     sphere = np.sum(np.square(solutions), axis=1)
     archive.add(
-        solution_batch=solutions,
-        objective_batch=-sphere,
-        measures_batch=solutions,
+        solution=solutions,
+        objective=-sphere,
+        measures=solutions,
     )
 
 


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the PR's purpose here. -->

Removes the `_batch` suffix from parameter names for add(), e.g., `solution_batch` just becomes `solution`. This change helps to make way for #421, where we support custom fields. With custom fields, it makes sense to just have the field name in the argument, e.g., `myfield`, rather than `myfield_batch`. Thus, this PR makes the current argument names consistent with this usage.

Furthermore, the names with `_batch` are rather verbose, as it is usually clear from context whether the data is batch or singular (i.e., our methods mostly take in batch data, and when they need single data, they are named with the `_single` suffix, e.g., `add_single`).

This change is not as likely to affect users, since most only deal with the scheduler and do not call the archive directly; furthermore, most who do use add will only pass in their arguments positionally -- our schedulers currently use positional arguments.

## TODO

<!-- Notable points that this PR has either accomplished or will accomplish. -->

## Questions

<!-- Any concerns or points of confusion? -->

## Status

- [x] I have read the guidelines in
      [CONTRIBUTING.md](https://github.com/icaros-usc/pyribs/blob/master/CONTRIBUTING.md)
- [x] I have formatted my code using `yapf`
- [x] I have tested my code by running `pytest`
- [x] I have linted my code with `pylint`
- [x] I have added a one-line description of my change to the changelog in
      `HISTORY.md`
- [x] This PR is ready to go
