### PR TITLE
Add ribs.emitters.operators to docs

### DIFF
--- a/docs/api/ribs.emitters.operators.rst
+++ b/docs/api/ribs.emitters.operators.rst
@@ -1,0 +1,7 @@
+ribs.emitters.operators
+=======================
+
+.. automodule:: ribs.emitters.operators
+   :no-members:
+   :no-inherited-members:
+   :no-special-members:

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,6 +19,7 @@ whats-new
 
 api/ribs.archives
 api/ribs.emitters
+api/ribs.emitters.operators
 api/ribs.emitters.opt
 api/ribs.emitters.rankers
 api/ribs.schedulers

--- a/ribs/emitters/operators/__init__.py
+++ b/ribs/emitters/operators/__init__.py
@@ -6,6 +6,8 @@ operators such as mutation and crossover.
 .. autosummary::
     :toctree:
 
+    ribs.emitters.operators.GaussianOperator
+    ribs.emitters.operators.IsoLineOperator
     ribs.emitters.operators.OperatorBase
 """
 from ribs.emitters.operators._gaussian import GaussianOperator


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the PR's purpose here. -->

`ribs.emitters.operators` now shows up in the docs.

## TODO

<!-- Notable points that this PR has either accomplished or will accomplish. -->

## Questions

<!-- Any concerns or points of confusion? -->

## Status

- [x] I have read the guidelines in
      [CONTRIBUTING.md](https://github.com/icaros-usc/pyribs/blob/master/CONTRIBUTING.md)
- [x] I have formatted my code using `yapf`
- [x] I have tested my code by running `pytest`
- [x] I have linted my code with `pylint`
- [N/A] I have added a one-line description of my change to the changelog in
      `HISTORY.md`
- [x] This PR is ready to go
