### PR TITLE
Allow overriding ES in sphere example

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,7 +6,6 @@
 
 #### API
 
-- Allow overriding ES in sphere example ({pr}`439`)
 - Add PyCMAEvolutionStrategy for using pycma in ES emitters ({pr}`434`)
 - **Backwards-incompatible:** Add ranking values to evolution strategy tell
   method ({pr}`438`)
@@ -39,6 +38,7 @@
 
 #### Improvements
 
+- Allow overriding ES in sphere example ({pr}`439`)
 - Use NumPy SeedSequence in emitters ({pr}`431`)
 - Use numbers types when checking arguments ({pr}`419`)
 - Reimplement ArchiveBase using ArrayStore ({pr}`399`)

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,6 +6,7 @@
 
 #### API
 
+- Allow overriding ES in sphere example ({pr}`439`)
 - Add PyCMAEvolutionStrategy for using pycma in ES emitters ({pr}`434`)
 - **Backwards-incompatible:** Add ranking values to evolution strategy tell
   method ({pr}`438`)

--- a/examples/sphere.py
+++ b/examples/sphere.py
@@ -801,6 +801,8 @@ def sphere_main(algorithm,
                 e["kwargs"]["es"] = es
 
     name = f"{algorithm}_{config['dim']}"
+    if es is not None:
+        name += f"_{es}"
     outdir = Path(outdir)
     if not outdir.is_dir():
         outdir.mkdir()

--- a/examples/sphere.py
+++ b/examples/sphere.py
@@ -757,6 +757,7 @@ def sphere_main(algorithm,
                 itrs=None,
                 archive_dims=None,
                 learning_rate=None,
+                es=None,
                 outdir="sphere_output",
                 log_freq=250,
                 seed=None):
@@ -768,6 +769,8 @@ def sphere_main(algorithm,
         itrs (int): Iterations to run.
         archive_dims (tuple): Dimensionality of the archive.
         learning_rate (float): The archive learning rate.
+        es (str): If passed, this will set the ES for all
+            EvolutionStrategyEmitter instances.
         outdir (str): Directory to save output.
         log_freq (int): Number of iterations to wait before recording metrics
             and saving heatmap.
@@ -790,6 +793,12 @@ def sphere_main(algorithm,
     # Use default learning_rate for each algorithm.
     if learning_rate is not None:
         config["archive"]["kwargs"]["learning_rate"] = learning_rate
+
+    # Set ES for all EvolutionStrategyEmitter.
+    if es is not None:
+        for e in config["emitters"]:
+            if e["class"] == EvolutionStrategyEmitter:
+                e["kwargs"]["es"] = es
 
     name = f"{algorithm}_{config['dim']}"
     outdir = Path(outdir)


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the PR's purpose here. -->

Added an `es` parameter to the sphere example. This makes it easier to experiment with different ES's.

## Status

- [x] I have read the guidelines in
      [CONTRIBUTING.md](https://github.com/icaros-usc/pyribs/blob/master/CONTRIBUTING.md)
- [x] I have formatted my code using `yapf`
- [x] I have tested my code by running `pytest`
- [x] I have linted my code with `pylint`
- [x] I have added a one-line description of my change to the changelog in
      `HISTORY.md`
- [x] This PR is ready to go
