### PR TITLE
Generalize check_1d_shape to check_shape

### DIFF
--- a/ribs/_utils.py
+++ b/ribs/_utils.py
@@ -1,4 +1,6 @@
 """Miscellaneous internal utilities."""
+import numbers
+
 import numpy as np
 
 
@@ -50,16 +52,20 @@ def check_batch_shape(array, array_name, dim, dim_name, extra_msg=""):
                          f"{array.shape}.{extra_msg}")
 
 
-def check_1d_shape(array, array_name, dim, dim_name, extra_msg=""):
-    """Checks that the array has shape (dim,).
+def check_shape(array, array_name, dim, dim_name, extra_msg=""):
+    """Checks that the array has shape dim.
 
-    `array` must be a numpy array, and `dim` must be an int.
+    `array` must be a numpy array, and `dim` must be an int or tuple of int.
     """
-    if array.ndim != 1 or array.shape[0] != dim:
+    if isinstance(dim, numbers.Integral):
+        dim = (dim,)
+    if array.ndim != len(dim) or array.shape != dim:
+        comma = "," if len(dim) == 1 else ""
+        dim_str = ", ".join(map(str, dim))
         raise ValueError(
-            f"Expected {array_name} to be a 1D array with shape "
-            f"({dim},) (i.e. shape ({dim_name},)) but it had shape "
-            f"{array.shape}.{extra_msg}")
+            f"Expected {array_name} to be an array with shape "
+            f"({dim_str}{comma}) (i.e. shape ({dim_name}{comma})) but it had "
+            f"shape {array.shape}.{extra_msg}")
 
 
 def check_is_1d(array, array_name, extra_msg=""):
@@ -194,13 +200,13 @@ def validate_batch_args(archive, solution_batch, **batch_kwargs):
 def validate_single_args(archive, solution, objective, measures):
     """Performs preprocessing and checks for arguments to add_single()."""
     solution = np.asarray(solution)
-    check_1d_shape(solution, "solution", archive.solution_dim, "solution_dim")
+    check_shape(solution, "solution", archive.solution_dim, "solution_dim")
 
     objective = archive.dtype(objective)
     check_finite(objective, "objective")
 
     measures = np.asarray(measures)
-    check_1d_shape(measures, "measures", archive.measure_dim, "measure_dim")
+    check_shape(measures, "measures", archive.measure_dim, "measure_dim")
     check_finite(measures, "measures")
 
     return solution, objective, measures

--- a/ribs/_utils.py
+++ b/ribs/_utils.py
@@ -61,11 +61,10 @@ def check_shape(array, array_name, dim, dim_name, extra_msg=""):
         dim = (dim,)
     if array.ndim != len(dim) or array.shape != dim:
         comma = "," if len(dim) == 1 else ""
-        dim_str = ", ".join(map(str, dim))
         raise ValueError(
             f"Expected {array_name} to be an array with shape "
-            f"({dim_str}{comma}) (i.e. shape ({dim_name}{comma})) but it had "
-            f"shape {array.shape}.{extra_msg}")
+            f"{dim} (i.e. shape ({dim_name}{comma})) but it had shape "
+            f"{array.shape}.{extra_msg}")
 
 
 def check_is_1d(array, array_name, extra_msg=""):

--- a/ribs/archives/_archive_base.py
+++ b/ribs/archives/_archive_base.py
@@ -3,8 +3,8 @@ from abc import ABC, abstractmethod
 
 import numpy as np
 
-from ribs._utils import (check_1d_shape, check_batch_shape, check_finite,
-                         check_is_1d, parse_float_dtype, validate_batch_args,
+from ribs._utils import (check_batch_shape, check_finite, check_is_1d,
+                         check_shape, parse_float_dtype, validate_batch_args,
                          validate_single_args)
 from ribs.archives._archive_data_frame import ArchiveDataFrame
 from ribs.archives._archive_stats import ArchiveStats
@@ -247,7 +247,7 @@ class ArchiveBase(ABC):
             ValueError: ``measures`` has non-finite values (inf or NaN).
         """
         measures = np.asarray(measures)
-        check_1d_shape(measures, "measures", self.measure_dim, "measure_dim")
+        check_shape(measures, "measures", self.measure_dim, "measure_dim")
         check_finite(measures, "measures")
         return self.index_of(measures[None])[0]
 
