### PR TITLE
Use seed instead of rng in ranker

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,6 +6,7 @@
 
 #### API
 
+- **Backwards-incompatible:** Use seed instead of rng in ranker ({pr}`432`)
 - **Backwards-incompatible:** Replace status and value with add_info ({pr}`430`)
 - Support custom data fields in archive, emitters, and scheduler ({pr}`421`,
   {pr}`429`)
@@ -33,6 +34,7 @@
 
 #### Improvements
 
+- Use NumPy SeedSequence in emitters ({pr}`431`)
 - Use numbers types when checking arguments ({pr}`419`)
 - Reimplement ArchiveBase using ArrayStore ({pr}`399`)
 - Use chunk computation in CVT brute force calculation to reduce memory usage


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the PR's purpose here. -->

Previously, we passed in an rng to every ranker method, which is inconsistent with other composed objects in pyribs like ES's. Thus, this PR switches rankers to take in a seed and manage their randomness by holding their own RNG.

## TODO

<!-- Notable points that this PR has either accomplished or will accomplish. -->

## Questions

<!-- Any concerns or points of confusion? -->

## Status

- [x] I have read the guidelines in
      [CONTRIBUTING.md](https://github.com/icaros-usc/pyribs/blob/master/CONTRIBUTING.md)
- [x] I have formatted my code using `yapf`
- [x] I have tested my code by running `pytest`
- [x] I have linted my code with `pylint`
- [x] I have added a one-line description of my change to the changelog in
      `HISTORY.md`
- [ ] This PR is ready to go
