### PR TITLE
Add ranking values to evolution strategy tell method

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,6 +6,8 @@
 
 #### API
 
+- **Backwards-incompatible:** Add ranking values to evolution strategy tell
+  method ({pr}`438`)
 - **Backwards-incompatible:** Move evolution strategy bounds to init ({pr}`436`)
 - **Backwards-incompatible:** Use seed instead of rng in ranker ({pr}`432`)
 - **Backwards-incompatible:** Replace status and value with add_info ({pr}`430`)

--- a/ribs/emitters/_evolution_strategy_emitter.py
+++ b/ribs/emitters/_evolution_strategy_emitter.py
@@ -241,7 +241,8 @@ class EvolutionStrategyEmitter(EmitterBase):
         self._opt.tell(indices, ranking_values, num_parents)
 
         # Check for reset.
-        if self._opt.check_stop() or self._check_restart(new_sols):
+        if (self._opt.check_stop(ranking_values[indices]) or
+                self._check_restart(new_sols)):
             new_x0 = self.archive.sample_elites(1)["solution"][0]
             self._opt.reset(new_x0)
             self._ranker.reset(self, self.archive)

--- a/ribs/emitters/_evolution_strategy_emitter.py
+++ b/ribs/emitters/_evolution_strategy_emitter.py
@@ -241,8 +241,7 @@ class EvolutionStrategyEmitter(EmitterBase):
         self._opt.tell(indices, ranking_values, num_parents)
 
         # Check for reset.
-        if (self._opt.check_stop(ranking_values[indices]) or
-                self._check_restart(new_sols)):
+        if self._opt.check_stop() or self._check_restart(new_sols):
             new_x0 = self.archive.sample_elites(1)["solution"][0]
             self._opt.reset(new_x0)
             self._ranker.reset(self, self.archive)

--- a/ribs/emitters/_evolution_strategy_emitter.py
+++ b/ribs/emitters/_evolution_strategy_emitter.py
@@ -238,7 +238,7 @@ class EvolutionStrategyEmitter(EmitterBase):
                        self._batch_size // 2)
 
         # Update Evolution Strategy.
