### PR TITLE
Support seed=SeedSequence in emitters

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -41,7 +41,7 @@
 #### Improvements
 
 - Allow overriding ES in sphere example ({pr}`439`)
-- Use NumPy SeedSequence in emitters ({pr}`431`)
+- Use NumPy SeedSequence in emitters ({pr}`431`, {pr}`440`)
 - Use numbers types when checking arguments ({pr}`419`)
 - Reimplement ArchiveBase using ArrayStore ({pr}`399`)
 - Use chunk computation in CVT brute force calculation to reduce memory usage

--- a/ribs/emitters/_evolution_strategy_emitter.py
+++ b/ribs/emitters/_evolution_strategy_emitter.py
@@ -99,7 +99,8 @@ class EvolutionStrategyEmitter(EmitterBase):
             bounds=bounds,
         )
 
-        seed_sequence = np.random.SeedSequence(seed)
+        seed_sequence = (seed if isinstance(seed, np.random.SeedSequence) else
+                         np.random.SeedSequence(seed))
         opt_seed, ranker_seed = seed_sequence.spawn(2)
 
         self._x0 = np.array(x0, dtype=archive.dtype)

--- a/ribs/emitters/_gradient_arborescence_emitter.py
+++ b/ribs/emitters/_gradient_arborescence_emitter.py
@@ -160,7 +160,8 @@ class GradientArborescenceEmitter(EmitterBase):
             bounds=bounds,
         )
 
-        seed_sequence = np.random.SeedSequence(seed)
+        seed_sequence = (seed if isinstance(seed, np.random.SeedSequence) else
+                         np.random.SeedSequence(seed))
         opt_seed, ranker_seed = seed_sequence.spawn(2)
 
         self._epsilon = epsilon

--- a/tests/emitters/evolution_strategy_emitter_test.py
+++ b/tests/emitters/evolution_strategy_emitter_test.py
@@ -63,6 +63,21 @@ def test_dtypes(dtype):
     assert emitter.x0.dtype == dtype
 
 
+def test_seed_sequence():
+    archive = GridArchive(
+        solution_dim=10,
+        dims=[20, 20],
+        ranges=[(-1.0, 1.0)] * 2,
+    )
+    EvolutionStrategyEmitter(
+        archive,
+        x0=np.zeros(10),
+        sigma0=1.0,
+        # Passing a SeedSequence here used to throw a TypeError.
+        seed=np.random.SeedSequence(42),
+    )
+
+
 @pytest.mark.parametrize("es", ES_LIST)
 def test_sphere(es):
     archive = GridArchive(solution_dim=10,

--- a/tests/emitters/gradient_arborescence_emitter_test.py
+++ b/tests/emitters/gradient_arborescence_emitter_test.py
@@ -85,6 +85,22 @@ def test_tell_dqd_must_be_called_before_tell():
         emitter.tell([[0]], [0], [[0]], {"status": [0], "value": [0]})
 
 
+def test_seed_sequence():
+    archive = GridArchive(
+        solution_dim=10,
+        dims=[20, 20],
+        ranges=[(-1.0, 1.0)] * 2,
+    )
+    GradientArborescenceEmitter(
+        archive,
+        x0=np.zeros(10),
+        sigma0=1.0,
+        lr=1.0,
+        # Passing a SeedSequence here used to throw a TypeError.
+        seed=np.random.SeedSequence(42),
+    )
+
+
 @pytest.mark.parametrize("es", ES_LIST)
 def test_sphere(es):
     archive = GridArchive(solution_dim=10,


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the PR's purpose here. -->

Previously, passing a SeedSequence as a seed in EvolutionStrategyEmitter and GradientArborescenceEmitter threw an error because SeedSequence cannot be initialized from another SeedSequence. This PR adds checks for SeedSequence so that SeedSequence can be passed in as a seed in these two emitters. Note that in other emitters, the seed is passed directly to the default_rng(), which can handle SeedSequence as input.

## Status

- [x] I have read the guidelines in
      [CONTRIBUTING.md](https://github.com/icaros-usc/pyribs/blob/master/CONTRIBUTING.md)
- [x] I have formatted my code using `yapf`
- [x] I have tested my code by running `pytest`
- [x] I have linted my code with `pylint`
- [x] I have added a one-line description of my change to the changelog in
      `HISTORY.md`
- [x] This PR is ready to go
