### PR TITLE
Replace status and value with add_info

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,8 +6,7 @@
 
 #### API
 
-- **Backwards-incompatible:** Return add_info as a dict in archive add method
-  ({pr}`430`)
+- **Backwards-incompatible:** Replace status and value with add_info ({pr}`430`)
 - Support custom data fields in archive, emitters, and scheduler ({pr}`421`,
   {pr}`429`)
 - **Backwards-incompatible:** Remove `_batch` from parameter names ({pr}`422`,

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,7 +6,8 @@
 
 #### API
 
-- Return add_info as a dict in archive add method ({pr}`430`)
+- **Backwards-incompatible:** Return add_info as a dict in archive add method
+  ({pr}`430`)
 - Support custom data fields in archive ({pr}`421`)
 - **Backwards-incompatible:** Remove `_batch` from parameter names ({pr}`422`,
   {pr}`424`, {pr}`425`, {pr}`426`, {pr}`428`)

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,6 +6,7 @@
 
 #### API
 
+- Return add_info as a dict in archive add method ({pr}`430`)
 - Support custom data fields in archive ({pr}`421`)
 - **Backwards-incompatible:** Remove `_batch` from parameter names ({pr}`422`,
   {pr}`424`, {pr}`425`, {pr}`426`, {pr}`428`)

--- a/ribs/emitters/_emitter_base.py
+++ b/ribs/emitters/_emitter_base.py
@@ -103,8 +103,7 @@ class EmitterBase(ABC):
         """
         return np.empty((0, self.solution_dim), dtype=self.archive.dtype)
 
-    def tell(self, solution, objective, measures, status_batch, value_batch,
-             **fields):
+    def tell(self, solution, objective, measures, add_info, **fields):
         """Gives the emitter results from evaluating solutions.
 
         This base class implementation (in :class:`~ribs.emitters.EmitterBase`)
@@ -117,13 +116,8 @@ class EmitterBase(ABC):
                 function value of each solution.
             measures (numpy.ndarray): ``(n, <measure space dimension>)`` array
                 with the measure space coordinates of each solution.
-            status_batch (numpy.ndarray): An array of integer statuses
-                returned by a series of calls to archive's :meth:`add_single()`
-                method or by a single call to archive's :meth:`add()`.
-            value_batch (numpy.ndarray): 1D array of floats returned by a
-                series of calls to archive's :meth:`add_single()` method or by a
-                single call to archive's :meth:`add()`. For what these floats
-                represent, refer to :meth:`ribs.archives.add()`.
+            add_info (dict): Data returned from the archive
+                :meth:`~ribs.archives.ArchiveBase.add` method.
             fields (keyword arguments): Additional data for each solution. Each
                 argument should be an array with batch_size as the first
                 dimension.
@@ -138,8 +132,8 @@ class EmitterBase(ABC):
         """
         return np.empty((0, self.solution_dim), dtype=self.archive.dtype)
 
-    def tell_dqd(self, solution, objective, measures, jacobian, status_batch,
-                 value_batch, **fields):
+    def tell_dqd(self, solution, objective, measures, jacobian, add_info,
+                 **fields):
         """Gives the emitter results from evaluating the gradient of the
         solutions, only used for DQD emitters.
 
@@ -156,12 +150,8 @@ class EmitterBase(ABC):
                 solutions obtained from :meth:`ask_dqd`. Each matrix should
                 consist of the objective gradient of the solution followed by
                 the measure gradients.
-            status_batch (numpy.ndarray): 1d array of
-                :class:`ribs.archive.addstatus` returned by a series of calls
-                to archive's :meth:`add()` method.
-            value_batch (numpy.ndarray): 1d array of floats returned by a series
-                of calls to archive's :meth:`add()` method. for what these
-                floats represent, refer to :meth:`ribs.archives.add()`.
+            add_info (dict): Data returned from the archive
+                :meth:`~ribs.archives.ArchiveBase.add` method.
             fields (keyword arguments): Additional data for each solution. Each
                 argument should be an array with batch_size as the first
                 dimension.

--- a/ribs/emitters/_evolution_strategy_emitter.py
+++ b/ribs/emitters/_evolution_strategy_emitter.py
@@ -183,8 +183,7 @@ class EvolutionStrategyEmitter(EmitterBase):
             return False
         raise ValueError(f"Invalid restart_rule {self._restart_rule}")
 
-    def tell(self, solution, objective, measures, status_batch, value_batch,
-             **fields):
+    def tell(self, solution, objective, measures, add_info, **fields):
         """Gives the emitter results from evaluating solutions.
 
         The solutions are ranked based on the `rank()` function defined by
@@ -201,12 +200,8 @@ class EvolutionStrategyEmitter(EmitterBase):
                 value of each solution.
             measures (array-like): (batch_size, measure space dimension) array
                 with the measure space coordinates of each solution.
-            status_batch (array-like): 1D array of
-                :class:`ribs.archive.AddStatus` returned by a series of calls
-                to archive's :meth:`add()` method.
-            value_batch (array-like): 1D array of floats returned by a series
-                of calls to archive's :meth:`add()` method. For what these
-                floats represent, refer to :meth:`ribs.archives.add()`.
+            add_info (dict): Data returned from the archive
+                :meth:`~ribs.archives.ArchiveBase.add` method.
             fields (keyword arguments): Additional data for each solution. Each
                 argument should be an array with batch_size as the first
                 dimension.
@@ -219,17 +214,14 @@ class EvolutionStrategyEmitter(EmitterBase):
                 "measures": measures,
                 **fields,
             },
-            {
-                "status": status_batch,
-                "value": value_batch,
-            },
+            add_info,
         )
 
         # Increase iteration counter.
         self._itrs += 1
 
         # Count number of new solutions.
-        new_sols = status_batch.astype(bool).sum()
+        new_sols = add_info["status"].astype(bool).sum()
 
         # Sort the solutions using ranker.
         indices, ranking_values = self._ranker.rank(self, self.archive,

--- a/ribs/emitters/_gradient_operator_emitter.py
+++ b/ribs/emitters/_gradient_operator_emitter.py
@@ -288,8 +288,8 @@ class GradientOperatorEmitter(EmitterBase):
 
         return sols
 
-    def tell_dqd(self, solution, objective, measures, jacobian, status_batch,
-                 value_batch, **fields):
+    def tell_dqd(self, solution, objective, measures, jacobian, add_info,
+                 **fields):
         """Gives the emitter results of evaluating solutions from ask_dqd().
 
         Args:
@@ -304,12 +304,8 @@ class GradientOperatorEmitter(EmitterBase):
                 from :meth:`ask_dqd`. Each matrix should consist of the
                 objective gradient of the solution followed by the measure
                 gradients.
-            status_batch (array-like): 1d array of
-                :class:`ribs.archive.addstatus` returned by a series of calls
-                to archive's :meth:`add()` method.
-            value_batch (array-like): 1d array of floats returned by a series
-                of calls to archive's :meth:`add()` method. for what these
-                floats represent, refer to :meth:`ribs.archives.add()`.
+            add_info (dict): Data returned from the archive
+                :meth:`~ribs.archives.ArchiveBase.add` method.
             fields (keyword arguments): Additional data for each solution. Each
                 argument should be an array with batch_size as the first
                 dimension.
@@ -322,10 +318,7 @@ class GradientOperatorEmitter(EmitterBase):
                 "measures": measures,
                 **fields,
             },
