### PR TITLE
Move evolution strategy bounds to init

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,6 +6,7 @@
 
 #### API
 
+- **Backwards-incompatible:** Move evolution strategy bounds to init ({pr}`436`)
 - **Backwards-incompatible:** Use seed instead of rng in ranker ({pr}`432`)
 - **Backwards-incompatible:** Replace status and value with add_info ({pr}`430`)
 - Support custom data fields in archive, emitters, and scheduler ({pr}`421`,

--- a/ribs/emitters/_evolution_strategy_emitter.py
+++ b/ribs/emitters/_evolution_strategy_emitter.py
@@ -118,13 +118,17 @@ class EvolutionStrategyEmitter(EmitterBase):
         # Check if the restart_rule is valid, discard check_restart result.
         _ = self._check_restart(0)
 
-        self._opt = _get_es(es,
-                            sigma0=sigma0,
-                            batch_size=batch_size,
-                            solution_dim=self._solution_dim,
-                            seed=opt_seed,
-                            dtype=self.archive.dtype,
-                            **(es_kwargs if es_kwargs is not None else {}))
+        self._opt = _get_es(
+            es,
+            sigma0=sigma0,
+            batch_size=batch_size,
+            solution_dim=self._solution_dim,
+            seed=opt_seed,
+            dtype=self.archive.dtype,
+            lower_bounds=self.lower_bounds,
+            upper_bounds=self.upper_bounds,
+            **(es_kwargs if es_kwargs is not None else {}),
+        )
         self._opt.reset(self._x0)
 
         self._ranker = _get_ranker(ranker, ranker_seed)
@@ -163,7 +167,7 @@ class EvolutionStrategyEmitter(EmitterBase):
             (batch_size, :attr:`solution_dim`) array -- a batch of new solutions
             to evaluate.
         """
-        return self._opt.ask(self.lower_bounds, self.upper_bounds)
+        return self._opt.ask()
 
     def _check_restart(self, num_parents):
         """Emitter-side checks for restarting the optimizer.

--- a/ribs/emitters/opt/_cma_es.py
+++ b/ribs/emitters/opt/_cma_es.py
@@ -86,6 +86,13 @@ class CMAEvolutionStrategy(EvolutionStrategyBase):
         solution_dim (int): Size of the solution space.
         seed (int): Seed for the random number generator.
         dtype (str or data-type): Data type of solutions.
+        lower_bounds (float or np.ndarray): scalar or (solution_dim,) array
+            indicating lower bounds of the solution space. Scalars specify
+            the same bound for the entire space, while arrays specify a
+            bound for each dimension. Pass -np.inf in the array or scalar to
+            indicated unbounded space.
+        upper_bounds (float or np.ndarray): Same as above, but for upper
+            bounds (and pass np.inf instead of -np.inf).
     """
 
     def __init__(  # pylint: disable = super-init-not-called
@@ -94,12 +101,17 @@ class CMAEvolutionStrategy(EvolutionStrategyBase):
             solution_dim,
             batch_size=None,
             seed=None,
-            dtype=np.float64):
+            dtype=np.float64,
+            lower_bounds=-np.inf,
+            upper_bounds=np.inf):
         self.batch_size = (4 + int(3 * np.log(solution_dim))
                            if batch_size is None else batch_size)
         self.sigma0 = sigma0
         self.solution_dim = solution_dim
         self.dtype = dtype
+        self.lower_bounds = lower_bounds
+        self.upper_bounds = upper_bounds
+
         self._rng = np.random.default_rng(seed)
         self._solutions = None
 
@@ -182,17 +194,10 @@ class CMAEvolutionStrategy(EvolutionStrategyBase):
     # Limit OpenBLAS to single thread. This is typically faster than
     # multithreading because our data is too small.
     @threadpool_limits.wrap(limits=1, user_api="blas")
-    def ask(self, lower_bounds, upper_bounds, batch_size=None):
+    def ask(self, batch_size=None):
         """Samples new solutions from the Gaussian distribution.
 
         Args:
-            lower_bounds (float or np.ndarray): scalar or (solution_dim,) array
-                indicating lower bounds of the solution space. Scalars specify
-                the same bound for the entire space, while arrays specify a
-                bound for each dimension. Pass -np.inf in the array or scalar to
-                indicated unbounded space.
-            upper_bounds (float or np.ndarray): Same as above, but for upper
-                bounds (and pass np.inf instead of -np.inf).
             batch_size (int): batch size of the sample. Defaults to
                 ``self.batch_size``.
         """
@@ -214,8 +219,8 @@ class CMAEvolutionStrategy(EvolutionStrategyBase):
                 (len(remaining_indices), self.solution_dim),
             ).astype(self.dtype)
             new_solutions, out_of_bounds = self._transform_and_check_sol(
-                unscaled_params, transform_mat, self.mean, lower_bounds,
-                upper_bounds)
+                unscaled_params, transform_mat, self.mean, self.lower_bounds,
+                self.upper_bounds)
             self._solutions[remaining_indices] = new_solutions
 
             # Find indices in remaining_indices that are still out of bounds

--- a/ribs/emitters/opt/_cma_es.py
+++ b/ribs/emitters/opt/_cma_es.py
@@ -109,8 +109,11 @@ class CMAEvolutionStrategy(EvolutionStrategyBase):
         self.sigma0 = sigma0
         self.solution_dim = solution_dim
         self.dtype = dtype
-        self.lower_bounds = lower_bounds
-        self.upper_bounds = upper_bounds
+
+        # Even scalars must be converted into 0-dim arrays so that they work
+        # with the bound check in numba.
+        self.lower_bounds = np.asarray(lower_bounds, dtype=self.dtype)
+        self.upper_bounds = np.asarray(upper_bounds, dtype=self.dtype)
 
         self._rng = np.random.default_rng(seed)
         self._solutions = None

--- a/ribs/emitters/opt/_evolution_strategy_base.py
+++ b/ribs/emitters/opt/_evolution_strategy_base.py
@@ -24,6 +24,13 @@ class EvolutionStrategyBase(ABC):
         batch_size (int): Number of solutions to evaluate at a time.
         seed (int): Seed for the random number generator.
         dtype (str or data-type): Data type of solutions.
+        lower_bounds (float or np.ndarray): scalar or (solution_dim,) array
+            indicating lower bounds of the solution space. Scalars specify
+            the same bound for the entire space, while arrays specify a
+            bound for each dimension. Pass -np.inf in the array or scalar to
+            indicated unbounded space.
+        upper_bounds (float or np.ndarray): Same as above, but for upper
+            bounds (and pass np.inf instead of -np.inf).
     """
 
     def __init__(self,
@@ -31,7 +38,9 @@ class EvolutionStrategyBase(ABC):
                  solution_dim,
                  batch_size=None,
                  seed=None,
-                 dtype=np.float64):
+                 dtype=np.float64,
+                 lower_bounds=-np.inf,
+                 upper_bounds=np.inf):
         pass
 
     @abstractmethod
