### PR TITLE
Fix Read the Docs build error

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -197,6 +197,7 @@ from `master` into the corresponding release branch.
 
 #### Minor Versions
 
+1. Check that the latest version of the docs is building on Read the Docs.
 1. Create a PR into master after doing the following:
    1. Update the version with `bump2version`:
       ```bash
@@ -228,6 +229,7 @@ from `master` into the corresponding release branch.
 
 #### Patch Versions
 
+1. Check that the latest version of the docs is building on Read the Docs.
 1. Create a PR into master after doing the following:
    1. Update the version with `bump2version`:
       ```bash

--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,7 @@ extras_require = {
         "sphinx-toolbox==3.1.0",
         "sphinx-autodoc-typehints==1.18.2",
         "sphinx-codeautolink==0.12.1",
+        "sphinxcontrib-applehelp==1.0.4",
 
         # Distribution
         "bump2version==1.0.1",


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the PR's purpose here. -->

Read the Docs had an error due to sphinxcontrib-applehelp. This PR also makes a note to check Read the Docs before deploying in the future.

## Status

- [x] I have read the guidelines in
      [CONTRIBUTING.md](https://github.com/icaros-usc/pyribs/blob/master/CONTRIBUTING.md)
- [x] I have formatted my code using `yapf`
- [x] I have tested my code by running `pytest`
- [x] I have linted my code with `pylint`
- [N/A] I have added a one-line description of my change to the changelog in
      `HISTORY.md`
- [x] This PR is ready to go