-            {
-                "status": status_batch,
-                "value": value_batch,
-            },
+            add_info,
             jacobian,
         )
 

--- a/tests/archives/cvt_archive_test.py
+++ b/tests/archives/cvt_archive_test.py
@@ -81,12 +81,12 @@ def test_add_single_to_archive(data, use_list, add_mode):
         measures = list(data.measures)
 
     if add_mode == "single":
-        status, value = data.archive.add_single(solution, objective, measures)
+        add_info = data.archive.add_single(solution, objective, measures)
     else:
-        status, value = data.archive.add([solution], [objective], [measures])
+        add_info = data.archive.add([solution], [objective], [measures])
 
-    assert status == AddStatus.NEW
-    assert np.isclose(value, data.objective)
+    assert add_info["status"] == AddStatus.NEW
+    assert np.isclose(add_info["value"], data.objective)
     assert_archive_elite(data.archive_with_elite, data.solution, data.objective,
                          data.measures, data.centroid)
 
@@ -97,15 +97,16 @@ def test_add_single_and_overwrite(data, add_mode):
     high_objective = data.objective + 1.0
 
     if add_mode == "single":
-        status, value = data.archive_with_elite.add_single(
-            arbitrary_sol, high_objective, data.measures)
+        add_info = data.archive_with_elite.add_single(arbitrary_sol,
+                                                      high_objective,
+                                                      data.measures)
     else:
-        status, value = data.archive_with_elite.add([arbitrary_sol],
-                                                    [high_objective],
-                                                    [data.measures])
+        add_info = data.archive_with_elite.add([arbitrary_sol],
+                                               [high_objective],
+                                               [data.measures])
 
