### PR TITLE
Remove batch name from remaining archive methods

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -7,8 +7,8 @@
 #### API
 
 - Support custom data fields in archive ({pr}`421`)
-- **Backwards-incompatible:** Remove `_batch` from archive add() parameter names
-  ({pr}`422`)
+- **Backwards-incompatible:** Remove `_batch` from archive method parameter
+  names ({pr}`422`, {pr}`423`)
 - Add Gaussian, IsoLine Operators and Refactor GaussianEmitter/IsoLineEmitter
   ({pr}`418`)
 - **Backwards-incompatible:** Remove metadata in favor of custom fields

--- a/ribs/archives/_archive_base.py
+++ b/ribs/archives/_archive_base.py
@@ -236,15 +236,15 @@ class ArchiveBase(ABC):
         self._stats_reset()
 
     @abstractmethod
-    def index_of(self, measures_batch):
+    def index_of(self, measures):
         """Returns archive indices for the given batch of measures.
 
         If you need to retrieve the index of the measures for a *single*
         solution, consider using :meth:`index_of_single`.
 
         Args:
-            measures_batch (array-like): (batch_size, :attr:`measure_dim`)
-                array of coordinates in measure space.
+            measures(array-like): (batch_size, :attr:`measure_dim`) array of
+                coordinates in measure space.
         Returns:
             (numpy.ndarray): (batch_size,) array with the indices of the
             batch of measures in the archive's storage arrays.
@@ -505,7 +505,7 @@ class ArchiveBase(ABC):
 
         return add_info["status"][0], add_info["value"][0]
 
-    def retrieve(self, measures_batch):
+    def retrieve(self, measures):
         """Retrieves the elites with measures in the same cells as the measures
         specified.
 
@@ -524,12 +524,12 @@ class ArchiveBase(ABC):
         ``elites["solution"][i]``, ``elites["objective"][i]``,
         ``elites["measures"][i]``, ``elites["threshold"][i]``, and
         ``elites["index"][i]`` will be set to the properties of the elite. Note
-        that ``elites["measures"][i]`` may not be equal to the
-        ``measures_batch[i]`` passed as an argument, since the measures only
-        need to be in the same archive cell.
+        that ``elites["measures"][i]`` may not be equal to the ``measures[i]``
+        passed as an argument, since the measures only need to be in the same
+        archive cell.
 
-        If the cell associated with ``measures_batch[i]`` *does not* have any
-        elite in it, then ``occupied[i]`` will be set to False. Furthermore, the
+        If the cell associated with ``measures[i]`` *does not* have any elite in
+        it, then ``occupied[i]`` will be set to False. Furthermore, the
         corresponding outputs will be set to empty values -- namely:
 
         * NaN for floating-point fields
@@ -541,25 +541,23 @@ class ArchiveBase(ABC):
         consider using :meth:`retrieve_single`.
 
         Args:
-            measures_batch (array-like): (batch_size, :attr:`measure_dim`)
-                array of coordinates in measure space.
+            measures (array-like): (batch_size, :attr:`measure_dim`) array of
+                coordinates in measure space.
         Returns:
             tuple: 2-element tuple of (occupied array, dict). The occupied array
-            indicates whether each of the cells indicated by the measures in
-            measures_batch has an elite, while the dict contains the data of
-            those elites. The dict maps from field name to the corresponding
-            array.
+            indicates whether each of the cells indicated by the coordinates in
+            ``measures`` has an elite, while the dict contains the data of those
+            elites. The dict maps from field name to the corresponding array.
         Raises:
-            ValueError: ``measures_batch`` is not of shape (batch_size,
+            ValueError: ``measures`` is not of shape (batch_size,
                 :attr:`measure_dim`).
-            ValueError: ``measures_batch`` has non-finite values (inf or NaN).
+            ValueError: ``measures`` has non-finite values (inf or NaN).
         """
-        measures_batch = np.asarray(measures_batch)
-        check_batch_shape(measures_batch, "measures_batch", self.measure_dim,
-                          "measure_dim")
-        check_finite(measures_batch, "measures_batch")
+        measures = np.asarray(measures)
+        check_batch_shape(measures, "measures", self.measure_dim, "measure_dim")
+        check_finite(measures, "measures")
 
-        occupied, data = self._store.retrieve(self.index_of(measures_batch))
+        occupied, data = self._store.retrieve(self.index_of(measures))
         unoccupied = ~occupied
 
         for name, arr in data.items():

--- a/ribs/archives/_archive_base.py
+++ b/ribs/archives/_archive_base.py
@@ -243,7 +243,7 @@ class ArchiveBase(ABC):
         solution, consider using :meth:`index_of_single`.
 
         Args:
-            measures(array-like): (batch_size, :attr:`measure_dim`) array of
+            measures (array-like): (batch_size, :attr:`measure_dim`) array of
                 coordinates in measure space.
         Returns:
             (numpy.ndarray): (batch_size,) array with the indices of the

--- a/ribs/archives/_archive_data_frame.py
+++ b/ribs/archives/_archive_data_frame.py
@@ -51,10 +51,10 @@ class ArchiveDataFrame(pd.DataFrame):
         **Thus, if you need to use the method several times, we recommend
         storing it first, like so**::
 
-            measures_batch = df.get_field("measures")
-            measures_batch[0]
-            measures_batch.mean()
-            measures_batch.median()
+            measures = df.get_field("measures")
+            measures[0]
+            measures.mean()
+            measures.median()
 
     .. note::
 

--- a/ribs/archives/_cvt_archive.py
+++ b/ribs/archives/_cvt_archive.py
@@ -243,42 +243,41 @@ class CVTArchive(ArchiveBase):
         """
         return self._centroids
 
-    def index_of(self, measures_batch):
+    def index_of(self, measures):
         """Finds the indices of the centroid closest to the given coordinates in
         measure space.
 
         If ``index_batch`` is the batch of indices returned by this method, then
         ``archive.centroids[index_batch[i]]`` holds the coordinates of the
-        centroid closest to ``measures_batch[i]``. See :attr:`centroids` for
-        more info.
+        centroid closest to ``measures[i]``. See :attr:`centroids` for more
+        info.
 
         The centroid indices are located using either the k-D tree or brute
         force, depending on the value of ``use_kd_tree`` in the constructor.
 
         Args:
-            measures_batch (array-like): (batch_size, :attr:`measure_dim`)
-                array of coordinates in measure space.
+            measures (array-like): (batch_size, :attr:`measure_dim`) array of
+                coordinates in measure space.
         Returns:
             numpy.ndarray: (batch_size,) array of centroid indices
             corresponding to each measure space coordinate.
         Raises:
-            ValueError: ``measures_batch`` is not of shape (batch_size,
+            ValueError: ``measures`` is not of shape (batch_size,
                 :attr:`measure_dim`).
-            ValueError: ``measures_batch`` has non-finite values (inf or NaN).
+            ValueError: ``measures`` has non-finite values (inf or NaN).
         """
-        measures_batch = np.asarray(measures_batch)
-        check_batch_shape(measures_batch, "measures_batch", self.measure_dim,
-                          "measure_dim")
-        check_finite(measures_batch, "measures_batch")
+        measures = np.asarray(measures)
+        check_batch_shape(measures, "measures", self.measure_dim, "measure_dim")
+        check_finite(measures, "measures")
 
         if self._use_kd_tree:
-            _, indices = self._centroid_kd_tree.query(measures_batch)
+            _, indices = self._centroid_kd_tree.query(measures)
             return indices.astype(np.int32)
         else:
-            expanded_measures = np.expand_dims(measures_batch, axis=1)
+            expanded_measures = np.expand_dims(measures, axis=1)
             # Compute indices chunks at a time
             if self._chunk_size is not None and \
-                    self._chunk_size < measures_batch.shape[0]:
+                    self._chunk_size < measures.shape[0]:
                 indices = []
                 chunks = np.array_split(
                     expanded_measures,

--- a/ribs/visualize/_cvt_archive_heatmap.py
+++ b/ribs/visualize/_cvt_archive_heatmap.py
@@ -85,9 +85,9 @@ def cvt_archive_heatmap(archive,
             >>> archive = CVTArchive(solution_dim=2,
             ...                      cells=20, ranges=[(-1, 1)])
             >>> x = np.random.uniform(-1, 1, 1000)
-            >>> archive.add(solution_batch=np.stack((x, x), axis=1),
-            ...             objective_batch=-x**2,
-            ...             measures_batch=x[:, None])
+            >>> archive.add(solution=np.stack((x, x), axis=1),
+            ...             objective=-x**2,
+            ...             measures=x[:, None])
             >>> # Plot a heatmap of the archive.
             >>> plt.figure(figsize=(8, 6))
             >>> cvt_archive_heatmap(archive)


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the PR's purpose here. -->

Continuation of #422. Note that I still use measures_batch and other batch names inside of methods themselves when it is necessary to have clarity.

## TODO

<!-- Notable points that this PR has either accomplished or will accomplish. -->

- [x] Rename measures_batch to measures in `index_of`
- [x] Rename measures_batch to measures in `retrieve`

## Questions

<!-- Any concerns or points of confusion? -->

## Status

- [x] I have read the guidelines in
      [CONTRIBUTING.md](https://github.com/icaros-usc/pyribs/blob/master/CONTRIBUTING.md)
- [x] I have formatted my code using `yapf`
- [x] I have tested my code by running `pytest`
- [x] I have linted my code with `pylint`
- [x] I have added a one-line description of my change to the changelog in
      `HISTORY.md`
- [x] This PR is ready to go