@@ -577,7 +577,7 @@ class ArchiveBase(ABC):
             ValueError: ``measures`` has non-finite values (inf or NaN).
         """
         measures = np.asarray(measures)
-        check_1d_shape(measures, "measures", self.measure_dim, "measure_dim")
+        check_shape(measures, "measures", self.measure_dim, "measure_dim")
         check_finite(measures, "measures")
 
         occupied, data = self.retrieve(measures[None])

--- a/ribs/emitters/_evolution_strategy_emitter.py
+++ b/ribs/emitters/_evolution_strategy_emitter.py
@@ -3,7 +3,7 @@ import numbers
 
 import numpy as np
 
-from ribs._utils import check_1d_shape, validate_batch_args
+from ribs._utils import check_shape, validate_batch_args
 from ribs.emitters._emitter_base import EmitterBase
 from ribs.emitters.opt import _get_es
 from ribs.emitters.rankers import _get_ranker
@@ -94,8 +94,8 @@ class EvolutionStrategyEmitter(EmitterBase):
     ):
         self._rng = np.random.default_rng(seed)
         self._x0 = np.array(x0, dtype=archive.dtype)
-        check_1d_shape(self._x0, "x0", archive.solution_dim,
-                       "archive.solution_dim")
+        check_shape(self._x0, "x0", archive.solution_dim,
+                    "archive.solution_dim")
         self._sigma0 = sigma0
         EmitterBase.__init__(
             self,

--- a/ribs/emitters/_gaussian_emitter.py
+++ b/ribs/emitters/_gaussian_emitter.py
@@ -1,7 +1,7 @@
 """Provides the GaussianEmitter."""
 import numpy as np
 
-from ribs._utils import check_1d_shape, check_batch_shape
+from ribs._utils import check_batch_shape, check_shape
 from ribs.emitters._emitter_base import EmitterBase
 from ribs.emitters.operators import GaussianOperator
 
@@ -72,8 +72,8 @@ class GaussianEmitter(EmitterBase):
 
         if x0 is not None:
             self._x0 = np.array(x0, dtype=archive.dtype)
-            check_1d_shape(self._x0, "x0", archive.solution_dim,
-                           "archive.solution_dim")
+            check_shape(self._x0, "x0", archive.solution_dim,
+                        "archive.solution_dim")
         elif initial_solutions is not None:
             self._initial_solutions = np.asarray(initial_solutions,
                                                  dtype=archive.dtype)

--- a/ribs/emitters/_gradient_arborescence_emitter.py
+++ b/ribs/emitters/_gradient_arborescence_emitter.py
@@ -3,7 +3,7 @@ import numbers
 
 import numpy as np
 
-from ribs._utils import check_1d_shape, validate_batch_args
+from ribs._utils import check_shape, validate_batch_args
 from ribs.emitters._emitter_base import EmitterBase
 from ribs.emitters.opt import _get_es, _get_grad_opt
 from ribs.emitters.rankers import _get_ranker
@@ -163,8 +163,8 @@ class GradientArborescenceEmitter(EmitterBase):
         self._epsilon = epsilon
         self._rng = np.random.default_rng(seed)
         self._x0 = np.array(x0, dtype=archive.dtype)
-        check_1d_shape(self._x0, "x0", archive.solution_dim,
-                       "archive.solution_dim")
+        check_shape(self._x0, "x0", archive.solution_dim,
+                    "archive.solution_dim")
         self._sigma0 = sigma0
         self._normalize_grads = normalize_grad
         self._jacobian_batch = None

--- a/ribs/emitters/_gradient_operator_emitter.py
+++ b/ribs/emitters/_gradient_operator_emitter.py
@@ -3,7 +3,7 @@ import numbers
 
 import numpy as np
 
-from ribs._utils import check_1d_shape, check_batch_shape, validate_batch_args
+from ribs._utils import check_batch_shape, check_shape, validate_batch_args
 from ribs.emitters._emitter_base import EmitterBase
 
 
@@ -131,8 +131,8 @@ class GradientOperatorEmitter(EmitterBase):
 
         if x0 is not None:
             self._x0 = np.array(x0, dtype=archive.dtype)
-            check_1d_shape(self._x0, "x0", archive.solution_dim,
-                           "archive.solution_dim")
+            check_shape(self._x0, "x0", archive.solution_dim,
+                        "archive.solution_dim")
         elif initial_solutions is not None:
             self._initial_solutions = np.asarray(initial_solutions,
                                                  dtype=archive.dtype)

--- a/ribs/emitters/_iso_line_emitter.py
+++ b/ribs/emitters/_iso_line_emitter.py
@@ -1,7 +1,7 @@
 """Provides the IsoLineEmitter."""
 import numpy as np
 
-from ribs._utils import check_1d_shape, check_batch_shape
+from ribs._utils import check_batch_shape, check_shape
 from ribs.emitters._emitter_base import EmitterBase
 from ribs.emitters.operators import IsoLineOperator
 
@@ -80,8 +80,8 @@ class IsoLineEmitter(EmitterBase):
 
         if x0 is not None:
             self._x0 = np.array(x0, dtype=archive.dtype)
-            check_1d_shape(self._x0, "x0", archive.solution_dim,
-                           "archive.solution_dim")
+            check_shape(self._x0, "x0", archive.solution_dim,
+                        "archive.solution_dim")
         elif initial_solutions is not None:
             self._initial_solutions = np.asarray(initial_solutions,
                                                  dtype=archive.dtype)


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the PR's purpose here. -->

There is currently a check called `check_1d_shape`; we can instead make it a general `check_shape` function to check arbitrary shapes.

## TODO

<!-- Notable points that this PR has either accomplished or will accomplish. -->

- [x] Generalize function
- [x] Fix calls

## Questions

<!-- Any concerns or points of confusion? -->

## Status

- [x] I have read the guidelines in
      [CONTRIBUTING.md](https://github.com/icaros-usc/pyribs/blob/master/CONTRIBUTING.md)
- [x] I have formatted my code using `yapf`
- [x] I have tested my code by running `pytest`
- [x] I have linted my code with `pylint`
- [N/A] I have added a one-line description of my change to the changelog in
      `HISTORY.md`
- [x] This PR is ready to go
