### PR TITLE
Fix solution retrieval in lunar lander eval

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,13 @@
 # History
 
+## 0.7.1 (Forthcoming)
+
+### Changelog
+
+#### Bugs
+
+- Fix solution retrieval in lunar lander eval ({pr}`457`)
+
 ## 0.7.0
 
 To learn about this release, see our page on What's New in v0.7.0:

--- a/examples/lunar_lander.py
+++ b/examples/lunar_lander.py
@@ -61,7 +61,7 @@ import pandas as pd
 import tqdm
 from dask.distributed import Client, LocalCluster
 
-from ribs.archives import GridArchive
+from ribs.archives import ArchiveDataFrame, GridArchive
 from ribs.emitters import EvolutionStrategyEmitter
 from ribs.schedulers import Scheduler
 from ribs.visualize import grid_archive_heatmap
@@ -318,7 +318,8 @@ def run_evaluation(outdir, env_seed):
             retrieve the archive and save videos.
         env_seed (int): Seed for the environment.
     """
-    df = pd.read_csv(outdir / "archive.csv")
+    df = ArchiveDataFrame(pd.read_csv(outdir / "archive.csv"))
+    solutions = df.get_field("solution")
     indices = np.random.permutation(len(df))[:10]
 
     # Use a single env so that all the videos go to the same directory.
@@ -330,7 +331,7 @@ def run_evaluation(outdir, env_seed):
     )
 
     for idx in indices:
-        model = np.array(df.loc[idx, "solution_0":])
+        model = solutions[idx]
         reward, impact_x_pos, impact_y_vel = simulate(model, env_seed,
                                                       video_env)
         print(f"=== Index {idx} ===\n"


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the PR's purpose here. -->

Previously, the script retrieved solutions incorrectly due to the reordering of columns in archive.data() compared to archive.as_pandas().

## Status

- [x] I have read the guidelines in
      [CONTRIBUTING.md](https://github.com/icaros-usc/pyribs/blob/master/CONTRIBUTING.md)
- [x] I have formatted my code using `yapf`
- [x] I have tested my code by running `pytest`
- [x] I have linted my code with `pylint`
- [x] I have added a one-line description of my change to the changelog in
      `HISTORY.md`
- [x] This PR is ready to go