@@ -55,17 +64,13 @@ class EvolutionStrategyBase(ABC):
         """
 
     @abstractmethod
-    def ask(self, lower_bounds, upper_bounds):
+    def ask(self, batch_size=None):
         """Samples new solutions from the Gaussian distribution.
 
         Args:
-            lower_bounds (float or np.ndarray): scalar or (solution_dim,) array
-                indicating lower bounds of the solution space. Scalars specify
-                the same bound for the entire space, while arrays specify a
-                bound for each dimension. Pass -np.inf in the array or scalar to
-                indicated unbounded space.
-            upper_bounds (float or np.ndarray): Same as above, but for upper
-                bounds (and pass np.inf instead of -np.inf).
+            batch_size (int): If passed in, the ES will be asked to return this
+                number of solutions instead of the number specified during
+                initialization.
         """
 
     @abstractmethod

--- a/ribs/emitters/opt/_evolution_strategy_base.py
+++ b/ribs/emitters/opt/_evolution_strategy_base.py
@@ -68,9 +68,8 @@ class EvolutionStrategyBase(ABC):
         """Samples new solutions from the Gaussian distribution.
 
         Args:
-            batch_size (int): If passed in, the ES will be asked to return this
-                number of solutions instead of the number specified during
-                initialization.
+            batch_size (int): batch size of the sample. Defaults to
+                ``self.batch_size``.
         """
 
     @abstractmethod

--- a/ribs/emitters/opt/_lm_ma_es.py
+++ b/ribs/emitters/opt/_lm_ma_es.py
@@ -48,8 +48,11 @@ class LMMAEvolutionStrategy(EvolutionStrategyBase):
         self.sigma0 = sigma0
         self.solution_dim = solution_dim
         self.dtype = dtype
-        self.lower_bounds = lower_bounds
-        self.upper_bounds = upper_bounds
+
+        # Even scalars must be converted into 0-dim arrays so that they work
+        # with the bound check in numba.
+        self.lower_bounds = np.asarray(lower_bounds, dtype=self.dtype)
+        self.upper_bounds = np.asarray(upper_bounds, dtype=self.dtype)
 
         self._rng = np.random.default_rng(seed)
         self._solutions = None

--- a/ribs/emitters/opt/_lm_ma_es.py
+++ b/ribs/emitters/opt/_lm_ma_es.py
@@ -5,7 +5,6 @@ https://github.com/CMA-ES/pycma/blob/master/cma/purecma.py
 """
 import numba as nb
 import numpy as np
