### PR TITLE
Support custom data fields in scheduler and emitters

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,7 +6,8 @@
 
 #### API
 
-- Support custom data fields in archive ({pr}`421`)
+- Support custom data fields in archive, emitters, and scheduler ({pr}`421`,
+  {pr}`429`)
 - **Backwards-incompatible:** Remove `_batch` from parameter names ({pr}`422`,
   {pr}`424`, {pr}`425`, {pr}`426`, {pr}`428`)
 - Add Gaussian, IsoLine Operators and Refactor GaussianEmitter/IsoLineEmitter

--- a/ribs/archives/_archive_base.py
+++ b/ribs/archives/_archive_base.py
@@ -407,7 +407,7 @@ class ArchiveBase(ABC):
             ValueError: ``objective`` or ``measures`` has non-finite values (inf
                 or NaN).
         """
-        new_data = validate_batch(
+        data = validate_batch(
             self,
             {
                 "solution": solution,
@@ -418,8 +418,8 @@ class ArchiveBase(ABC):
         )
 
         add_info = self._store.add(
-            self.index_of(new_data["measures"]),
-            new_data,
+            self.index_of(data["measures"]),
+            data,
             {
                 "dtype": self._dtype,
                 "learning_rate": self._learning_rate,
@@ -470,7 +470,7 @@ class ArchiveBase(ABC):
             ValueError: ``objective`` is non-finite (inf or NaN) or ``measures``
                 has non-finite values.
         """
