### PR TITLE
Add qd score to lunar lander example

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -8,6 +8,10 @@
 
 - Support Python 3.12 ({pr}`390`)
 
+#### Improvements
+
+- Add qd score to lunar lander example ({pr}`458`)
+
 #### Bugs
 
 - Fix solution retrieval in lunar lander eval ({pr}`457`)

--- a/examples/lunar_lander.py
+++ b/examples/lunar_lander.py
@@ -155,7 +155,9 @@ def create_scheduler(seed, n_emitters, sigma0, batch_size):
         dims=[50, 50],  # 50 cells in each dimension.
         # (-1, 1) for x-pos and (-3, 0) for y-vel.
         ranges=[(-1.0, 1.0), (-3.0, 0.0)],
-        seed=seed)
+        seed=seed,
+        qd_score_offset=-600,
+    )
 
     # If we create the emitters with identical seeds, they will all output the
     # same initial solutions. The algorithm should still work -- eventually, the
@@ -209,6 +211,10 @@ def run_search(client, scheduler, env_seed, iterations, log_freq):
             "x": [0],
             "y": [0],
         },
+        "QD Score": {
+            "x": [0],
+            "y": [0],
+        },
     }
 
     start_time = time.time()
@@ -239,10 +245,13 @@ def run_search(client, scheduler, env_seed, iterations, log_freq):
             metrics["Max Score"]["y"].append(scheduler.archive.stats.obj_max)
             metrics["Archive Size"]["x"].append(itr)
             metrics["Archive Size"]["y"].append(len(scheduler.archive))
+            metrics["QD Score"]["x"].append(itr)
+            metrics["QD Score"]["y"].append(scheduler.archive.stats.qd_score)
             tqdm.tqdm.write(
                 f"> {itr} itrs completed after {elapsed_time:.2f} s\n"
                 f"  - Max Score: {metrics['Max Score']['y'][-1]}\n"
-                f"  - Archive Size: {metrics['Archive Size']['y'][-1]}")
+                f"  - Archive Size: {metrics['Archive Size']['y'][-1]}\n"
+                f"  - QD Score: {metrics['QD Score']['y'][-1]}")
 
     return metrics
 


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the PR's purpose here. -->

Previously, we did not record the qd score metric like in the lunar lander tutorial, nor did we consider the qd score offset in the archive.

## Status

- [x] I have read the guidelines in
      [CONTRIBUTING.md](https://github.com/icaros-usc/pyribs/blob/master/CONTRIBUTING.md)
- [x] I have formatted my code using `yapf`
- [x] I have tested my code by running `pytest`
- [x] I have linted my code with `pylint`
- [x] I have added a one-line description of my change to the changelog in
      `HISTORY.md`
- [x] This PR is ready to go
