### PR TITLE
Fix alternative centroid methods

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,6 +6,8 @@
 
 #### API
 
+- Support alternative centroid generation methods in CVTArchive ({pr}`417`,
+  {pr}`437`)
 - **Backwards-incompatible:** Move evolution strategy bounds to init ({pr}`436`)
 - **Backwards-incompatible:** Use seed instead of rng in ranker ({pr}`432`)
 - **Backwards-incompatible:** Replace status and value with add_info ({pr}`430`)

--- a/ribs/archives/_cvt_archive.py
+++ b/ribs/archives/_cvt_archive.py
@@ -206,35 +206,29 @@ class CVTArchive(ArchiveBase):
                         "likely happened because there are too few samples "
                         "and/or too many cells.")
             elif centroid_method == "random":
-                # Generate random centroids for the archive.
+                # Generates random centroids.
                 self._centroids = self._rng.uniform(self._lower_bounds,
                                                     self._upper_bounds,
                                                     size=(self._cells,
                                                           self._measure_dim))
             elif centroid_method == "sobol":
-                # Generate self._cells number of centroids as a Sobol sequence.
+                # Generates centroids as a Sobol sequence.
                 sampler = Sobol(d=self._measure_dim, scramble=False)
                 sobol_nums = sampler.random(n=self._cells)
-                lower = self._lower_bounds
-                upper = self._upper_bounds
-                scaled_sobol_nums = lower + sobol_nums * (upper - lower)
-                self._centroids = scaled_sobol_nums
+                self._centroids = (self._lower_bounds + sobol_nums *
+                                   (self._upper_bounds - self._lower_bounds))
             elif centroid_method == "scrambled_sobol":
                 # Generates centroids as a scrambled Sobol sequence.
                 sampler = Sobol(d=self._measure_dim, scramble=True)
                 sobol_nums = sampler.random(n=self._cells)
-                lower = self._lower_bounds
-                upper = self._upper_bounds
-                scaled_sobol_nums = lower + sobol_nums * (upper - lower)
-                self._centroids = scaled_sobol_nums
+                self._centroids = (self._lower_bounds + sobol_nums *
+                                   (self._upper_bounds - self._lower_bounds))
             elif centroid_method == "halton":
-                # Generates centroids using a Halton sequence.
+                # Generates centroids with a Halton sequence.
                 sampler = Halton(d=self._measure_dim)
                 halton_nums = sampler.random(n=self._cells)
-                lower = self._lower_bounds
-                upper = self._upper_bounds
-                scaled_halton_nums = lower + halton_nums * (upper - lower)
-                self._centroids = scaled_halton_nums
+                self._centroids = (self._lower_bounds + halton_nums *
+                                   (self._upper_bounds - self._lower_bounds))
         else:
             # Validate shape of `custom_centroids` when they are provided.
             custom_centroids = np.asarray(custom_centroids, dtype=self.dtype)

--- a/ribs/archives/_cvt_archive.py
+++ b/ribs/archives/_cvt_archive.py
@@ -214,17 +214,27 @@ class CVTArchive(ArchiveBase):
             elif centroid_method == "sobol":
                 # Generate self._cells number of centroids as a Sobol sequence.
                 sampler = Sobol(d=self._measure_dim, scramble=False)
-                num_points = np.log2(self._cells).astype(int)
-                self._centroids = sampler.random_base2(num_points)
+                sobol_nums = sampler.random(n=self._cells)
+                lower = self._lower_bounds
+                upper = self._upper_bounds
+                scaled_sobol_nums = lower + sobol_nums * (upper - lower)
+                self._centroids = scaled_sobol_nums
             elif centroid_method == "scrambled_sobol":
                 # Generates centroids as a scrambled Sobol sequence.
                 sampler = Sobol(d=self._measure_dim, scramble=True)
-                num_points = np.log2(self._cells).astype(int)
-                self._centroids = sampler.random_base2(num_points)
+                sobol_nums = sampler.random(n=self._cells)
+                lower = self._lower_bounds
+                upper = self._upper_bounds
+                scaled_sobol_nums = lower + sobol_nums * (upper - lower)
+                self._centroids = scaled_sobol_nums
             elif centroid_method == "halton":
                 # Generates centroids using a Halton sequence.
                 sampler = Halton(d=self._measure_dim)