-        new_data = validate_single(
+        data = validate_single(
             self,
             {
                 "solution": solution,
@@ -480,12 +480,12 @@ class ArchiveBase(ABC):
             },
         )
 
-        for name, arr in new_data.items():
-            new_data[name] = np.expand_dims(arr, axis=0)
+        for name, arr in data.items():
+            data[name] = np.expand_dims(arr, axis=0)
 
         add_info = self._store.add(
             np.expand_dims(self.index_of_single(measures), axis=0),
-            new_data,
+            data,
             {
                 "dtype": self._dtype,
                 "learning_rate": self._learning_rate,

--- a/ribs/archives/_array_store.py
+++ b/ribs/archives/_array_store.py
@@ -460,7 +460,10 @@ class ArrayStore:
         if new_data.keys() != self._fields.keys():
             raise ValueError(
                 f"`new_data` had keys {new_data.keys()} but should have the "
-                f"same keys as this ArrayStore, i.e., {self._fields.keys()}")
+                f"same keys as this ArrayStore, i.e., {self._fields.keys()}. "
+                "You may be seeing this error if your archive has "
+                "extra_fields but the fields were not passed into "
+                "archive.add() or scheduler.tell().")
 
         # Update occupancy data.
         unique_indices = np.where(aggregate(indices, 1, func="len") != 0)[0]

--- a/ribs/emitters/_emitter_base.py
+++ b/ribs/emitters/_emitter_base.py
@@ -103,7 +103,8 @@ class EmitterBase(ABC):
         """
         return np.empty((0, self.solution_dim), dtype=self.archive.dtype)
 
-    def tell(self, solution, objective, measures, status_batch, value_batch):
+    def tell(self, solution, objective, measures, status_batch, value_batch,
+             **fields):
         """Gives the emitter results from evaluating solutions.
 
         This base class implementation (in :class:`~ribs.emitters.EmitterBase`)
@@ -123,6 +124,9 @@ class EmitterBase(ABC):
                 series of calls to archive's :meth:`add_single()` method or by a
                 single call to archive's :meth:`add()`. For what these floats
                 represent, refer to :meth:`ribs.archives.add()`.
+            fields (keyword arguments): Additional data for each solution. Each
+                argument should be an array with batch_size as the first
+                dimension.
         """
 
     def ask_dqd(self):
@@ -135,7 +139,7 @@ class EmitterBase(ABC):
         return np.empty((0, self.solution_dim), dtype=self.archive.dtype)
 
     def tell_dqd(self, solution, objective, measures, jacobian, status_batch,
-                 value_batch):
+                 value_batch, **fields):
         """Gives the emitter results from evaluating the gradient of the
         solutions, only used for DQD emitters.
 
@@ -158,4 +162,7 @@ class EmitterBase(ABC):
             value_batch (numpy.ndarray): 1d array of floats returned by a series
                 of calls to archive's :meth:`add()` method. for what these
                 floats represent, refer to :meth:`ribs.archives.add()`.
+            fields (keyword arguments): Additional data for each solution. Each
+                argument should be an array with batch_size as the first
+                dimension.
         """

--- a/ribs/emitters/_evolution_strategy_emitter.py
+++ b/ribs/emitters/_evolution_strategy_emitter.py
@@ -183,7 +183,8 @@ class EvolutionStrategyEmitter(EmitterBase):
             return False
         raise ValueError(f"Invalid restart_rule {self._restart_rule}")
 
-    def tell(self, solution, objective, measures, status_batch, value_batch):
+    def tell(self, solution, objective, measures, status_batch, value_batch,
+             **fields):
         """Gives the emitter results from evaluating solutions.
 
         The solutions are ranked based on the `rank()` function defined by
@@ -206,6 +207,9 @@ class EvolutionStrategyEmitter(EmitterBase):
             value_batch (array-like): 1D array of floats returned by a series
                 of calls to archive's :meth:`add()` method. For what these
                 floats represent, refer to :meth:`ribs.archives.add()`.
+            fields (keyword arguments): Additional data for each solution. Each
+                argument should be an array with batch_size as the first
+                dimension.
         """
         data, add_info = validate_batch(
             self.archive,
@@ -213,6 +217,7 @@ class EvolutionStrategyEmitter(EmitterBase):
                 "solution": solution,
                 "objective": objective,
                 "measures": measures,
+                **fields,
             },
             {
                 "status": status_batch,

--- a/ribs/emitters/_gradient_arborescence_emitter.py
+++ b/ribs/emitters/_gradient_arborescence_emitter.py
@@ -312,7 +312,7 @@ class GradientArborescenceEmitter(EmitterBase):
         raise ValueError(f"Invalid restart_rule {self._restart_rule}")
 
     def tell_dqd(self, solution, objective, measures, jacobian, status_batch,
-                 value_batch):
+                 value_batch, **fields):
         """Gives the emitter results from evaluating the gradient of the
         solutions.
 
@@ -334,6 +334,9 @@ class GradientArborescenceEmitter(EmitterBase):
             value_batch (array-like): 1d array of floats returned by a series
                 of calls to archive's :meth:`add()` method. for what these
                 floats represent, refer to :meth:`ribs.archives.add()`.
+            fields (keyword arguments): Additional data for each solution. Each
+                argument should be an array with batch_size as the first
+                dimension.
         """
         data, add_info, jacobian = validate_batch(  # pylint: disable = unused-variable
             self.archive,
@@ -341,6 +344,7 @@ class GradientArborescenceEmitter(EmitterBase):
                 "solution": solution,
                 "objective": objective,
                 "measures": measures,
+                **fields,
             },
             {
                 "status": status_batch,
@@ -355,7 +359,8 @@ class GradientArborescenceEmitter(EmitterBase):
             jacobian /= norms
         self._jacobian_batch = jacobian
 
-    def tell(self, solution, objective, measures, status_batch, value_batch):
+    def tell(self, solution, objective, measures, status_batch, value_batch,
+             **fields):
         """Gives the emitter results from evaluating solutions.
 
         The solutions are ranked based on the `rank()` function defined by
@@ -374,6 +379,9 @@ class GradientArborescenceEmitter(EmitterBase):
             value_batch (array-like): 1d array of floats returned by a series
                 of calls to archive's :meth:`add()` method. for what these
                 floats represent, refer to :meth:`ribs.archives.add()`.
+            fields (keyword arguments): Additional data for each solution. Each
+                argument should be an array with batch_size as the first
+                dimension.
         Raises:
             RuntimeError: This method was called without first passing gradients
                 with calls to ask_dqd() and tell_dqd().
@@ -384,6 +392,7 @@ class GradientArborescenceEmitter(EmitterBase):
                 "solution": solution,
                 "objective": objective,
                 "measures": measures,
+                **fields,
             },
             {
                 "status": status_batch,

--- a/ribs/emitters/_gradient_operator_emitter.py
+++ b/ribs/emitters/_gradient_operator_emitter.py
@@ -289,7 +289,7 @@ class GradientOperatorEmitter(EmitterBase):
         return sols
 
     def tell_dqd(self, solution, objective, measures, jacobian, status_batch,
-                 value_batch):
+                 value_batch, **fields):
         """Gives the emitter results of evaluating solutions from ask_dqd().
 
         Args:
@@ -310,6 +310,9 @@ class GradientOperatorEmitter(EmitterBase):
             value_batch (array-like): 1d array of floats returned by a series
                 of calls to archive's :meth:`add()` method. for what these
                 floats represent, refer to :meth:`ribs.archives.add()`.
+            fields (keyword arguments): Additional data for each solution. Each
+                argument should be an array with batch_size as the first
+                dimension.
         """
         data, add_info, jacobian = validate_batch(  # pylint: disable = unused-variable
             self.archive,
@@ -317,6 +320,7 @@ class GradientOperatorEmitter(EmitterBase):
                 "solution": solution,
                 "objective": objective,
                 "measures": measures,
+                **fields,
             },
             {
                 "status": status_batch,

--- a/ribs/schedulers/_scheduler.py
+++ b/ribs/schedulers/_scheduler.py
@@ -310,7 +310,7 @@ class Scheduler:
         pos = 0
         for emitter, n in zip(self._emitters, self._num_emitted):
             end = pos + n
-            emitter.tell(
+            emitter.tell_dqd(
                 **{
                     name: arr[pos:end] for name, arr in data.items()
                 },

--- a/tests/archives/grid_archive_test.py
+++ b/tests/archives/grid_archive_test.py
@@ -32,6 +32,7 @@ def assert_archive_elites(
     objective_batch=None,
     measures_batch=None,
     grid_indices_batch=None,
+    metadata_batch=None,
 ):
     """Asserts that the archive contains a batch of elites.
 
@@ -63,8 +64,12 @@ def assert_archive_elites(
             index_match = (grid_indices_batch is None or
                            data["index"][j] == index_batch[i])
 
+            # Used for testing custom fields.
+            metadata_match = (metadata_batch is None or np.isclose(
+                data["metadata"][j], metadata_batch[i]).all())
+
             if (solution_match and objective_match and measures_match and
-                    index_match):
+                    index_match and metadata_match):
                 archive_covered[j] = True
 
     assert np.all(archive_covered)

--- a/tests/archives/grid_archive_test.py
+++ b/tests/archives/grid_archive_test.py
@@ -65,8 +65,8 @@ def assert_archive_elites(
                            data["index"][j] == index_batch[i])
 
             # Used for testing custom fields.
-            metadata_match = (metadata_batch is None or np.isclose(
-                data["metadata"][j], metadata_batch[i]).all())
+            metadata_match = (metadata_batch is None or
+                              data["metadata"][j] == metadata_batch[i])
 
             if (solution_match and objective_match and measures_match and
                     index_match and metadata_match):

--- a/tests/schedulers/scheduler_test.py
+++ b/tests/schedulers/scheduler_test.py
@@ -192,6 +192,35 @@ def test_tell_inserts_solutions_with_multiple_emitters(add_mode):
     )
 
 
+def test_tell_with_fields(add_mode):
+    batch_size = 4
+    archive = GridArchive(solution_dim=2,
+                          dims=[100, 100],
+                          ranges=[(-1, 1), (-1, 1)],
+                          extra_fields={"metadata": ((), object)})
+    emitters = [
+        GaussianEmitter(archive, sigma=1, x0=[0.0, 0.0], batch_size=batch_size)
+    ]
+    scheduler = Scheduler(archive, emitters, add_mode=add_mode)
+
+    measures_batch = [[1.0, 1.0], [-1.0, 1.0], [-1.0, -1.0], [1.0, -1.0]]
+
+    _ = scheduler.ask()  # Ignore the actual values of the solutions.
+    # We pass in 4 solutions with unique measures, so all should go into
+    # the archive.
+    scheduler.tell(np.ones(batch_size),
+                   measures_batch,
+                   metadata=["a", "b", "c", "d"])
+
+    assert_archive_elites(
+        archive=scheduler.archive,
+        batch_size=batch_size,
+        objective_batch=np.ones(batch_size),
+        measures_batch=measures_batch,
+        metadata_batch=["a", "b", "c", "d"],
+    )
+
+
 ### TESTS FOR OUT-OF-ORDER ASK-TELL ###
 
 


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the PR's purpose here. -->

This PR makes it possible to pass in custom data to schedulers and emitters. For instance, one can call

```python
scheduler.tell(objective, measures, my_data=[1,2,3], my_other_data=[4,5,6])
```

The same applies for tell_dqd, and also for emitter methods.

## TODO

<!-- Notable points that this PR has either accomplished or will accomplish. -->

- [x] Update scheduler signatures
- [x] Update emitter signatures
- [x] Miscellaneous edits to ArrayStore and archives
- [x] Write scheduler test

## Questions

<!-- Any concerns or points of confusion? -->

## Status

- [x] I have read the guidelines in
      [CONTRIBUTING.md](https://github.com/icaros-usc/pyribs/blob/master/CONTRIBUTING.md)
- [x] I have formatted my code using `yapf`
- [x] I have tested my code by running `pytest`
- [x] I have linted my code with `pylint`
- [x] I have added a one-line description of my change to the changelog in
      `HISTORY.md`
- [x] This PR is ready to go