-from threadpoolctl import threadpool_limits
 
 from ribs._utils import readonly
 from ribs.emitters.opt._evolution_strategy_base import EvolutionStrategyBase
@@ -146,9 +145,6 @@ class LMMAEvolutionStrategy(EvolutionStrategyBase):
 
         return new_solutions, out_of_bounds
 
-    # Limit OpenBLAS to single thread. This is typically faster than
-    # multithreading because our data is too small.
-    @threadpool_limits.wrap(limits=1, user_api="blas")
     def ask(self, batch_size=None):
         """Samples new solutions from the Gaussian distribution.
 
@@ -199,9 +195,6 @@ class LMMAEvolutionStrategy(EvolutionStrategyBase):
 
         return weights, mueff
 
-    # Limit OpenBLAS to single thread. This is typically faster than
-    # multithreading because our data is too small.
-    @threadpool_limits.wrap(limits=1, user_api="blas")
     def tell(self, ranking_indices, num_parents):
         """Passes the solutions back to the optimizer.
 

--- a/ribs/emitters/opt/_openai_es.py
+++ b/ribs/emitters/opt/_openai_es.py
@@ -3,7 +3,6 @@
 See here for more info: https://arxiv.org/abs/1703.03864
 """
 import numpy as np
-from threadpoolctl import threadpool_limits
 
 from ribs._utils import readonly
 from ribs.emitters.opt._adam_opt import AdamOpt
@@ -108,9 +107,6 @@ class OpenAIEvolutionStrategy(EvolutionStrategyBase):
 
         return False
 
-    # Limit OpenBLAS to single thread. This is typically faster than
-    # multithreading because our data is too small.
-    @threadpool_limits.wrap(limits=1, user_api="blas")
     def ask(self, batch_size=None):
         """Samples new solutions from the Gaussian distribution.
 
@@ -152,9 +148,6 @@ class OpenAIEvolutionStrategy(EvolutionStrategyBase):
 
         return readonly(self._solutions)
 
