### PR TITLE
Use NumPy SeedSequence in emitters

### DIFF
--- a/ribs/emitters/_evolution_strategy_emitter.py
+++ b/ribs/emitters/_evolution_strategy_emitter.py
@@ -92,17 +92,21 @@ class EvolutionStrategyEmitter(EmitterBase):
         batch_size=None,
         seed=None,
     ):
-        self._rng = np.random.default_rng(seed)
-        self._x0 = np.array(x0, dtype=archive.dtype)
-        check_shape(self._x0, "x0", archive.solution_dim,
-                    "archive.solution_dim")
-        self._sigma0 = sigma0
         EmitterBase.__init__(
             self,
             archive,
             solution_dim=archive.solution_dim,
             bounds=bounds,
         )
+
+        seed_sequence = np.random.SeedSequence(seed)
+        rng_seed, opt_seed = seed_sequence.spawn(2)
+
+        self._rng = np.random.default_rng(rng_seed)
+        self._x0 = np.array(x0, dtype=archive.dtype)
+        check_shape(self._x0, "x0", archive.solution_dim,
+                    "archive.solution_dim")
+        self._sigma0 = sigma0
 
         if selection_rule not in ["mu", "filter"]:
             raise ValueError(f"Invalid selection_rule {selection_rule}")
@@ -115,7 +119,6 @@ class EvolutionStrategyEmitter(EmitterBase):
         # Check if the restart_rule is valid, discard check_restart result.
         _ = self._check_restart(0)
 
-        opt_seed = None if seed is None else self._rng.integers(10_000)
         self._opt = _get_es(es,
                             sigma0=sigma0,
                             batch_size=batch_size,

--- a/ribs/emitters/_gradient_arborescence_emitter.py
+++ b/ribs/emitters/_gradient_arborescence_emitter.py
@@ -160,8 +160,11 @@ class GradientArborescenceEmitter(EmitterBase):
             bounds=bounds,
         )
 
+        seed_sequence = np.random.SeedSequence(seed)
+        rng_seed, opt_seed = seed_sequence.spawn(2)
+
         self._epsilon = epsilon
-        self._rng = np.random.default_rng(seed)
+        self._rng = np.random.default_rng(rng_seed)
         self._x0 = np.array(x0, dtype=archive.dtype)
         check_shape(self._x0, "x0", archive.solution_dim,
                     "archive.solution_dim")
@@ -194,7 +197,6 @@ class GradientArborescenceEmitter(EmitterBase):
             lr=lr,
             **(grad_opt_kwargs if grad_opt_kwargs is not None else {}))
 
-        opt_seed = None if seed is None else self._rng.integers(10_000)
         self._opt = _get_es(es,
                             sigma0=sigma0,
                             batch_size=batch_size,


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the PR's purpose here. -->

This PR uses SeedSequence to seed the optimizer in emitters, rather than drawing integers from the current RNG. The ideal method would be to use `rng.spawn` (https://numpy.org/doc/stable//reference/random/generated/numpy.random.Generator.spawn.html#numpy.random.Generator.spawn) to create a child RNG, but this feature is only in NumPy 1.25, which only supports Python 3.9+ (we use 3.8+).

## TODO

<!-- Notable points that this PR has either accomplished or will accomplish. -->

## Questions

<!-- Any concerns or points of confusion? -->

## Status

- [x] I have read the guidelines in
      [CONTRIBUTING.md](https://github.com/icaros-usc/pyribs/blob/master/CONTRIBUTING.md)
- [x] I have formatted my code using `yapf`
- [x] I have tested my code by running `pytest`
- [x] I have linted my code with `pylint`
- [x] I have added a one-line description of my change to the changelog in
      `HISTORY.md`
- [x] This PR is ready to go