-        self._opt.tell(indices, num_parents)
+        self._opt.tell(indices, ranking_values, num_parents)
 
         # Check for reset.
         if (self._opt.check_stop(ranking_values[indices]) or

--- a/ribs/emitters/_gradient_arborescence_emitter.py
+++ b/ribs/emitters/_gradient_arborescence_emitter.py
@@ -411,7 +411,8 @@ class GradientArborescenceEmitter(EmitterBase):
         self._grad_opt.step(gradient_step)
 
         # Check for reset.
-        if self._opt.check_stop() or self._check_restart(new_sols):
+        if (self._opt.check_stop(ranking_values[indices]) or
+                self._check_restart(new_sols)):
             new_coeff = self.archive.sample_elites(1)["solution"][0]
             self._grad_opt.reset(new_coeff)
             self._opt.reset(np.zeros(self._num_coefficients))

--- a/ribs/emitters/_gradient_arborescence_emitter.py
+++ b/ribs/emitters/_gradient_arborescence_emitter.py
@@ -396,7 +396,7 @@ class GradientArborescenceEmitter(EmitterBase):
                        self._batch_size // 2)
 
         # Update Evolution Strategy.
-        self._opt.tell(indices, num_parents)
+        self._opt.tell(indices, ranking_values, num_parents)
 
         # Calculate a new mean in solution space. These weights are from CMA-ES.
         parents = data["solution"][indices]

--- a/ribs/emitters/_gradient_arborescence_emitter.py
+++ b/ribs/emitters/_gradient_arborescence_emitter.py
@@ -411,8 +411,7 @@ class GradientArborescenceEmitter(EmitterBase):
         self._grad_opt.step(gradient_step)
 
         # Check for reset.
-        if (self._opt.check_stop(ranking_values[indices]) or
-                self._check_restart(new_sols)):
+        if self._opt.check_stop() or self._check_restart(new_sols):
             new_coeff = self.archive.sample_elites(1)["solution"][0]
             self._grad_opt.reset(new_coeff)
             self._opt.reset(np.zeros(self._num_coefficients))

--- a/ribs/emitters/opt/_cma_es.py
+++ b/ribs/emitters/opt/_cma_es.py
@@ -244,7 +244,7 @@ class CMAEvolutionStrategy(EvolutionStrategyBase):
     # Limit OpenBLAS to single thread. This is typically faster than
     # multithreading because our data is too small.
     @threadpool_limits.wrap(limits=1, user_api="blas")
-    def tell(self, ranking_indices, num_parents):
+    def tell(self, ranking_indices, ranking_values, num_parents):
         self.current_eval += len(self._solutions[ranking_indices])
 
         if num_parents == 0:

--- a/ribs/emitters/opt/_cma_es.py
+++ b/ribs/emitters/opt/_cma_es.py
@@ -117,6 +117,8 @@ class CMAEvolutionStrategy(EvolutionStrategyBase):
 
         self._rng = np.random.default_rng(seed)
         self._solutions = None
+        self._ranking_indices = None
+        self._ranking_values = None
 
         # Calculate gap between covariance matrix updates.
         num_parents = self.batch_size // 2
@@ -144,7 +146,7 @@ class CMAEvolutionStrategy(EvolutionStrategyBase):
         # Setup the covariance matrix.
         self.cov = DecompMatrix(self.solution_dim, self.dtype)
 
-    def check_stop(self, ranking_values):
+    def check_stop(self):
         # Tolerances from pycma CMA-ES.
         if self.cov.condition_number > 1e14:
             return True
@@ -156,8 +158,9 @@ class CMAEvolutionStrategy(EvolutionStrategyBase):
 
         # Fitness is too flat (only applies if there are at least 2 parents).
         # NOTE: We use norm here because we may have multiple ranking values.
-        if (len(ranking_values) >= 2 and
-                np.linalg.norm(ranking_values[0] - ranking_values[-1]) < 1e-12):
+        sorted_values = self._ranking_values[self._ranking_indices]
+        if (len(sorted_values) >= 2 and
+                np.linalg.norm(sorted_values[0] - sorted_values[-1]) < 1e-12):
             return True
 
         return False
@@ -244,8 +247,10 @@ class CMAEvolutionStrategy(EvolutionStrategyBase):
     # Limit OpenBLAS to single thread. This is typically faster than
     # multithreading because our data is too small.
     @threadpool_limits.wrap(limits=1, user_api="blas")
-    def tell(self, ranking_indices, num_parents):
+    def tell(self, ranking_indices, ranking_values, num_parents):
         self.current_eval += len(self._solutions[ranking_indices])
+        self._ranking_indices = ranking_indices
+        self._ranking_values = ranking_values
 
         if num_parents == 0:
             return

--- a/ribs/emitters/opt/_cma_es.py
+++ b/ribs/emitters/opt/_cma_es.py
@@ -133,11 +133,6 @@ class CMAEvolutionStrategy(EvolutionStrategyBase):
         self.cov = None
 
     def reset(self, x0):
-        """Resets the optimizer to start at x0.
-
-        Args:
-            x0 (np.ndarray): Initial mean.
-        """
         self.current_eval = 0
         self.sigma = self.sigma0
         self.mean = np.array(x0, self.dtype)
@@ -150,18 +145,7 @@ class CMAEvolutionStrategy(EvolutionStrategyBase):
         self.cov = DecompMatrix(self.solution_dim, self.dtype)
 
     def check_stop(self, ranking_values):
-        """Checks if the optimization should stop and be reset.
-
-        Tolerances come from CMA-ES.
-
-        Args:
-            ranking_values (np.ndarray): Array of objective values of the
-                solutions, sorted in the same order that the solutions were
-                sorted when passed to ``tell()``.
-
-        Returns:
-            True if any of the stopping conditions are satisfied.
-        """
+        # Tolerances from pycma CMA-ES.
         if self.cov.condition_number > 1e14:
             return True
 
@@ -198,12 +182,6 @@ class CMAEvolutionStrategy(EvolutionStrategyBase):
     # multithreading because our data is too small.
     @threadpool_limits.wrap(limits=1, user_api="blas")
     def ask(self, batch_size=None):
-        """Samples new solutions from the Gaussian distribution.
-
-        Args:
-            batch_size (int): batch size of the sample. Defaults to
-                ``self.batch_size``.
-        """
         if batch_size is None:
             batch_size = self.batch_size
 
@@ -267,14 +245,6 @@ class CMAEvolutionStrategy(EvolutionStrategyBase):
     # multithreading because our data is too small.
     @threadpool_limits.wrap(limits=1, user_api="blas")
     def tell(self, ranking_indices, num_parents):
-        """Passes the solutions back to the optimizer.
-
-        Args:
-            ranking_indices (array-like of int): Indices that indicate the
-                ranking of the original solutions returned in ``ask()``.
-            num_parents (int): Number of top solutions to select from the
-                ranked solutions.
-        """
         self.current_eval += len(self._solutions[ranking_indices])
 
         if num_parents == 0:

--- a/ribs/emitters/opt/_evolution_strategy_base.py
+++ b/ribs/emitters/opt/_evolution_strategy_base.py
@@ -52,18 +52,6 @@ class EvolutionStrategyBase(ABC):
         """
 
     @abstractmethod
-    def check_stop(self, ranking_values):
-        """Checks if the ES should stop and be reset.
-
-        Args:
-            ranking_values (numpy.ndarray): Array of objective values of the
-                solutions, sorted in the same order that the solutions were
-                sorted when passed to tell().
-        Returns:
-            True if any of the stopping conditions are satisfied.
-        """
-
-    @abstractmethod
     def ask(self, batch_size=None):
         """Samples new solutions.
 
@@ -82,9 +70,25 @@ class EvolutionStrategyBase(ABC):
                 NOT the ranks of the solutions. Rather, they are indices such
                 that ``solutions[ranking_indices]`` will correctly rank the
                 solutions (think of an argsort).
-            ranking_values (numpy.ndarray): Array of objective values of the
-                solutions, sorted in the same order that the solutions were
-                sorted when passed to tell().
+            ranking_values (numpy.ndarray): Array of values that were used to
+                rank the solutions. Shape can be either ``(batch_size,)`` or
+                (batch_size, n_values)``, where ``batch_size`` is the number of
+                solutions and ``n_values`` is the number of values that the
+                ranker used.
             num_parents (int): Number of top solutions to select from the
                 ranked solutions.
+        """
+
+    @abstractmethod
+    def check_stop(self, ranking_values):
+        """Checks if the ES should stop and be reset.
+
+        Args:
+            ranking_values (numpy.ndarray): Array of values that were used to
+                rank the solutions. Shape can be either ``(batch_size,)`` or
+                (batch_size, n_values)``, where ``batch_size`` is the number of
+                solutions and ``n_values`` is the number of values that the
+                ranker used.
+        Returns:
+            True if any of the stopping conditions are satisfied.
         """

--- a/ribs/emitters/opt/_evolution_strategy_base.py
+++ b/ribs/emitters/opt/_evolution_strategy_base.py
@@ -52,18 +52,6 @@ class EvolutionStrategyBase(ABC):
         """
 
     @abstractmethod
-    def check_stop(self, ranking_values):
-        """Checks if the ES should stop and be reset.
-
-        Args:
-            ranking_values (numpy.ndarray): Array of objective values of the
-                solutions, sorted in the same order that the solutions were
-                sorted when passed to tell().
-        Returns:
-            True if any of the stopping conditions are satisfied.
-        """
-
-    @abstractmethod
     def ask(self, batch_size=None):
         """Samples new solutions.
 
@@ -82,9 +70,22 @@ class EvolutionStrategyBase(ABC):
                 NOT the ranks of the solutions. Rather, they are indices such
                 that ``solutions[ranking_indices]`` will correctly rank the
                 solutions (think of an argsort).
-            ranking_values (numpy.ndarray): Array of objective values of the
-                solutions, sorted in the same order that the solutions were
-                sorted when passed to tell().
+            ranking_values (numpy.ndarray): Array of values that were used to
+                rank the solutions. Shape can be either ``(batch_size,)`` or
+                (batch_size, n_values)``, where ``batch_size`` is the number of
+                solutions and ``n_values`` is the number of values that the
+                ranker used.
             num_parents (int): Number of top solutions to select from the
                 ranked solutions.
+        """
+
+    @abstractmethod
+    def check_stop(self):
+        """Checks if the ES should stop and be reset.
+
+        This must be called after calling :meth:`tell`, since we need to look at
+        ``ranking_values`` before deciding whether to terminate.
+
+        Returns:
+            True if any of the stopping conditions are satisfied.
         """

--- a/ribs/emitters/opt/_evolution_strategy_base.py
+++ b/ribs/emitters/opt/_evolution_strategy_base.py
@@ -14,7 +14,7 @@ class EvolutionStrategyBase(ABC):
 
         - Request new solutions with ``ask()``
         - Rank the solutions in the emitter (better solutions come first) and
-          pass the indices back with ``tell()``.
+          pass the indices and values back with ``tell()``.
         - Use ``check_stop()`` to see if the optimizer has reached a stopping
           condition, and if so, call ``reset()``.
 
@@ -24,12 +24,12 @@ class EvolutionStrategyBase(ABC):
         batch_size (int): Number of solutions to evaluate at a time.
         seed (int): Seed for the random number generator.
         dtype (str or data-type): Data type of solutions.
-        lower_bounds (float or np.ndarray): scalar or (solution_dim,) array
+        lower_bounds (float or numpy.ndarray): scalar or (solution_dim,) array
             indicating lower bounds of the solution space. Scalars specify
             the same bound for the entire space, while arrays specify a
             bound for each dimension. Pass -np.inf in the array or scalar to
             indicated unbounded space.
-        upper_bounds (float or np.ndarray): Same as above, but for upper
+        upper_bounds (float or numpy.ndarray): Same as above, but for upper
             bounds (and pass np.inf instead of -np.inf).
     """
 
@@ -45,18 +45,18 @@ class EvolutionStrategyBase(ABC):
 
     @abstractmethod
     def reset(self, x0):
-        """Resets the optimizer to start at x0.
+        """Resets the ES to start at x0.
 
         Args:
-            x0 (np.ndarray): Initial mean.
+            x0 (numpy.ndarray): Initial mean.
         """
 
     @abstractmethod
     def check_stop(self, ranking_values):
-        """Checks if the optimizer should stop and be reset.
+        """Checks if the ES should stop and be reset.
 
         Args:
-            ranking_values (np.ndarray): Array of objective values of the
+            ranking_values (numpy.ndarray): Array of objective values of the
                 solutions, sorted in the same order that the solutions were
                 sorted when passed to tell().
         Returns:
@@ -65,7 +65,7 @@ class EvolutionStrategyBase(ABC):
 
     @abstractmethod
     def ask(self, batch_size=None):
-        """Samples new solutions from the Gaussian distribution.
+        """Samples new solutions.
 
         Args:
             batch_size (int): batch size of the sample. Defaults to
@@ -73,12 +73,18 @@ class EvolutionStrategyBase(ABC):
         """
 
     @abstractmethod
-    def tell(self, ranking_indices, num_parents):
-        """Passes the solutions back to the optimizer.
+    def tell(self, ranking_indices, ranking_values, num_parents):
+        """Passes the solutions back to the ES.
 
         Args:
-            ranking_indices (array-like of int): Indices that indicate the
-                ranking of the original solutions returned in ``ask()``.
+            ranking_indices (numpy.ndarray): Integer indices that are used to
+                rank the solutions returned in :meth:`ask`. Note that these are
+                NOT the ranks of the solutions. Rather, they are indices such
+                that ``solutions[ranking_indices]`` will correctly rank the
+                solutions (think of an argsort).
+            ranking_values (numpy.ndarray): Array of objective values of the
+                solutions, sorted in the same order that the solutions were
+                sorted when passed to tell().
             num_parents (int): Number of top solutions to select from the
                 ranked solutions.
         """

--- a/ribs/emitters/opt/_evolution_strategy_base.py
+++ b/ribs/emitters/opt/_evolution_strategy_base.py
@@ -52,6 +52,20 @@ class EvolutionStrategyBase(ABC):
         """
 
     @abstractmethod
+    def check_stop(self, ranking_values):
+        """Checks if the ES should stop and be reset.
+
+        Args:
+            ranking_values (numpy.ndarray): Array of values that were used to
+                rank the solutions. Shape can be either ``(batch_size,)`` or
+                (batch_size, n_values)``, where ``batch_size`` is the number of
+                solutions and ``n_values`` is the number of values that the
+                ranker used.
+        Returns:
+            True if any of the stopping conditions are satisfied.
+        """
+
+    @abstractmethod
     def ask(self, batch_size=None):
         """Samples new solutions.
 
@@ -77,18 +91,4 @@ class EvolutionStrategyBase(ABC):
                 ranker used.
             num_parents (int): Number of top solutions to select from the
                 ranked solutions.
-        """
-
-    @abstractmethod
-    def check_stop(self, ranking_values):
-        """Checks if the ES should stop and be reset.
-
-        Args:
-            ranking_values (numpy.ndarray): Array of values that were used to
-                rank the solutions. Shape can be either ``(batch_size,)`` or
-                (batch_size, n_values)``, where ``batch_size`` is the number of
-                solutions and ``n_values`` is the number of values that the
-                ranker used.
-        Returns:
-            True if any of the stopping conditions are satisfied.
         """

--- a/ribs/emitters/opt/_evolution_strategy_base.py
+++ b/ribs/emitters/opt/_evolution_strategy_base.py
@@ -60,7 +60,9 @@ class EvolutionStrategyBase(ABC):
                 rank the solutions. Shape can be either ``(batch_size,)`` or
                 (batch_size, n_values)``, where ``batch_size`` is the number of
                 solutions and ``n_values`` is the number of values that the
-                ranker used.
+                ranker used. Note that unlike in :meth:`tell`, these values must
+                be sorted according to the ``ranking_indices`` passed to
+                :meth:`tell`.
         Returns:
             True if any of the stopping conditions are satisfied.
         """

--- a/ribs/emitters/opt/_evolution_strategy_base.py
+++ b/ribs/emitters/opt/_evolution_strategy_base.py
@@ -52,6 +52,18 @@ class EvolutionStrategyBase(ABC):
         """
 
     @abstractmethod
+    def check_stop(self, ranking_values):
+        """Checks if the ES should stop and be reset.
+
+        Args:
+            ranking_values (numpy.ndarray): Array of objective values of the
+                solutions, sorted in the same order that the solutions were
+                sorted when passed to tell().
+        Returns:
+            True if any of the stopping conditions are satisfied.
+        """
+
+    @abstractmethod
     def ask(self, batch_size=None):
         """Samples new solutions.
 
@@ -70,22 +82,9 @@ class EvolutionStrategyBase(ABC):
                 NOT the ranks of the solutions. Rather, they are indices such
                 that ``solutions[ranking_indices]`` will correctly rank the
                 solutions (think of an argsort).
-            ranking_values (numpy.ndarray): Array of values that were used to
-                rank the solutions. Shape can be either ``(batch_size,)`` or
-                (batch_size, n_values)``, where ``batch_size`` is the number of
-                solutions and ``n_values`` is the number of values that the
-                ranker used.
+            ranking_values (numpy.ndarray): Array of objective values of the
+                solutions, sorted in the same order that the solutions were
+                sorted when passed to tell().
             num_parents (int): Number of top solutions to select from the
                 ranked solutions.
-        """
-
-    @abstractmethod
-    def check_stop(self):
-        """Checks if the ES should stop and be reset.
-
-        This must be called after calling :meth:`tell`, since we need to look at
-        ``ranking_values`` before deciding whether to terminate.
-
-        Returns:
-            True if any of the stopping conditions are satisfied.
         """

--- a/ribs/emitters/opt/_lm_ma_es.py
+++ b/ribs/emitters/opt/_lm_ma_es.py
@@ -175,7 +175,7 @@ class LMMAEvolutionStrategy(EvolutionStrategyBase):
 
         return weights, mueff
 
-    def tell(self, ranking_indices, num_parents):
+    def tell(self, ranking_indices, ranking_values, num_parents):
         self.current_gens += 1
 
         if num_parents == 0:

--- a/ribs/emitters/opt/_lm_ma_es.py
+++ b/ribs/emitters/opt/_lm_ma_es.py
@@ -84,11 +84,6 @@ class LMMAEvolutionStrategy(EvolutionStrategyBase):
         self.m = None
 
     def reset(self, x0):
-        """Resets the optimizer to start at x0.
-
-        Args:
-            x0 (np.ndarray): Initial mean.
-        """
         self.current_gens = 0
         self.sigma = self.sigma0
         self.mean = np.array(x0, self.dtype)
@@ -100,18 +95,6 @@ class LMMAEvolutionStrategy(EvolutionStrategyBase):
         self.m = np.zeros((self.n_vectors, self.solution_dim))
 
     def check_stop(self, ranking_values):
-        """Checks if the optimization should stop and be reset.
-
-        Tolerances come from CMA-ES.
-
-        Args:
-            ranking_values (np.ndarray): Array of objective values of the
-                solutions, sorted in the same order that the solutions were
-                sorted when passed to ``tell()``.
-
-        Returns:
-            True if any of the stopping conditions are satisfied.
-        """
         # Sigma too small - Note: this was 1e-20 in the reference LM-MA-ES code.
         if self.sigma < 1e-12:
             return True
@@ -149,12 +132,6 @@ class LMMAEvolutionStrategy(EvolutionStrategyBase):
         return new_solutions, out_of_bounds
 
     def ask(self, batch_size=None):
-        """Samples new solutions from the Gaussian distribution.
-
-        Args:
-            batch_size (int): batch size of the sample. Defaults to
-                ``self.batch_size``.
-        """
         # NOTE: The LM-MA-ES uses mirror sampling by default, but we do not.
         if batch_size is None:
             batch_size = self.batch_size
@@ -199,14 +176,6 @@ class LMMAEvolutionStrategy(EvolutionStrategyBase):
         return weights, mueff
 
     def tell(self, ranking_indices, num_parents):
-        """Passes the solutions back to the optimizer.
-
-        Args:
-            ranking_indices (array-like of int): Indices that indicate the
-                ranking of the original solutions returned in ``ask()``.
-            num_parents (int): Number of top solutions to select from the
-                ranked solutions.
-        """
         self.current_gens += 1
 
         if num_parents == 0:

--- a/ribs/emitters/opt/_lm_ma_es.py
+++ b/ribs/emitters/opt/_lm_ma_es.py
@@ -56,8 +56,6 @@ class LMMAEvolutionStrategy(EvolutionStrategyBase):
 
         self._rng = np.random.default_rng(seed)
         self._solutions = None
-        self._ranking_indices = None
-        self._ranking_values = None
 
         if self.batch_size > self.solution_dim:
             raise ValueError(f"batch_size ({self.batch_size}) is greater than"
@@ -96,16 +94,14 @@ class LMMAEvolutionStrategy(EvolutionStrategyBase):
         # Setup the matrix vectors.
         self.m = np.zeros((self.n_vectors, self.solution_dim))
 
-    def check_stop(self):
+    def check_stop(self, ranking_values):
         # Sigma too small - Note: this was 1e-20 in the reference LM-MA-ES code.
         if self.sigma < 1e-12:
             return True
 
-        # Fitness is too flat (only applies if there are at least 2 parents).
         # NOTE: We use norm here because we may have multiple ranking values.
-        sorted_values = self._ranking_values[self._ranking_indices]
-        if (len(sorted_values) >= 2 and
-                np.linalg.norm(sorted_values[0] - sorted_values[-1]) < 1e-12):
+        if (len(ranking_values) >= 2 and
+                np.linalg.norm(ranking_values[0] - ranking_values[-1]) < 1e-12):
             return True
 
         return False
@@ -179,10 +175,8 @@ class LMMAEvolutionStrategy(EvolutionStrategyBase):
 
         return weights, mueff
 
-    def tell(self, ranking_indices, ranking_values, num_parents):
+    def tell(self, ranking_indices, num_parents):
         self.current_gens += 1
-        self._ranking_indices = ranking_indices
-        self._ranking_values = ranking_values
 
         if num_parents == 0:
             return

--- a/ribs/emitters/opt/_openai_es.py
+++ b/ribs/emitters/opt/_openai_es.py
@@ -79,26 +79,11 @@ class OpenAIEvolutionStrategy(EvolutionStrategyBase):
         self.noise = None
 
     def reset(self, x0):
-        """Resets the optimizer to start at x0.
-
-        Args:
-            x0 (np.ndarray): Initial mean.
-        """
         self.adam_opt.reset(x0)
         self.last_update_ratio = np.inf  # Updated at end of tell().
         self.noise = None  # Becomes (batch_size, solution_dim) array in ask().
 
     def check_stop(self, ranking_values):
-        """Checks if the optimization should stop and be reset.
-
-        Args:
-            ranking_values (np.ndarray): Array of objective values of the
-                solutions, sorted in the same order that the solutions were
-                sorted when passed to ``tell()``.
-
-        Returns:
-            True if any of the stopping conditions are satisfied.
-        """
         if self.last_update_ratio < 1e-9:
             return True
 
@@ -111,12 +96,6 @@ class OpenAIEvolutionStrategy(EvolutionStrategyBase):
         return False
 
     def ask(self, batch_size=None):
-        """Samples new solutions from the Gaussian distribution.
-
-        Args:
-            batch_size (int): batch size of the sample. Defaults to
-                ``self.batch_size``.
-        """
         if batch_size is None:
             batch_size = self.batch_size
 
@@ -156,14 +135,6 @@ class OpenAIEvolutionStrategy(EvolutionStrategyBase):
             ranking_indices,
             num_parents,  # pylint: disable = unused-argument
     ):
-        """Passes the solutions back to the optimizer.
-
-        Args:
-            ranking_indices (array-like of int): Indices that indicate the
-                ranking of the original solutions returned in ``ask()``.
-            num_parents (int): Number of top solutions to select from the
-                ranked solutions.
-        """
         # Indices come in decreasing order, so we reverse to get them to
         # increasing order.
         ranks = np.empty(self.batch_size, dtype=np.int32)

--- a/ribs/emitters/opt/_openai_es.py
+++ b/ribs/emitters/opt/_openai_es.py
@@ -57,6 +57,8 @@ class OpenAIEvolutionStrategy(EvolutionStrategyBase):
 
         self._rng = np.random.default_rng(seed)
         self._solutions = None
+        self._ranking_indices = None
+        self._ranking_values = None
 
         self.mirror_sampling = mirror_sampling
 
@@ -82,18 +84,6 @@ class OpenAIEvolutionStrategy(EvolutionStrategyBase):
         self.adam_opt.reset(x0)
         self.last_update_ratio = np.inf  # Updated at end of tell().
         self.noise = None  # Becomes (batch_size, solution_dim) array in ask().
-
-    def check_stop(self, ranking_values):
-        if self.last_update_ratio < 1e-9:
-            return True
-
-        # Fitness is too flat (only applies if there are at least 2 parents).
-        # NOTE: We use norm here because we may have multiple ranking values.
-        if (len(ranking_values) >= 2 and
-                np.linalg.norm(ranking_values[0] - ranking_values[-1]) < 1e-12):
-            return True
-
-        return False
 
     def ask(self, batch_size=None):
         if batch_size is None:
@@ -130,11 +120,10 @@ class OpenAIEvolutionStrategy(EvolutionStrategyBase):
 
         return readonly(self._solutions)
 
-    def tell(
-            self,
-            ranking_indices,
-            num_parents,  # pylint: disable = unused-argument
-    ):
+    def tell(self, ranking_indices, ranking_values, num_parents):
+        self._ranking_indices = ranking_indices
+        self._ranking_values = ranking_values
+
         # Indices come in decreasing order, so we reverse to get them to
         # increasing order.
         ranks = np.empty(self.batch_size, dtype=np.int32)
@@ -165,3 +154,16 @@ class OpenAIEvolutionStrategy(EvolutionStrategyBase):
         self.last_update_ratio = (
             np.linalg.norm(self.adam_opt.theta - theta_prev) /
             np.linalg.norm(self.adam_opt.theta))
+
+    def check_stop(self):
+        if self.last_update_ratio < 1e-9:
+            return True
+
+        # Fitness is too flat (only applies if there are at least 2 parents).
+        # NOTE: We use norm here because we may have multiple ranking values.
+        sorted_values = self._ranking_values[self._ranking_indices]
+        if (len(sorted_values) >= 2 and
+                np.linalg.norm(sorted_values[0] - sorted_values[-1]) < 1e-12):
+            return True
+
+        return False

--- a/ribs/emitters/opt/_openai_es.py
+++ b/ribs/emitters/opt/_openai_es.py
@@ -130,11 +130,7 @@ class OpenAIEvolutionStrategy(EvolutionStrategyBase):
 
         return readonly(self._solutions)
 
-    def tell(
-            self,
-            ranking_indices,
-            num_parents,  # pylint: disable = unused-argument
-    ):
+    def tell(self, ranking_indices, ranking_values, num_parents):
         # Indices come in decreasing order, so we reverse to get them to
         # increasing order.
         ranks = np.empty(self.batch_size, dtype=np.int32)

--- a/ribs/emitters/opt/_sep_cma_es.py
+++ b/ribs/emitters/opt/_sep_cma_es.py
@@ -234,7 +234,7 @@ class SeparableCMAEvolutionStrategy(EvolutionStrategyBase):
         return (cov * (1 - c1a - cmu * np.sum(weights)) + rank_one_update * c1 +
                 rank_mu_update * cmu / (sigma**2))
 
-    def tell(self, ranking_indices, num_parents):
+    def tell(self, ranking_indices, ranking_values, num_parents):
         self.current_eval += len(self._solutions[ranking_indices])
 
         if num_parents == 0:

--- a/ribs/emitters/opt/_sep_cma_es.py
+++ b/ribs/emitters/opt/_sep_cma_es.py
@@ -95,11 +95,6 @@ class SeparableCMAEvolutionStrategy(EvolutionStrategyBase):
         self.cov = None
 
     def reset(self, x0):
-        """Resets the optimizer to start at x0.
-
-        Args:
-            x0 (np.ndarray): Initial mean.
-        """
         self.current_eval = 0
         self.sigma = self.sigma0
         self.mean = np.array(x0, self.dtype)
@@ -112,18 +107,7 @@ class SeparableCMAEvolutionStrategy(EvolutionStrategyBase):
         self.cov = DiagonalMatrix(self.solution_dim, self.dtype)
 
     def check_stop(self, ranking_values):
-        """Checks if the optimization should stop and be reset.
-
-        Tolerances come from CMA-ES.
-
-        Args:
-            ranking_values (np.ndarray): Array of objective values of the
-                solutions, sorted in the same order that the solutions were
-                sorted when passed to ``tell()``.
-
-        Returns:
-            True if any of the stopping conditions are satisfied.
-        """
+        # Tolerances from pycma CMA-ES.
         if self.cov.condition_number > 1e14:
             return True
 
@@ -154,12 +138,6 @@ class SeparableCMAEvolutionStrategy(EvolutionStrategyBase):
         return solutions, out_of_bounds
 
     def ask(self, batch_size=None):
-        """Samples new solutions from the Gaussian distribution.
-
-        Args:
-            batch_size (int): batch size of the sample. Defaults to
-                ``self.batch_size``.
-        """
         if batch_size is None:
             batch_size = self.batch_size
 
@@ -257,14 +235,6 @@ class SeparableCMAEvolutionStrategy(EvolutionStrategyBase):
                 rank_mu_update * cmu / (sigma**2))
 
     def tell(self, ranking_indices, num_parents):
-        """Passes the solutions back to the optimizer.
-
-        Args:
-            ranking_indices (array-like of int): Indices that indicate the
-                ranking of the original solutions returned in ``ask()``.
-            num_parents (int): Number of top solutions to select from the
-                ranked solutions.
-        """
         self.current_eval += len(self._solutions[ranking_indices])
 
         if num_parents == 0:

--- a/ribs/emitters/opt/_sep_cma_es.py
+++ b/ribs/emitters/opt/_sep_cma_es.py
@@ -85,6 +85,8 @@ class SeparableCMAEvolutionStrategy(EvolutionStrategyBase):
 
         self._rng = np.random.default_rng(seed)
         self._solutions = None
+        self._ranking_indices = None
+        self._ranking_values = None
 
         # Strategy-specific params -> initialized in reset().
         self.current_eval = None
@@ -106,7 +108,7 @@ class SeparableCMAEvolutionStrategy(EvolutionStrategyBase):
         # Setup the covariance matrix.
         self.cov = DiagonalMatrix(self.solution_dim, self.dtype)
 
-    def check_stop(self, ranking_values):
+    def check_stop(self):
         # Tolerances from pycma CMA-ES.
         if self.cov.condition_number > 1e14:
             return True
@@ -118,8 +120,9 @@ class SeparableCMAEvolutionStrategy(EvolutionStrategyBase):
 
         # Fitness is too flat (only applies if there are at least 2 parents).
         # NOTE: We use norm here because we may have multiple ranking values.
-        if (len(ranking_values) >= 2 and
-                np.linalg.norm(ranking_values[0] - ranking_values[-1]) < 1e-12):
+        sorted_values = self._ranking_values[self._ranking_indices]
+        if (len(sorted_values) >= 2 and
+                np.linalg.norm(sorted_values[0] - sorted_values[-1]) < 1e-12):
             return True
 
         return False
@@ -234,8 +237,10 @@ class SeparableCMAEvolutionStrategy(EvolutionStrategyBase):
         return (cov * (1 - c1a - cmu * np.sum(weights)) + rank_one_update * c1 +
                 rank_mu_update * cmu / (sigma**2))
 
-    def tell(self, ranking_indices, num_parents):
+    def tell(self, ranking_indices, ranking_values, num_parents):
         self.current_eval += len(self._solutions[ranking_indices])
+        self._ranking_indices = ranking_indices
+        self._ranking_values = ranking_values
 
         if num_parents == 0:
             return

--- a/ribs/emitters/opt/_sep_cma_es.py
+++ b/ribs/emitters/opt/_sep_cma_es.py
@@ -85,8 +85,6 @@ class SeparableCMAEvolutionStrategy(EvolutionStrategyBase):
 
         self._rng = np.random.default_rng(seed)
         self._solutions = None
-        self._ranking_indices = None
-        self._ranking_values = None
 
         # Strategy-specific params -> initialized in reset().
         self.current_eval = None
@@ -108,7 +106,7 @@ class SeparableCMAEvolutionStrategy(EvolutionStrategyBase):
         # Setup the covariance matrix.
         self.cov = DiagonalMatrix(self.solution_dim, self.dtype)
 
-    def check_stop(self):
+    def check_stop(self, ranking_values):
         # Tolerances from pycma CMA-ES.
         if self.cov.condition_number > 1e14:
             return True
@@ -120,9 +118,8 @@ class SeparableCMAEvolutionStrategy(EvolutionStrategyBase):
 
         # Fitness is too flat (only applies if there are at least 2 parents).
         # NOTE: We use norm here because we may have multiple ranking values.
-        sorted_values = self._ranking_values[self._ranking_indices]
-        if (len(sorted_values) >= 2 and
-                np.linalg.norm(sorted_values[0] - sorted_values[-1]) < 1e-12):
+        if (len(ranking_values) >= 2 and
+                np.linalg.norm(ranking_values[0] - ranking_values[-1]) < 1e-12):
             return True
 
         return False
@@ -237,10 +234,8 @@ class SeparableCMAEvolutionStrategy(EvolutionStrategyBase):
         return (cov * (1 - c1a - cmu * np.sum(weights)) + rank_one_update * c1 +
                 rank_mu_update * cmu / (sigma**2))
 
-    def tell(self, ranking_indices, ranking_values, num_parents):
+    def tell(self, ranking_indices, num_parents):
         self.current_eval += len(self._solutions[ranking_indices])
-        self._ranking_indices = ranking_indices
-        self._ranking_values = ranking_values
 
         if num_parents == 0:
             return

--- a/ribs/emitters/rankers.py
+++ b/ribs/emitters/rankers.py
@@ -125,7 +125,7 @@ class ImprovementRanker(RankerBase):
     """
 
     def rank(self, emitter, archive, data, add_info):
-        # Note that lexsort sorts the values in ascending order,
+        # Note that argsort sorts the values in ascending order,
         # so we use np.flip to reverse the sorted array.
         return np.flip(np.argsort(add_info["value"])), add_info["value"]
 


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the PR's purpose here. -->

This PR adds the `ranking_values` argument to the tell() method in evolution strategies. This paves the way for #434, since pycma needs the ranking values to be passed into tell().

Note that I considered removing ranking_values from `check_stop` and instead forcing the ES to store its own ranking values like pycma does, but I do not think this is a necessary change.

This change is backwards-incompatible, but similar to #436, I do not think it will affect most users.

## TODO

<!-- Notable points that this PR has either accomplished or will accomplish. -->

- [x] Update EvolutionStrategyBase and corresponding ESs
- [x] Update emitter calls
- [x] Remove redundant method docstrings

## Questions

<!-- Any concerns or points of confusion? -->

## Status

- [x] I have read the guidelines in
      [CONTRIBUTING.md](https://github.com/icaros-usc/pyribs/blob/master/CONTRIBUTING.md)
- [x] I have formatted my code using `yapf`
- [x] I have tested my code by running `pytest`
- [x] I have linted my code with `pylint`
- [x] I have added a one-line description of my change to the changelog in
      `HISTORY.md`
- [x] This PR is ready to go