-    # Limit OpenBLAS to single thread. This is typically faster than
-    # multithreading because our data is too small.
-    @threadpool_limits.wrap(limits=1, user_api="blas")
     def tell(
             self,
             ranking_indices,

--- a/ribs/emitters/opt/_openai_es.py
+++ b/ribs/emitters/opt/_openai_es.py
@@ -49,8 +49,11 @@ class OpenAIEvolutionStrategy(EvolutionStrategyBase):
         self.sigma0 = sigma0
         self.solution_dim = solution_dim
         self.dtype = dtype
-        self.lower_bounds = lower_bounds
-        self.upper_bounds = upper_bounds
+
+        # Even scalars must be converted into 0-dim arrays so that they work
+        # with the bound check in numba.
+        self.lower_bounds = np.asarray(lower_bounds, dtype=self.dtype)
+        self.upper_bounds = np.asarray(upper_bounds, dtype=self.dtype)
 
         self._rng = np.random.default_rng(seed)
         self._solutions = None

--- a/ribs/emitters/opt/_openai_es.py
+++ b/ribs/emitters/opt/_openai_es.py
@@ -22,6 +22,13 @@ class OpenAIEvolutionStrategy(EvolutionStrategyBase):
         solution_dim (int): Size of the solution space.
         seed (int): Seed for the random number generator.
         dtype (str or data-type): Data type of solutions.
+        lower_bounds (float or np.ndarray): scalar or (solution_dim,) array
+            indicating lower bounds of the solution space. Scalars specify
+            the same bound for the entire space, while arrays specify a
+            bound for each dimension. Pass -np.inf in the array or scalar to
+            indicated unbounded space.
+        upper_bounds (float or np.ndarray): Same as above, but for upper
+            bounds (and pass np.inf instead of -np.inf).
         mirror_sampling (bool): Whether to use mirror sampling when gathering
             solutions. Defaults to True.
         adam_kwargs (dict): Keyword arguments passed to :class:`AdamOpt`.
@@ -34,6 +41,8 @@ class OpenAIEvolutionStrategy(EvolutionStrategyBase):
             batch_size=None,
             seed=None,
             dtype=np.float64,
+            lower_bounds=-np.inf,
+            upper_bounds=np.inf,
             mirror_sampling=True,
             **adam_kwargs):
         self.batch_size = (4 + int(3 * np.log(solution_dim))
@@ -41,6 +50,9 @@ class OpenAIEvolutionStrategy(EvolutionStrategyBase):
         self.sigma0 = sigma0
         self.solution_dim = solution_dim
         self.dtype = dtype
+        self.lower_bounds = lower_bounds
+        self.upper_bounds = upper_bounds
+
         self._rng = np.random.default_rng(seed)
         self._solutions = None
 
@@ -99,19 +111,10 @@ class OpenAIEvolutionStrategy(EvolutionStrategyBase):
     # Limit OpenBLAS to single thread. This is typically faster than
     # multithreading because our data is too small.
     @threadpool_limits.wrap(limits=1, user_api="blas")
-    def ask(self, lower_bounds, upper_bounds, batch_size=None):
+    def ask(self, batch_size=None):
         """Samples new solutions from the Gaussian distribution.
 
-        Note: Bounds are currently not enforced.
-
         Args:
-            lower_bounds (float or np.ndarray): scalar or (solution_dim,) array
-                indicating lower bounds of the solution space. Scalars specify
-                the same bound for the entire space, while arrays specify a
-                bound for each dimension. Pass -np.inf in the array or scalar to
-                indicated unbounded space.
-            upper_bounds (float or np.ndarray): Same as above, but for upper
-                bounds (and pass np.inf instead of -np.inf).
             batch_size (int): batch size of the sample. Defaults to
                 ``self.batch_size``.
         """
@@ -133,12 +136,11 @@ class OpenAIEvolutionStrategy(EvolutionStrategyBase):
                 self.noise = self._rng.standard_normal(
                     (batch_size, self.solution_dim), dtype=self.dtype)
 
-            # TODO Numba
             new_solutions = (self.adam_opt.theta[None] +
                              self.sigma0 * self.noise)
             out_of_bounds = np.logical_or(
-                new_solutions < np.expand_dims(lower_bounds, axis=0),
-                new_solutions > np.expand_dims(upper_bounds, axis=0),
+                new_solutions < np.expand_dims(self.lower_bounds, axis=0),
+                new_solutions > np.expand_dims(self.upper_bounds, axis=0),
             )
 
             self._solutions[remaining_indices] = new_solutions

--- a/ribs/emitters/opt/_sep_cma_es.py
+++ b/ribs/emitters/opt/_sep_cma_es.py
@@ -5,7 +5,6 @@ https://github.com/CMA-ES/pycma/blob/master/cma/purecma.py
 """
 import numba as nb
 import numpy as np
-from threadpoolctl import threadpool_limits
 
 from ribs._utils import readonly
 from ribs.emitters.opt._evolution_strategy_base import EvolutionStrategyBase
@@ -151,9 +150,6 @@ class SeparableCMAEvolutionStrategy(EvolutionStrategyBase):
         )
         return solutions, out_of_bounds
 
-    # Limit OpenBLAS to single thread. This is typically faster than
-    # multithreading because our data is too small.
-    @threadpool_limits.wrap(limits=1, user_api="blas")
     def ask(self, batch_size=None):
         """Samples new solutions from the Gaussian distribution.
 
@@ -257,9 +253,6 @@ class SeparableCMAEvolutionStrategy(EvolutionStrategyBase):
         return (cov * (1 - c1a - cmu * np.sum(weights)) + rank_one_update * c1 +
                 rank_mu_update * cmu / (sigma**2))
 
-    # Limit OpenBLAS to single thread. This is typically faster than
-    # multithreading because our data is too small.
-    @threadpool_limits.wrap(limits=1, user_api="blas")
     def tell(self, ranking_indices, num_parents):
         """Passes the solutions back to the optimizer.
 

--- a/ribs/emitters/opt/_sep_cma_es.py
+++ b/ribs/emitters/opt/_sep_cma_es.py
@@ -77,8 +77,11 @@ class SeparableCMAEvolutionStrategy(EvolutionStrategyBase):
         self.sigma0 = sigma0
         self.solution_dim = solution_dim
         self.dtype = dtype
-        self.lower_bounds = lower_bounds
-        self.upper_bounds = upper_bounds
+
+        # Even scalars must be converted into 0-dim arrays so that they work
+        # with the bound check in numba.
+        self.lower_bounds = np.asarray(lower_bounds, dtype=self.dtype)
+        self.upper_bounds = np.asarray(upper_bounds, dtype=self.dtype)
 
         self._rng = np.random.default_rng(seed)
         self._solutions = None

--- a/ribs/emitters/opt/_sep_cma_es.py
+++ b/ribs/emitters/opt/_sep_cma_es.py
@@ -55,8 +55,13 @@ class SeparableCMAEvolutionStrategy(EvolutionStrategyBase):
         solution_dim (int): Size of the solution space.
         seed (int): Seed for the random number generator.
         dtype (str or data-type): Data type of solutions.
-        weight_rule (str): Method for generating weights. Either "truncation"
-            (positive weights only) or "active" (include negative weights).
+        lower_bounds (float or np.ndarray): scalar or (solution_dim,) array
+            indicating lower bounds of the solution space. Scalars specify
+            the same bound for the entire space, while arrays specify a
+            bound for each dimension. Pass -np.inf in the array or scalar to
+            indicated unbounded space.
+        upper_bounds (float or np.ndarray): Same as above, but for upper
+            bounds (and pass np.inf instead of -np.inf).
     """
 
     def __init__(  # pylint: disable = super-init-not-called
@@ -65,12 +70,17 @@ class SeparableCMAEvolutionStrategy(EvolutionStrategyBase):
             solution_dim,
             batch_size=None,
             seed=None,
-            dtype=np.float64):
+            dtype=np.float64,
+            lower_bounds=-np.inf,
+            upper_bounds=np.inf):
         self.batch_size = (4 + int(3 * np.log(solution_dim))
                            if batch_size is None else batch_size)
         self.sigma0 = sigma0
         self.solution_dim = solution_dim
         self.dtype = dtype
