### PR TITLE
Remove `_batch` from scheduler tell() parameter names

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -8,7 +8,7 @@
 
 - Support custom data fields in archive ({pr}`421`)
 - **Backwards-incompatible:** Remove `_batch` from parameter names ({pr}`422`,
-  {pr}`423`, {pr}`424`)
+  {pr}`423`, {pr}`425`)
 - Add Gaussian, IsoLine Operators and Refactor GaussianEmitter/IsoLineEmitter
   ({pr}`418`)
 - **Backwards-incompatible:** Remove metadata in favor of custom fields

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -7,8 +7,8 @@
 #### API
 
 - Support custom data fields in archive ({pr}`421`)
-- **Backwards-incompatible:** Remove `_batch` from archive method parameter
-  names ({pr}`422`, {pr}`423`)
+- **Backwards-incompatible:** Remove `_batch` from parameter names ({pr}`422`,
+  {pr}`423`, {pr}`424`)
 - Add Gaussian, IsoLine Operators and Refactor GaussianEmitter/IsoLineEmitter
   ({pr}`418`)
 - **Backwards-incompatible:** Remove metadata in favor of custom fields

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -8,7 +8,7 @@
 
 - Support custom data fields in archive ({pr}`421`)
 - **Backwards-incompatible:** Remove `_batch` from parameter names ({pr}`422`,
-  {pr}`423`, {pr}`425`)
+  {pr}`424`, {pr}`425`)
 - Add Gaussian, IsoLine Operators and Refactor GaussianEmitter/IsoLineEmitter
   ({pr}`418`)
 - **Backwards-incompatible:** Remove metadata in favor of custom fields

--- a/ribs/schedulers/_bandit_scheduler.py
+++ b/ribs/schedulers/_bandit_scheduler.py
@@ -148,7 +148,7 @@ class BanditScheduler:
         # ask() or tell().
         self._last_called = None
         # The last set of solutions returned by ask().
-        self._solution_batch = []
+        self._cur_solutions = []
         # The number of solutions created by each emitter.
         self._num_emitted = np.array([None for _ in self._active_arr])
 
@@ -257,30 +257,42 @@ class BanditScheduler:
             activate = np.argsort(ucb1)[-reselect.sum():]
             self._active_arr[activate] = True
 
-        self._solution_batch = []
+        self._cur_solutions = []
 
         for i in np.where(self._active_arr)[0]:
             emitter = self._emitter_pool[i]
             emitter_sols = emitter.ask()
-            self._solution_batch.append(emitter_sols)
+            self._cur_solutions.append(emitter_sols)
             self._num_emitted[i] = len(emitter_sols)
 
         # In case the emitters didn't return any solutions.
-        self._solution_batch = np.concatenate(
-            self._solution_batch, axis=0) if self._solution_batch else np.empty(
+        self._cur_solutions = np.concatenate(
+            self._cur_solutions, axis=0) if self._cur_solutions else np.empty(
                 (0, self._solution_dim))
-        return self._solution_batch
+        return self._cur_solutions
 
-    def _check_length(self, name, array):
+    def _check_length(self, name, arr):
         """Raises a ValueError if array does not have the same length as the
         solutions."""
-        if len(array) != len(self._solution_batch):
+        if len(arr) != len(self._cur_solutions):
             raise ValueError(
-                f"{name} should have length {len(self._solution_batch)} "
+                f"{name} should have length {len(self._cur_solutions)} "
                 "(this is the number of solutions output by ask()) but "
-                f"has length {len(array)}")
+                f"has length {len(arr)}")
 
