### PR TITLE
Fix interval_size in CVTArchive and SlidingBoundariesArchive

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -40,6 +40,7 @@
 
 #### Improvements
 
+- Fix interval_size in CVTArchive and SlidingBoundariesArchive ({pr}`452`)
 - Allow overriding ES in sphere example ({pr}`439`)
 - Use NumPy SeedSequence in emitters ({pr}`431`, {pr}`440`)
 - Use numbers types when checking arguments ({pr}`419`)

--- a/ribs/archives/_cvt_archive.py
+++ b/ribs/archives/_cvt_archive.py
@@ -160,6 +160,7 @@ class CVTArchive(ArchiveBase):
         ranges = list(zip(*ranges))
         self._lower_bounds = np.array(ranges[0], dtype=self.dtype)
         self._upper_bounds = np.array(ranges[1], dtype=self.dtype)
+        self._interval_size = self._upper_bounds - self._lower_bounds
 
         # Apply default args for k-means. Users can easily override these,
         # particularly if they want higher quality clusters.
@@ -258,6 +259,12 @@ class CVTArchive(ArchiveBase):
     def upper_bounds(self):
         """(measure_dim,) numpy.ndarray: Upper bound of each dimension."""
         return self._upper_bounds
+
+    @property
+    def interval_size(self):
+        """(measure_dim,) numpy.ndarray: The size of each dim (upper_bounds -
+        lower_bounds)."""
+        return self._interval_size
 
     @property
     def samples(self):

--- a/ribs/archives/_sliding_boundaries_archive.py
+++ b/ribs/archives/_sliding_boundaries_archive.py
@@ -454,6 +454,7 @@ class SlidingBoundariesArchive(ArchiveBase):
             self._upper_bounds = np.array([
                 bound[dim] for bound, dim in zip(self._boundaries, self._dims)
             ])
+            self._interval_size = self._upper_bounds - self._lower_bounds
         else:
             add_info = ArchiveBase.add_single(self, **new_data)
         return add_info

--- a/tests/archives/cvt_archive_test.py
+++ b/tests/archives/cvt_archive_test.py
@@ -41,6 +41,7 @@ def test_samples_bad_shape(use_kd_tree):
 def test_properties_are_correct(data):
     assert np.all(data.archive.lower_bounds == [-1, -1])
     assert np.all(data.archive.upper_bounds == [1, 1])
+    assert np.all(data.archive.interval_size == [2, 2])
 
     points = [[0.5, 0.5], [-0.5, 0.5], [-0.5, -0.5], [0.5, -0.5]]
     unittest.TestCase().assertCountEqual(data.archive.samples.tolist(), points)


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the PR's purpose here. -->

Previously, SlidingBoundariesArchive updated the lower_bounds and upper_bounds but not the interval_size. CVTArchive did not have an interval_size property at all.

## Status

- [x] I have read the guidelines in
      [CONTRIBUTING.md](https://github.com/icaros-usc/pyribs/blob/master/CONTRIBUTING.md)
- [x] I have formatted my code using `yapf`
- [x] I have tested my code by running `pytest`
- [x] I have linted my code with `pylint`
- [x] I have added a one-line description of my change to the changelog in
      `HISTORY.md`
- [x] This PR is ready to go