-                self._centroids = sampler.random(n=self._cells)
+                halton_nums = sampler.random(n=self._cells)
+                lower = self._lower_bounds
+                upper = self._upper_bounds
+                scaled_halton_nums = lower + halton_nums * (upper - lower)
+                self._centroids = scaled_halton_nums
         else:
             # Validate shape of `custom_centroids` when they are provided.
             custom_centroids = np.asarray(custom_centroids, dtype=self.dtype)

--- a/ribs/archives/_cvt_archive.py
+++ b/ribs/archives/_cvt_archive.py
@@ -99,7 +99,7 @@ class CVTArchive(ArchiveBase):
             ``archive.samples`` will be None. This can be useful when one wishes
             to use the same CVT across experiments for fair comparison.
         centroid_method (str): Pass in the following methods for
-            generating centroids: "random", "sobol", "scrambled sobol",
+            generating centroids: "random", "sobol", "scrambled_sobol",
             "halton". Default method is "kmeans". These methods are derived from
             Mouret 2023: https://dl.acm.org/doi/pdf/10.1145/3583133.3590726.
             Note: Samples are only used when method is "kmeans".

--- a/tests/archives/cvt_archive_test.py
+++ b/tests/archives/cvt_archive_test.py
@@ -70,6 +70,24 @@ def test_custom_centroids_bad_shape(use_kd_tree):
                    use_kd_tree=use_kd_tree)
 
 
+@pytest.mark.parametrize("method",
+                         ["random", "sobol", "scrambled_sobol", "halton"])
+def test_alternative_centroids(method):
+    archive = CVTArchive(
+        solution_dim=10,
+        cells=100,
+        ranges=[(0.1, 0.5), (-0.6, -0.2)],
+        centroid_method=method,
+    )
+
+    centroid_x = archive.centroids[:, 0]
+    centroid_y = archive.centroids[:, 1]
+
+    assert archive.centroids.shape == (100, 2)
+    assert np.all(centroid_x >= 0.1) and np.all(centroid_x <= 0.5)
+    assert np.all(centroid_y >= -0.6) and np.all(centroid_y <= -0.2)
+
+
 @pytest.mark.parametrize("use_list", [True, False], ids=["list", "ndarray"])
 def test_add_single_to_archive(data, use_list, add_mode):
     solution = data.solution
@@ -130,8 +148,8 @@ def test_add_single_without_overwrite(data, add_mode):
                          data.measures, data.centroid)
 
 
-def test_chunked_calculation_short():
-    """Testing accuracy of chunked computation"""
+def test_chunked_calculation():
+    """Testing accuracy of chunked computation for nearest neighbors."""
     centroids = [[-1, 1], [0, 1], [1, 1], [-1, 0], [0, 0], [1, 0], [-1, -1],
                  [0, -1], [1, -1]]
 

--- a/tests/archives/cvt_archive_test.py
+++ b/tests/archives/cvt_archive_test.py
@@ -83,6 +83,7 @@ def test_alternative_centroids(method):
     centroid_x = archive.centroids[:, 0]
     centroid_y = archive.centroids[:, 1]
 
+    # Centroids should have correct shape and be within bounds.
     assert archive.centroids.shape == (100, 2)
     assert np.all(centroid_x >= 0.1) and np.all(centroid_x <= 0.5)
     assert np.all(centroid_y >= -0.6) and np.all(centroid_y <= -0.2)


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the PR's purpose here. -->

The centroid methods in CVTArchive were not generating centroids according to the specifications, i.e., the centroids were not of the correct number, and the centroids were not within the correct bounds.

## TODO

<!-- Notable points that this PR has either accomplished or will accomplish. -->

- [x] Write test to demonstrate bug
- [x] Fix methods

## Status

- [x] I have read the guidelines in
      [CONTRIBUTING.md](https://github.com/icaros-usc/pyribs/blob/master/CONTRIBUTING.md)
- [x] I have formatted my code using `yapf`
- [x] I have tested my code by running `pytest`
- [x] I have linted my code with `pylint`
- [x] I have added a one-line description of my change to the changelog in
      `HISTORY.md`
- [x] This PR is ready to go