+        self.lower_bounds = lower_bounds
+        self.upper_bounds = upper_bounds
+
         self._rng = np.random.default_rng(seed)
         self._solutions = None
 
@@ -144,17 +154,10 @@ class SeparableCMAEvolutionStrategy(EvolutionStrategyBase):
     # Limit OpenBLAS to single thread. This is typically faster than
     # multithreading because our data is too small.
     @threadpool_limits.wrap(limits=1, user_api="blas")
-    def ask(self, lower_bounds, upper_bounds, batch_size=None):
+    def ask(self, batch_size=None):
         """Samples new solutions from the Gaussian distribution.
 
         Args:
-            lower_bounds (float or np.ndarray): scalar or (solution_dim,) array
-                indicating lower bounds of the solution space. Scalars specify
-                the same bound for the entire space, while arrays specify a
-                bound for each dimension. Pass -np.inf in the array or scalar to
-                indicated unbounded space.
-            upper_bounds (float or np.ndarray): Same as above, but for upper
-                bounds (and pass np.inf instead of -np.inf).
             batch_size (int): batch size of the sample. Defaults to
                 ``self.batch_size``.
         """
@@ -175,8 +178,8 @@ class SeparableCMAEvolutionStrategy(EvolutionStrategyBase):
                 (len(remaining_indices), self.solution_dim),
             ).astype(self.dtype)
             new_solutions, out_of_bounds = self._transform_and_check_sol(
-                unscaled_params, transform_vec, self.mean, lower_bounds,
-                upper_bounds)
+                unscaled_params, transform_vec, self.mean, self.lower_bounds,
+                self.upper_bounds)
             self._solutions[remaining_indices] = new_solutions
 
             # Find indices in remaining_indices that are still out of bounds