-    def tell_dqd(self, objective_batch, measures_batch, jacobian_batch):
+    def _validate_tell_data(self, data):
+        """Preprocesses data passed into tell methods."""
+        for name, arr in data.items():
+            data[name] = np.asarray(arr)
+            self._check_length(name, arr)
+
+        # Convenient to have solutions be part of data, so that everything is
+        # just one dict.
+        data["solution"] = self._cur_solutions
+
+        return data
+
+    def tell_dqd(self, objective, measures, jacobian):
         """Returns info for solutions from :meth:`ask_dqd`.
 
         This method is not supported for this scheduler and throws an error if
@@ -293,7 +305,7 @@ class BanditScheduler:
         raise NotImplementedError("tell_dqd() is not supported by"
                                   "BanditScheduler.")
 
-    def tell(self, objective_batch, measures_batch):
+    def tell(self, objective, measures):
         """Returns info for solutions from :meth:`ask`.
 
         The emitters are the same with those used in the last call to
@@ -318,11 +330,10 @@ class BanditScheduler:
             raise RuntimeError("tell() was called without calling ask().")
         self._last_called = "tell"
 
-        objective_batch = np.asarray(objective_batch)
-        measures_batch = np.asarray(measures_batch)
-
-        self._check_length("objective_batch", objective_batch)
-        self._check_length("measures_batch", measures_batch)
+        data = self._validate_tell_data({
+            "objective": objective,
+            "measures": measures,
+        })
 
         archive_empty_before = self.archive.empty
         if self._result_archive is not None:
@@ -332,31 +343,25 @@ class BanditScheduler:
 
         # Add solutions to the archive.
         if self._add_mode == "batch":
-            status_batch, value_batch = self.archive.add(
-                self._solution_batch,
-                objective_batch,
-                measures_batch,
-            )
+            status_batch, value_batch = self.archive.add(**data)
 
             # Add solutions to result_archive.
             if self._result_archive is not None:
-                self._result_archive.add(self._solution_batch, objective_batch,
-                                         measures_batch)
+                self._result_archive.add(**data)
         elif self._add_mode == "single":
             status_batch = []
             value_batch = []
-            for solution, objective, measure in zip(self._solution_batch,
-                                                    objective_batch,
-                                                    measures_batch):
-                status, value = self.archive.add_single(solution, objective,
-                                                        measure)
+
+            for i in range(len(self._cur_solutions)):
+                single_data = {name: arr[i] for name, arr in data.items()}
+                status, value = self.archive.add_single(**single_data)
                 status_batch.append(status)
                 value_batch.append(value)
 
                 # Add solutions to result_archive.
                 if self._result_archive is not None:
-                    self._result_archive.add_single(solution, objective,
-                                                    measure)
+                    self._result_archive.add_single(**single_data)
+
             status_batch = np.asarray(status_batch)
             value_batch = np.asarray(value_batch)
 
@@ -377,7 +382,7 @@ class BanditScheduler:
             end = pos + n
             self._selection[i] += n
             self._success[i] += np.count_nonzero(status_batch[pos:end])
-            emitter.tell(self._solution_batch[pos:end],
-                         objective_batch[pos:end], measures_batch[pos:end],
+            emitter.tell(self._cur_solutions[pos:end],
+                         data["objective"][pos:end], data["measures"][pos:end],
                          status_batch[pos:end], value_batch[pos:end])
             pos = end

--- a/ribs/schedulers/_scheduler.py
+++ b/ribs/schedulers/_scheduler.py
@@ -105,7 +105,7 @@ class Scheduler:
         # ask() or tell().
         self._last_called = None
         # The last set of solutions returned by ask().
-        self._solution_batch = []
+        self._cur_solutions = []
         # The number of solutions created by each emitter.
         self._num_emitted = [None for _ in self._emitters]
 
@@ -150,18 +150,18 @@ class Scheduler:
                                self._last_called)
         self._last_called = "ask_dqd"
 
-        self._solution_batch = []
+        self._cur_solutions = []
 
         for i, emitter in enumerate(self._emitters):
             emitter_sols = emitter.ask_dqd()