-    assert status == AddStatus.IMPROVE_EXISTING
-    assert np.isclose(value, high_objective - data.objective)
+    assert add_info["status"] == AddStatus.IMPROVE_EXISTING
+    assert np.isclose(add_info["value"], high_objective - data.objective)
     assert_archive_elite(data.archive_with_elite, arbitrary_sol, high_objective,
                          data.measures, data.centroid)
 
@@ -116,15 +117,15 @@ def test_add_single_without_overwrite(data, add_mode):
     low_objective = data.objective - 1.0
 
     if add_mode == "single":
-        status, value = data.archive_with_elite.add_single(
-            arbitrary_sol, low_objective, data.measures)
+        add_info = data.archive_with_elite.add_single(arbitrary_sol,
+                                                      low_objective,
+                                                      data.measures)
     else:
-        status, value = data.archive_with_elite.add([arbitrary_sol],
-                                                    [low_objective],
-                                                    [data.measures])
+        add_info = data.archive_with_elite.add([arbitrary_sol], [low_objective],
+                                               [data.measures])
 
-    assert status == AddStatus.NOT_ADDED
-    assert np.isclose(value, low_objective - data.objective)
+    assert add_info["status"] == AddStatus.NOT_ADDED
+    assert np.isclose(add_info["value"], low_objective - data.objective)
     assert_archive_elite(data.archive_with_elite, data.solution, data.objective,
                          data.measures, data.centroid)
 

--- a/tests/archives/grid_archive_test.py
+++ b/tests/archives/grid_archive_test.py
@@ -102,12 +102,12 @@ def test_add_single_to_archive(data, use_list, add_mode):
         measures = list(data.measures)
 
     if add_mode == "single":
-        status, value = data.archive.add_single(solution, objective, measures)
+        add_info = data.archive.add_single(solution, objective, measures)
     else:
-        status, value = data.archive.add([solution], [objective], [measures])
+        add_info = data.archive.add([solution], [objective], [measures])
 
-    assert status == AddStatus.NEW
-    assert np.isclose(value, data.objective)
+    assert add_info["status"] == AddStatus.NEW
+    assert np.isclose(add_info["value"], data.objective)
     assert_archive_elite(data.archive_with_elite, data.solution, data.objective,
                          data.measures, data.grid_indices)
 
@@ -125,12 +125,12 @@ def test_add_single_to_archive_negative_objective(data, use_list, add_mode):
         measures = list(data.measures)
 
     if add_mode == "single":
-        status, value = data.archive.add_single(solution, objective, measures)
+        add_info = data.archive.add_single(solution, objective, measures)
     else:
-        status, value = data.archive.add([solution], [objective], [measures])
+        add_info = data.archive.add([solution], [objective], [measures])
 
-    assert status == AddStatus.NEW
-    assert np.isclose(value, -data.objective)
+    assert add_info["status"] == AddStatus.NEW
+    assert np.isclose(add_info["value"], -data.objective)
     assert_archive_elite(data.archive_with_elite, data.solution, data.objective,
                          data.measures, data.grid_indices)
 
@@ -139,13 +139,13 @@ def test_add_single_with_low_measures(data, add_mode):
     measures = np.array([-2, -3])
     indices = (0, 0)
     if add_mode == "single":
-        status, _ = data.archive.add_single(data.solution, data.objective,
-                                            measures)
+        add_info = data.archive.add_single(data.solution, data.objective,
+                                           measures)
     else:
-        status, _ = data.archive.add([data.solution], [data.objective],
-                                     [measures])
+        add_info = data.archive.add([data.solution], [data.objective],
+                                    [measures])
 
-    assert status
+    assert add_info["status"]
     assert_archive_elite(data.archive, data.solution, data.objective, measures,
                          indices)
 
@@ -154,12 +154,12 @@ def test_add_single_with_high_measures(data, add_mode):
     measures = np.array([2, 3])
     indices = (9, 19)
     if add_mode == "single":
-        status, _ = data.archive.add_single(data.solution, data.objective,
-                                            measures)
+        add_info = data.archive.add_single(data.solution, data.objective,
+                                           measures)
     else:
-        status, _ = data.archive.add([data.solution], [data.objective],
-                                     [measures])
-    assert status
+        add_info = data.archive.add([data.solution], [data.objective],
+                                    [measures])
+    assert add_info["status"]
     assert_archive_elite(data.archive, data.solution, data.objective, measures,
                          indices)
 
@@ -170,15 +170,16 @@ def test_add_single_and_overwrite(data, add_mode):
     high_objective = data.objective + 1.0
 
     if add_mode == "single":
-        status, value = data.archive_with_elite.add_single(
-            arbitrary_sol, high_objective, data.measures)
+        add_info = data.archive_with_elite.add_single(arbitrary_sol,
+                                                      high_objective,
+                                                      data.measures)
     else:
-        status, value = data.archive_with_elite.add([arbitrary_sol],
-                                                    [high_objective],
-                                                    [data.measures])
+        add_info = data.archive_with_elite.add([arbitrary_sol],
+                                               [high_objective],
+                                               [data.measures])
 
-    assert status == AddStatus.IMPROVE_EXISTING
-    assert np.isclose(value, high_objective - data.objective)
+    assert add_info["status"] == AddStatus.IMPROVE_EXISTING
+    assert np.isclose(add_info["value"], high_objective - data.objective)
     assert_archive_elite(data.archive_with_elite, arbitrary_sol, high_objective,
                          data.measures, data.grid_indices)
 
@@ -189,15 +190,15 @@ def test_add_single_without_overwrite(data, add_mode):
     low_objective = data.objective - 1.0
 
     if add_mode == "single":
-        status, value = data.archive_with_elite.add_single(
-            arbitrary_sol, low_objective, data.measures)
+        add_info = data.archive_with_elite.add_single(arbitrary_sol,
+                                                      low_objective,
+                                                      data.measures)
     else:
-        status, value = data.archive_with_elite.add([arbitrary_sol],
-                                                    [low_objective],
-                                                    [data.measures])
+        add_info = data.archive_with_elite.add([arbitrary_sol], [low_objective],
+                                               [data.measures])
 
-    assert status == AddStatus.NOT_ADDED
-    assert np.isclose(value, low_objective - data.objective)
+    assert add_info["status"] == AddStatus.NOT_ADDED
+    assert np.isclose(add_info["value"], low_objective - data.objective)
     assert_archive_elite(data.archive_with_elite, data.solution, data.objective,
                          data.measures, data.grid_indices)
 
@@ -215,35 +216,35 @@ def test_add_single_threshold_update(add_mode):
 
     # Add a new solution to the archive.
     if add_mode == "single":
-        status, value = archive.add_single(solution, 0.0, measures)
+        add_info = archive.add_single(solution, 0.0, measures)
     else:
-        status_batch, value_batch = archive.add([solution], [0.0], [measures])
-        status, value = status_batch[0], value_batch[0]
+        add_info = archive.add([solution], [0.0], [measures])
+        add_info = {name: arr[0] for name, arr in add_info.items()}
 
-    assert status == 2  # NEW
-    assert np.isclose(value, 1.0)  # 0.0 - (-1.0)
+    assert add_info["status"] == 2  # NEW
+    assert np.isclose(add_info["value"], 1.0)  # 0.0 - (-1.0)
 
     # Threshold should now be (1 - 0.1) * -1.0 + 0.1 * 0.0 = -0.9
 
     # These solutions are below the threshold and should not be inserted.
     if add_mode == "single":
-        status, value = archive.add_single(solution, -0.95, measures)
+        add_info = archive.add_single(solution, -0.95, measures)
     else:
-        status_batch, value_batch = archive.add([solution], [-0.95], [measures])
-        status, value = status_batch[0], value_batch[0]
+        add_info = archive.add([solution], [-0.95], [measures])
+        add_info = {name: arr[0] for name, arr in add_info.items()}
 
-    assert status == 0  # NOT_ADDED
-    assert np.isclose(value, -0.05)  # -0.95 - (-0.9)
+    assert add_info["status"] == 0  # NOT_ADDED
+    assert np.isclose(add_info["value"], -0.05)  # -0.95 - (-0.9)
 
     # These solutions are above the threshold and should be inserted.
     if add_mode == "single":
-        status, value = archive.add_single(solution, -0.8, measures)
+        add_info = archive.add_single(solution, -0.8, measures)
     else:
-        status_batch, value_batch = archive.add([solution], [-0.8], [measures])
-        status, value = status_batch[0], value_batch[0]
+        add_info = archive.add([solution], [-0.8], [measures])
+        add_info = {name: arr[0] for name, arr in add_info.items()}
 
-    assert status == 1  # IMPROVE_EXISTING
-    assert np.isclose(value, 0.1)  # -0.8 - (-0.9)
+    assert add_info["status"] == 1  # IMPROVE_EXISTING
+    assert np.isclose(add_info["value"], 0.1)  # -0.8 - (-0.9)
 
 
 def test_add_single_after_clear(data):