--- a/tests/emitters/evolution_strategy_emitter_test.py
+++ b/tests/emitters/evolution_strategy_emitter_test.py
@@ -45,10 +45,7 @@ def test_list_as_initial_solution():
     archive = GridArchive(solution_dim=10,
                           dims=[20, 20],
                           ranges=[(-1.0, 1.0)] * 2)
-    emitter = EvolutionStrategyEmitter(archive,
-                                       x0=[0.0] * 10,
-                                       sigma0=1.0,
-                                       ranker="obj")
+    emitter = EvolutionStrategyEmitter(archive, x0=[0.0] * 10, sigma0=1.0)
 
     # The list was passed in but should be converted to a numpy array.
     assert isinstance(emitter.x0, np.ndarray)
@@ -62,10 +59,7 @@ def test_dtypes(dtype):
                           dims=[20, 20],
                           ranges=[(-1.0, 1.0)] * 2,
                           dtype=dtype)
-    emitter = EvolutionStrategyEmitter(archive,
-                                       x0=np.zeros(10),
-                                       sigma0=1.0,
-                                       ranker="obj")
+    emitter = EvolutionStrategyEmitter(archive, x0=np.zeros(10), sigma0=1.0)
     assert emitter.x0.dtype == dtype
 
 
@@ -77,7 +71,6 @@ def test_sphere(es):
     emitter = EvolutionStrategyEmitter(archive,
                                        x0=np.zeros(10),
                                        sigma0=1.0,
-                                       ranker="obj",
                                        es=es)
 
     # Try running with the negative sphere function for a few iterations.

--- a/tests/emitters/evolution_strategy_emitter_test.py
+++ b/tests/emitters/evolution_strategy_emitter_test.py
@@ -68,6 +68,18 @@ def test_dtypes(dtype):
                                        ranker="obj")
     assert emitter.x0.dtype == dtype
 
+
+@pytest.mark.parametrize("es", ES_LIST)
+def test_sphere(es):
+    archive = GridArchive(solution_dim=10,
+                          dims=[20, 20],
+                          ranges=[(-1.0, 1.0)] * 2)
+    emitter = EvolutionStrategyEmitter(archive,
+                                       x0=np.zeros(10),
+                                       sigma0=1.0,
+                                       ranker="obj",
+                                       es=es)
+
     # Try running with the negative sphere function for a few iterations.
     for _ in range(10):
         solution_batch = emitter.ask()