-            self._solution_batch.append(emitter_sols)
+            self._cur_solutions.append(emitter_sols)
             self._num_emitted[i] = len(emitter_sols)
 
         # In case the emitters didn't return any solutions.
-        self._solution_batch = np.concatenate(
-            self._solution_batch, axis=0) if self._solution_batch else np.empty(
+        self._cur_solutions = np.concatenate(
+            self._cur_solutions, axis=0) if self._cur_solutions else np.empty(
                 (0, self._solution_dim))
-        return self._solution_batch
+        return self._cur_solutions
 
     def ask(self):
         """Generates a batch of solutions by calling ask() on all emitters.
@@ -181,27 +181,39 @@ class Scheduler:
                                self._last_called)
         self._last_called = "ask"
 
-        self._solution_batch = []
+        self._cur_solutions = []
 
         for i, emitter in enumerate(self._emitters):
             emitter_sols = emitter.ask()
-            self._solution_batch.append(emitter_sols)
+            self._cur_solutions.append(emitter_sols)
             self._num_emitted[i] = len(emitter_sols)
 
         # In case the emitters didn't return any solutions.
-        self._solution_batch = np.concatenate(
-            self._solution_batch, axis=0) if self._solution_batch else np.empty(
+        self._cur_solutions = np.concatenate(
+            self._cur_solutions, axis=0) if self._cur_solutions else np.empty(
                 (0, self._solution_dim))
-        return self._solution_batch
+        return self._cur_solutions
 
-    def _check_length(self, name, array):
+    def _check_length(self, name, arr):
         """Raises a ValueError if array does not have the same length as the
         solutions."""
-        if len(array) != len(self._solution_batch):
+        if len(arr) != len(self._cur_solutions):
             raise ValueError(
-                f"{name} should have length {len(self._solution_batch)} "
+                f"{name} should have length {len(self._cur_solutions)} "
                 "(this is the number of solutions output by ask()) but "
-                f"has length {len(array)}")
+                f"has length {len(arr)}")
+
+    def _validate_tell_data(self, data):
+        """Preprocesses data passed into tell methods."""
+        for name, arr in data.items():
+            data[name] = np.asarray(arr)
+            self._check_length(name, arr)
+
+        # Convenient to have solutions be part of data, so that everything is
+        # just one dict.
+        data["solution"] = self._cur_solutions
+
+        return data
 
     EMPTY_WARNING = (
         "`{name}` was empty before adding solutions, and it is still empty "
@@ -210,14 +222,8 @@ class Scheduler:
         "archive, i.e., solutions are not being inserted because their "
         "objective value does not exceed `threshold_min`.")
 
-    def _tell_internal(self, objective_batch, measures_batch):
-        """Internal method that handles duplicate subroutine between
-        :meth:`tell` and :meth:`tell_dqd`."""
-        objective_batch = np.asarray(objective_batch)
-        measures_batch = np.asarray(measures_batch)
-
-        self._check_length("objective_batch", objective_batch)
-        self._check_length("measures_batch", measures_batch)
+    def _add_to_archives(self, data):
+        """Adds solutions to both the regular archive and the result archive."""
 
         archive_empty_before = self.archive.empty
         if self._result_archive is not None:
@@ -227,31 +233,25 @@ class Scheduler:
 
         # Add solutions to the archive.
         if self._add_mode == "batch":
-            status_batch, value_batch = self.archive.add(
-                self._solution_batch,
-                objective_batch,
-                measures_batch,
-            )
+            status_batch, value_batch = self.archive.add(**data)
 
             # Add solutions to result_archive.
             if self._result_archive is not None:
-                self._result_archive.add(self._solution_batch, objective_batch,
-                                         measures_batch)
+                self._result_archive.add(**data)
         elif self._add_mode == "single":
             status_batch = []
             value_batch = []
-            for solution, objective, measure in zip(self._solution_batch,
-                                                    objective_batch,
-                                                    measures_batch):
-                status, value = self.archive.add_single(solution, objective,
-                                                        measure)
+
+            for i in range(len(self._cur_solutions)):
+                single_data = {name: arr[i] for name, arr in data.items()}
+                status, value = self.archive.add_single(**single_data)
                 status_batch.append(status)
                 value_batch.append(value)
 
                 # Add solutions to result_archive.
                 if self._result_archive is not None:
-                    self._result_archive.add_single(solution, objective,
-                                                    measure)
+                    self._result_archive.add_single(**single_data)
+
             status_batch = np.asarray(status_batch)
             value_batch = np.asarray(value_batch)
 
@@ -262,28 +262,22 @@ class Scheduler:
             if result_archive_empty_before and self.result_archive.empty:
                 warnings.warn(self.EMPTY_WARNING.format(name="result_archive"))
 
-        return (
-            objective_batch,
-            measures_batch,
-            status_batch,
-            value_batch,
-        )
+        return status_batch, value_batch
 
-    def tell_dqd(self, objective_batch, measures_batch, jacobian_batch):
+    def tell_dqd(self, objective, measures, jacobian):
         """Returns info for solutions from :meth:`ask_dqd`.
 
         .. note:: The objective batch, measures batch, and jacobian batch must
             be in the same order as the solutions created by :meth:`ask_dqd`;
-            i.e. ``objective_batch[i]``, ``measures_batch[i]``, and
-            ``jacobian_batch[i]`` should be the objective, measures, and
-            jacobian for ``solution_batch[i]``.
+            i.e. ``objective[i]``, ``measures[i]``, and ``jacobian[i]`` should
+            be the objective, measures, and jacobian for ``solution[i]``.
 
         Args:
-            objective_batch ((batch_size,) array): Each entry of this array
-                contains the objective function evaluation of a solution.
-            measures_batch ((batch_size, measure_dim) array): Each row of
-                this array contains a solution's coordinates in measure space.
-            jacobian_batch (numpy.ndarray): ``(batch_size, 1 + measure_dim,
+            objective ((batch_size,) array): Each entry of this array contains
+                the objective function evaluation of a solution.
+            measures ((batch_size, measure_dim) array): Each row of this array
+                contains a solution's coordinates in measure space.
+            jacobian (numpy.ndarray): ``(batch_size, 1 + measure_dim,
                 solution_dim)`` array consisting of Jacobian matrices of the
                 solutions obtained from :meth:`ask_dqd`. Each matrix should
                 consist of the objective gradient of the solution followed by
@@ -298,36 +292,39 @@ class Scheduler:
                 "tell_dqd() was called without calling ask_dqd().")
         self._last_called = "tell_dqd"
 
-        (
-            objective_batch,
-            measures_batch,
-            status_batch,
-            value_batch,
-        ) = self._tell_internal(objective_batch, measures_batch)
+        data = self._validate_tell_data({
+            "objective": objective,
+            "measures": measures,
+        })
+
+        jacobian = np.asarray(jacobian)
+        self._check_length("jacobian", jacobian)
+
+        status_batch, value_batch = self._add_to_archives(data)
 
         # Keep track of pos because emitters may have different batch sizes.
         pos = 0
         for emitter, n in zip(self._emitters, self._num_emitted):
             end = pos + n
-            emitter.tell_dqd(self._solution_batch[pos:end],
-                             objective_batch[pos:end], measures_batch[pos:end],
-                             jacobian_batch[pos:end], status_batch[pos:end],
-                             value_batch[pos:end])
+            emitter.tell_dqd(self._cur_solutions[pos:end],
+                             data["objective"][pos:end],
+                             data["measures"][pos:end], jacobian[pos:end],
+                             status_batch[pos:end], value_batch[pos:end])
             pos = end
 
-    def tell(self, objective_batch, measures_batch):
+    def tell(self, objective, measures):
         """Returns info for solutions from :meth:`ask`.
 
         .. note:: The objective batch and measures batch must be in the same
             order as the solutions created by :meth:`ask_dqd`; i.e.
-            ``objective_batch[i]`` and ``measures_batch[i]`` should be the
-            objective and measures for ``solution_batch[i]``.
+            ``objective[i]`` and ``measures[i]`` should be the objective and
+            measures for ``solution[i]``.
 
         Args:
-            objective_batch ((batch_size,) array): Each entry of this array
-                contains the objective function evaluation of a solution.
-            measures_batch ((batch_size, measures_dm) array): Each row of
-                this array contains a solution's coordinates in measure space.
+            objective ((batch_size,) array): Each entry of this array contains
+                the objective function evaluation of a solution.
+            measures ((batch_size, measures_dm) array): Each row of this array
+                contains a solution's coordinates in measure space.
         Raises:
             RuntimeError: This method is called without first calling
                 :meth:`ask`.
@@ -337,18 +334,18 @@ class Scheduler:
             raise RuntimeError("tell() was called without calling ask().")
         self._last_called = "tell"
 
-        (
-            objective_batch,
-            measures_batch,
-            status_batch,
-            value_batch,
-        ) = self._tell_internal(objective_batch, measures_batch)
+        data = self._validate_tell_data({
+            "objective": objective,
+            "measures": measures,
+        })
+
+        status_batch, value_batch = self._add_to_archives(data)
 
         # Keep track of pos because emitters may have different batch sizes.
         pos = 0
         for emitter, n in zip(self._emitters, self._num_emitted):
             end = pos + n
-            emitter.tell(self._solution_batch[pos:end],
-                         objective_batch[pos:end], measures_batch[pos:end],
+            emitter.tell(self._cur_solutions[pos:end],
+                         data["objective"][pos:end], data["measures"][pos:end],
                          status_batch[pos:end], value_batch[pos:end])
             pos = end

--- a/tests/schedulers/scheduler_test.py
+++ b/tests/schedulers/scheduler_test.py
@@ -99,9 +99,9 @@ def test_warn_nothing_added_to_archive(archive_type):
     with pytest.warns(UserWarning):
         scheduler.tell(
             # All objectives are below threshold_min of 1.0.
-            objective_batch=np.zeros(4),
+            objective=np.zeros(4),
             # Arbitrary measures.
-            measures_batch=np.linspace(-1, 1, 4 * 2).reshape((4, 2)),
+            measures=np.linspace(-1, 1, 4 * 2).reshape((4, 2)),
         )
 
 
@@ -134,9 +134,9 @@ def test_warn_nothing_added_to_result_archive(archive_type):
     with pytest.warns(UserWarning):
         scheduler.tell(
             # All objectives are below threshold_min of 1.0.
-            objective_batch=np.zeros(4),
+            objective=np.zeros(4),
             # Arbitrary measures.
-            measures_batch=np.linspace(-1, 1, 4 * 2).reshape((4, 2)),
+            measures=np.linspace(-1, 1, 4 * 2).reshape((4, 2)),
         )
 
 


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the PR's purpose here. -->

Similar to #422, this removes `_batch` from parameter names in the scheduler. Even here, in a part of the API that is frequently used, I still anticipate that it will not affect users much, since most will pass in arguments positionally rather than as keywords.

## TODO

<!-- Notable points that this PR has either accomplished or will accomplish. -->

- [x] Rename in both schedulers
- [x] Check tests 

## Questions

<!-- Any concerns or points of confusion? -->

## Status

- [x] I have read the guidelines in
      [CONTRIBUTING.md](https://github.com/icaros-usc/pyribs/blob/master/CONTRIBUTING.md)
- [x] I have formatted my code using `yapf`
- [x] I have tested my code by running `pytest`
- [x] I have linted my code with `pylint`
- [x] I have added a one-line description of my change to the changelog in
      `HISTORY.md`
- [x] This PR is ready to go