@@ -252,19 +253,19 @@ def test_add_single_after_clear(data):
 
     https://github.com/icaros-usc/pyribs/pull/260
     """
-    status, value = data.archive.add_single(data.solution, data.objective,
-                                            data.measures)
+    add_info = data.archive.add_single(data.solution, data.objective,
+                                       data.measures)
 
-    assert status == 2
-    assert value == data.objective
+    assert add_info["status"] == 2
+    assert add_info["value"] == data.objective
 
     data.archive.clear()
 
-    status, value = data.archive.add_single(data.solution, data.objective,
-                                            data.measures)
+    add_info = data.archive.add_single(data.solution, data.objective,
+                                       data.measures)
 
-    assert status == 2
-    assert value == data.objective
+    assert add_info["status"] == 2
+    assert add_info["value"] == data.objective
 
 
 def test_add_single_wrong_shapes(data):
@@ -283,7 +284,7 @@ def test_add_single_wrong_shapes(data):
 
 
 def test_add_batch_all_new(data):
-    status_batch, value_batch = data.archive.add(
+    add_info = data.archive.add(
         # 4 solutions of arbitrary value.
         solution=[[1, 2, 3]] * 4,
         # The first two solutions end up in separate cells, and the next two end
@@ -291,8 +292,8 @@ def test_add_batch_all_new(data):
         objective=[0, 0, 0, 1],
         measures=[[0, 0], [0.25, 0.25], [0.5, 0.5], [0.5, 0.5]],
     )
-    assert (status_batch == 2).all()
-    assert np.isclose(value_batch, [0, 0, 0, 1]).all()
+    assert (add_info["status"] == 2).all()
+    assert np.isclose(add_info["value"], [0, 0, 0, 1]).all()
 
     assert_archive_elites(
         archive=data.archive,
@@ -305,7 +306,7 @@ def test_add_batch_all_new(data):
 
 
 def test_add_batch_none_inserted(data):
-    status_batch, value_batch = data.archive_with_elite.add(
+    add_info = data.archive_with_elite.add(
         solution=[[1, 2, 3]] * 4,
         objective=[data.objective - 1 for _ in range(4)],
         measures=[data.measures for _ in range(4)],
@@ -313,8 +314,8 @@ def test_add_batch_none_inserted(data):
 
     # All solutions were inserted into the same cell as the elite already in the
     # archive and had objective value 1 less.
-    assert (status_batch == 0).all()
-    assert np.isclose(value_batch, -1.0).all()
+    assert (add_info["status"] == 0).all()
+    assert np.isclose(add_info["value"], -1.0).all()
 
     assert_archive_elites(
         archive=data.archive_with_elite,
@@ -327,7 +328,7 @@ def test_add_batch_none_inserted(data):
 
 
 def test_add_batch_with_improvement(data):
-    status_batch, value_batch = data.archive_with_elite.add(
+    add_info = data.archive_with_elite.add(
         solution=[[1, 2, 3]] * 4,
         objective=[data.objective + 1 for _ in range(4)],
         measures=[data.measures for _ in range(4)],
@@ -335,8 +336,8 @@ def test_add_batch_with_improvement(data):
 
     # All solutions were inserted into the same cell as the elite already in the
     # archive and had objective value 1 greater.
-    assert (status_batch == 1).all()
-    assert np.isclose(value_batch, 1.0).all()
+    assert (add_info["status"] == 1).all()
+    assert np.isclose(add_info["value"], 1.0).all()
 
     assert_archive_elites(
         archive=data.archive_with_elite,
@@ -349,7 +350,7 @@ def test_add_batch_with_improvement(data):
 
 
 def test_add_batch_mixed_statuses(data):
-    status_batch, value_batch = data.archive_with_elite.add(
+    add_info = data.archive_with_elite.add(
         solution=[[1, 2, 3]] * 6,
         objective=[
             # Not added.
@@ -374,8 +375,8 @@ def test_add_batch_mixed_statuses(data):
             [0, 0],
         ],
     )
-    assert (status_batch == [0, 0, 1, 1, 2, 2]).all()
-    assert np.isclose(value_batch, [-1, -2, 1, 2, 1, 2]).all()
+    assert (add_info["status"] == [0, 0, 1, 1, 2, 2]).all()
+    assert np.isclose(add_info["value"], [-1, -2, 1, 2, 1, 2]).all()
 
     assert_archive_elites(
         archive=data.archive_with_elite,
@@ -388,7 +389,7 @@ def test_add_batch_mixed_statuses(data):
 
 
 def test_add_batch_first_solution_wins_in_ties(data):
-    status_batch, value_batch = data.archive_with_elite.add(
+    add_info = data.archive_with_elite.add(
         solution=[
             [1, 2, 3],
             [4, 5, 6],
@@ -410,8 +411,8 @@ def test_add_batch_first_solution_wins_in_ties(data):
             [0, 0],
         ],
     )
-    assert (status_batch == [1, 1, 2, 2]).all()
-    assert np.isclose(value_batch, [1, 1, 3, 3]).all()
+    assert (add_info["status"] == [1, 1, 2, 2]).all()
+    assert np.isclose(add_info["value"], [1, 1, 3, 3]).all()
 
     assert_archive_elites(
         archive=data.archive_with_elite,
@@ -433,7 +434,7 @@ def test_add_batch_not_inserted_if_below_threshold_min():
         learning_rate=0.1,
     )
 
-    status_batch, value_batch = archive.add(
+    add_info = archive.add(
         solution=[[1, 2, 3]] * 4,
         objective=[-20.0, -20.0, 10.0, 10.0],
         measures=[[0.0, 0.0]] * 4,
@@ -441,8 +442,8 @@ def test_add_batch_not_inserted_if_below_threshold_min():
 
     # The first two solutions should not have been inserted since they did not
     # cross the threshold_min of -10.0.
-    assert (status_batch == [0, 0, 2, 2]).all()
-    assert np.isclose(value_batch, [-10.0, -10.0, 20.0, 20.0]).all()
+    assert (add_info["status"] == [0, 0, 2, 2]).all()
+    assert np.isclose(add_info["value"], [-10.0, -10.0, 20.0, 20.0]).all()
 
     assert_archive_elites(
         archive=archive,
@@ -468,7 +469,7 @@ def test_add_batch_threshold_update():
 
     # Add new solutions to the archive in two cells determined by measures and
     # measures2.
-    status_batch, value_batch = archive.add(
+    add_info = archive.add(
         [solution, solution, solution, solution, solution, solution],
         # The first three solutions are inserted since they cross
         # threshold_min, but the last solution is not inserted since it does not
@@ -477,9 +478,10 @@ def test_add_batch_threshold_update():
         [measures, measures, measures, measures2, measures2, measures2],
     )
 
-    assert (status_batch == [2, 2, 2, 2, 2, 0]).all()
+    assert (add_info["status"] == [2, 2, 2, 2, 2, 0]).all()
     assert np.isclose(
-        value_batch, [1.0, 2.0, 3.0, 11.0, 101.0, -9.0]).all()  # [...] - (-1.0)
+        add_info["value"],
+        [1.0, 2.0, 3.0, 11.0, 101.0, -9.0]).all()  # [...] - (-1.0)
 
     # Thresholds based on batch update rule should now be
     # (1 - 0.1)**3 * -1.0 + (0.0 + 1.0 + 2.0) / 3 * (1 - (1 - 0.1)**3) = -0.458
@@ -487,15 +489,15 @@ def test_add_batch_threshold_update():
     # (1 - 0.1)**2 * -1.0 + (10.0 + 100.0) / 2 * (1 - (1 - 0.1)**2) = 9.64
 
     # Mix between solutions which are inserted and not inserted.
-    status_batch, value_batch = archive.add(
+    add_info = archive.add(
         [solution, solution, solution, solution],
         [-0.95, -0.457, 9.63, 9.65],
         [measures, measures, measures2, measures2],
     )
 
-    assert (status_batch == [0, 1, 0, 1]).all()
+    assert (add_info["status"] == [0, 1, 0, 1]).all()
     # [-0.95 - (-0.458), -0.458 - (-0.457), 9.63 - 9.64, 9.65 - 9.64]
-    assert np.isclose(value_batch, [-0.492, 0.001, -0.01, 0.01]).all()
+    assert np.isclose(add_info["value"], [-0.492, 0.001, -0.01, 0.01]).all()
 
     # Thresholds should now be
     # (1 - 0.1)**1 * -0.458 + (-0.457) / 1 * (1 - (1 - 0.1)**1) = -0.4579
@@ -503,14 +505,14 @@ def test_add_batch_threshold_update():
     # (1 - 0.1)**1 * 9.64 + (9.65) / 1 * (1 - (1 - 0.1)**1) = 9.641
 
     # Again mix between solutions which are inserted and not inserted.
-    status_batch, value_batch = archive.add(
+    add_info = archive.add(
         [solution, solution, solution, solution],
         [-0.4580, -0.4578, 9.640, 9.642],
         [measures, measures, measures2, measures2],
     )
 
-    assert (status_batch == [0, 1, 0, 1]).all()
-    assert np.isclose(value_batch, [-0.0001, 0.0001, -0.001, 0.001]).all()
+    assert (add_info["status"] == [0, 1, 0, 1]).all()
+    assert np.isclose(add_info["value"], [-0.0001, 0.0001, -0.001, 0.001]).all()
 
 
 def test_add_batch_threshold_update_inf_threshold_min():
@@ -528,29 +530,30 @@ def test_add_batch_threshold_update_inf_threshold_min():
     measures2 = [-0.1, -0.1]
 
     # Add new solutions to the archive.
-    status_batch, value_batch = archive.add(
+    add_info = archive.add(
         [solution, solution, solution, solution, solution, solution],
         [0.0, 1.0, 2.0, -10.0, 10.0, 100.0],
         [measures, measures, measures, measures2, measures2, measures2],
     )
 
     # Value is same as objective since these are new cells.
-    assert (status_batch == [2, 2, 2, 2, 2, 2]).all()
-    assert np.isclose(value_batch, [0.0, 1.0, 2.0, -10.0, 10.0, 100.0]).all()
+    assert (add_info["status"] == [2, 2, 2, 2, 2, 2]).all()
+    assert np.isclose(add_info["value"],
+                      [0.0, 1.0, 2.0, -10.0, 10.0, 100.0]).all()
 
     # Thresholds are updated based on maximum values in each cell, i.e. 2.0 and
     # 100.0.
 
     # Mix between solutions which are inserted and not inserted.
-    status_batch, value_batch = archive.add(
+    add_info = archive.add(
         [solution, solution, solution, solution],
         [1.0, 10.0, 99.0, 101.0],
         [measures, measures, measures2, measures2],
     )
 
-    assert (status_batch == [0, 1, 0, 1]).all()
+    assert (add_info["status"] == [0, 1, 0, 1]).all()
     # [1.0 - 2.0, 10.0 - 2.0, 99.0 - 100.0, 101.0 - 100.0]
-    assert np.isclose(value_batch, [-1.0, 8.0, -1.0, 1.0]).all()
+    assert np.isclose(add_info["value"], [-1.0, 8.0, -1.0, 1.0]).all()
 
 
 def test_add_batch_wrong_shapes(data):
@@ -576,14 +579,14 @@ def test_add_batch_wrong_shapes(data):
 
 def test_add_batch_zero_length(data):
     """Nothing should happen when adding a batch with length 0."""
-    status_batch, value_batch = data.archive.add(
+    add_info = data.archive.add(
         solution=np.ones((0, 3)),
         objective=np.ones((0,)),
         measures=np.ones((0, 2)),
     )
 
-    assert len(status_batch) == 0
-    assert len(value_batch) == 0
+    assert len(add_info["status"]) == 0
+    assert len(add_info["value"]) == 0
     assert len(data.archive) == 0
 
 

--- a/tests/archives/sliding_boundaries_archive_test.py
+++ b/tests/archives/sliding_boundaries_archive_test.py
@@ -41,15 +41,14 @@ def test_attributes_correctly_constructed(data):
 @pytest.mark.parametrize("use_list", [True, False], ids=["list", "ndarray"])
 def test_add_to_archive(data, use_list):
     if use_list:
-        status, value = data.archive.add_single(list(data.solution),
-                                                data.objective,
-                                                list(data.measures))
+        add_info = data.archive.add_single(list(data.solution), data.objective,
+                                           list(data.measures))
     else:
-        status, value = data.archive.add_single(data.solution, data.objective,
-                                                data.measures)
+        add_info = data.archive.add_single(data.solution, data.objective,
+                                           data.measures)
 
-    assert status == AddStatus.NEW
-    assert np.isclose(value, data.objective)
+    assert add_info["status"] == AddStatus.NEW
+    assert np.isclose(add_info["value"], data.objective)
     assert_archive_elite(data.archive_with_elite, data.solution, data.objective,
                          data.measures, data.grid_indices)
 
@@ -59,11 +58,10 @@ def test_add_and_overwrite(data):
     arbitrary_sol = data.solution + 1
     high_objective = data.objective + 1.0
 
-    status, value = data.archive_with_elite.add_single(arbitrary_sol,
-                                                       high_objective,
-                                                       data.measures)
-    assert status == AddStatus.IMPROVE_EXISTING
-    assert np.isclose(value, high_objective - data.objective)
+    add_info = data.archive_with_elite.add_single(arbitrary_sol, high_objective,
+                                                  data.measures)
+    assert add_info["status"] == AddStatus.IMPROVE_EXISTING
+    assert np.isclose(add_info["value"], high_objective - data.objective)
     assert_archive_elite(data.archive_with_elite, arbitrary_sol, high_objective,
                          data.measures, data.grid_indices)
 
@@ -73,11 +71,10 @@ def test_add_without_overwrite(data):
     arbitrary_sol = data.solution + 1
     low_objective = data.objective - 1.0
 
-    status, value = data.archive_with_elite.add_single(arbitrary_sol,
-                                                       low_objective,
-                                                       data.measures)
-    assert status == AddStatus.NOT_ADDED
-    assert np.isclose(value, low_objective - data.objective)
+    add_info = data.archive_with_elite.add_single(arbitrary_sol, low_objective,
+                                                  data.measures)
+    assert add_info["status"] == AddStatus.NOT_ADDED
+    assert np.isclose(add_info["value"], low_objective - data.objective)
     assert_archive_elite(data.archive_with_elite, data.solution, data.objective,
                          data.measures, data.grid_indices)
 

--- a/tests/emitters/emitter_base_test.py
+++ b/tests/emitters/emitter_base_test.py
@@ -150,9 +150,16 @@ def test_tell_arguments_incorrect_shape(emitter_type, wrong_array, offsets):
         # Only GradientArborescenceEmitter has tell_dqd method.
         if isinstance(emitter, GradientArborescenceEmitter):
             with pytest.raises(ValueError):
-                emitter.tell_dqd(solution_batch, objective_batch,
-                                 measures_batch, jacobian_batch, status_batch,
-                                 value_batch)
+                emitter.tell_dqd(
+                    solution_batch,
+                    objective_batch,
+                    measures_batch,
+                    jacobian_batch,
+                    {
+                        "status": status_batch,
+                        "value": value_batch,
+                    },
+                )
 
         if wrong_array == "jacobian_batch":
             # tell() does not use jacobian_batch paramter, so we skip calling
@@ -163,8 +170,15 @@ def test_tell_arguments_incorrect_shape(emitter_type, wrong_array, offsets):
             # For GradientArborescenceEmitter, tell is called before tell_dqd,
             # but shape check exception should be thrown before tell complains
             # that tell_dqd is not called.
-            emitter.tell(solution_batch, objective_batch, measures_batch,
-                         status_batch, value_batch)
+            emitter.tell(
+                solution_batch,
+                objective_batch,
+                measures_batch,
+                {
+                    "status": status_batch,
+                    "value": value_batch
+                },
+            )
 
 
 #

--- a/tests/emitters/evolution_strategy_emitter_test.py
+++ b/tests/emitters/evolution_strategy_emitter_test.py
@@ -5,6 +5,8 @@ import pytest
 from ribs.archives import GridArchive
 from ribs.emitters import EvolutionStrategyEmitter
 
+# pylint: disable = redefined-outer-name
+
 RANKER_LIST = ["imp", "2imp", "rd", "2rd", "obj", "2obj"]
 ES_LIST = ["cma_es", "sep_cma_es", "lm_ma_es", "openai_es"]
 
@@ -71,8 +73,5 @@ def test_dtypes(dtype):
         solution_batch = emitter.ask()
         objective_batch = -np.sum(np.square(solution_batch), axis=1)
         measures_batch = solution_batch[:, :2]
-
-        status_batch, value_batch = archive.add(solution_batch, objective_batch,
-                                                measures_batch)
-        emitter.tell(solution_batch, objective_batch, measures_batch,
-                     status_batch, value_batch)
+        add_info = archive.add(solution_batch, objective_batch, measures_batch)
+        emitter.tell(solution_batch, objective_batch, measures_batch, add_info)

--- a/tests/emitters/gradient_arborescence_emitter_test.py
+++ b/tests/emitters/gradient_arborescence_emitter_test.py
@@ -80,4 +80,4 @@ def test_tell_dqd_must_be_called_before_tell():
                                               sigma0=1.0,
                                               lr=1.0)
         # Must call ask_dqd() before calling ask() to set the jacobian.
-        emitter.tell([[0]], [0], [[0]], [0], [0])
+        emitter.tell([[0]], [0], [[0]], {"status": [0], "value": [0]})


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the PR's purpose here. -->

To make the, more flexible, add() methods now return add_info instead of separate status_batch and value_batch. This will make it easy to return more info in the future.

Correspondingly, emitters now take in add_info instead of separate status_batch and value_batch arguments, and calls to add() have been fixed in the schedulers.

## TODO

<!-- Notable points that this PR has either accomplished or will accomplish. -->

- [x] Update in ArchiveBase
- [x] Update in SlidingBoundariesArchive
- [x] Update calls in scheduler
- [x] Update emitters to take in add_info
- [x] Fix tests

## Questions

<!-- Any concerns or points of confusion? -->

## Status

- [x] I have read the guidelines in
      [CONTRIBUTING.md](https://github.com/icaros-usc/pyribs/blob/master/CONTRIBUTING.md)
- [x] I have formatted my code using `yapf`
- [x] I have tested my code by running `pytest`
- [x] I have linted my code with `pylint`
- [x] I have added a one-line description of my change to the changelog in
      `HISTORY.md`
- [x] This PR is ready to go