--- a/tests/emitters/evolution_strategy_emitter_test.py
+++ b/tests/emitters/evolution_strategy_emitter_test.py
@@ -74,7 +74,7 @@ def test_sphere(es):
                                        es=es)
 
     # Try running with the negative sphere function for a few iterations.
-    for _ in range(10):
+    for _ in range(5):
         solution_batch = emitter.ask()
         objective_batch = -np.sum(np.square(solution_batch), axis=1)
         measures_batch = solution_batch[:, :2]

--- a/tests/emitters/gradient_arborescence_emitter_test.py
+++ b/tests/emitters/gradient_arborescence_emitter_test.py
@@ -81,3 +81,28 @@ def test_tell_dqd_must_be_called_before_tell():
                                               lr=1.0)
         # Must call ask_dqd() before calling ask() to set the jacobian.
         emitter.tell([[0]], [0], [[0]], {"status": [0], "value": [0]})
+
+
+def test_sphere():
+    archive = GridArchive(solution_dim=10,
+                          dims=[20, 20],
+                          ranges=[(-1.0, 1.0)] * 2)
+    emitter = GradientArborescenceEmitter(archive,
+                                          x0=np.zeros(10),
+                                          sigma0=1.0,
+                                          lr=1.0)
+
+    # Try running with the negative sphere function for a few iterations.
+    for _ in range(10):
+        solution = emitter.ask_dqd()
+        objective = -np.sum(np.square(solution), axis=1)
+        measures = solution[:, :2]
+        jacobian = np.random.uniform(-1, 1, (1, 3, 10))
+        add_info = archive.add(solution, objective, measures)
+        emitter.tell_dqd(solution, objective, measures, jacobian, add_info)
+
+        solution = emitter.ask()
+        objective = -np.sum(np.square(solution), axis=1)
+        measures = solution[:, :2]
+        add_info = archive.add(solution, objective, measures)
+        emitter.tell(solution, objective, measures, add_info)

--- a/tests/emitters/gradient_arborescence_emitter_test.py
+++ b/tests/emitters/gradient_arborescence_emitter_test.py
@@ -5,7 +5,7 @@ import pytest
 from ribs.archives import GridArchive
 from ribs.emitters import GradientArborescenceEmitter
 
-ES_LIST = ["cma_es", "sep_cma_es", "lm_ma_es", "openai_es"]
+from .evolution_strategy_emitter_test import ES_LIST
 
 
 def test_auto_batch_size():


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the PR's purpose here. -->

Previously, bounds were passed in to the ES's in the `ask` method. However, we never use dynamic bounds, so it makes more sense to simply pass in the bounds in the init, as is done in the emitters.

Also made some other small changes to clean up the ESs (see TODO list below).

While moving the bounds around is a backwards-incompatible change, I do not anticipate this will affect many people since the evolution strategies are mostly internal classes that are called by the emitters.

## TODO

<!-- Notable points that this PR has either accomplished or will accomplish. -->

- [x] Add `lower_bounds` and `upper_bounds` to `EvolutionStrategyBase.__init__`
- [x] Remove `lower_bounds` and `upper_bounds` from `EvolutionStrategyBase.ask()`
- [x] Add `batch_size=None` to `EvolutionStrategyBase.ask()` (currently, all ES's do this but it was not reflected in the base class).
- [x] Update other ES's to match `EvolutionStrategyBase`
- [x] Remove unnecessary calls to `threadpool_limits` in sep-CMA-ES, LM-MA-ES, and OpenAI-ES -- threadpool_limits was only intended to help with eigendecompositions, and these classes do not use eigendecompositions
- [x] Fix calls in emitters
- [x] Add better tests for emitters

## Questions

<!-- Any concerns or points of confusion? -->

## Status

- [x] I have read the guidelines in
      [CONTRIBUTING.md](https://github.com/icaros-usc/pyribs/blob/master/CONTRIBUTING.md)
- [x] I have formatted my code using `yapf`
- [x] I have tested my code by running `pytest`
- [x] I have linted my code with `pylint`
- [x] I have added a one-line description of my change to the changelog in
      `HISTORY.md`
- [x] This PR is ready to go
