### PR TITLE
Upgrade setup-miniconda to v3 due to deprecation

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -26,7 +26,7 @@ jobs:
       SKIP: pylint
     steps:
       - uses: actions/checkout@v4
-      - uses: conda-incubator/setup-miniconda@v2
+      - uses: conda-incubator/setup-miniconda@v3
         with:
           python-version: "3.11"
       - name: Install all deps and pylint (to be available to pre-commit)
@@ -43,7 +43,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
-      - uses: conda-incubator/setup-miniconda@v2
+      - uses: conda-incubator/setup-miniconda@v3
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install core deps
@@ -55,7 +55,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: conda-incubator/setup-miniconda@v2
+      - uses: conda-incubator/setup-miniconda@v3
         with:
           python-version: "3.8"
       - name: Install core deps
@@ -80,7 +80,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: conda-incubator/setup-miniconda@v2
+      - uses: conda-incubator/setup-miniconda@v3
         with:
           python-version: "3.8"
       - name: Install deps
@@ -97,7 +97,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: conda-incubator/setup-miniconda@v2
+      - uses: conda-incubator/setup-miniconda@v3
         with:
           python-version: "3.8"
       - name: Install deps
@@ -112,7 +112,7 @@ jobs:
       - name: Remove swig
         run: sudo apt-get remove swig
       - uses: actions/checkout@v4
-      - uses: conda-incubator/setup-miniconda@v2
+      - uses: conda-incubator/setup-miniconda@v3
         with:
           python-version: 3.8
       - name: Install deps
@@ -140,7 +140,7 @@ jobs:
         run: sudo apt-get remove swig
       # We use Python 3.10 instead of 3.8 here since Google Colab uses 3.10.
       - uses: actions/checkout@v4
-      - uses: conda-incubator/setup-miniconda@v2
+      - uses: conda-incubator/setup-miniconda@v3
         with:
           python-version: "3.10"
       - name: Install deps
@@ -154,7 +154,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: conda-incubator/setup-miniconda@v2
+      - uses: conda-incubator/setup-miniconda@v3
         with:
           python-version: "3.8"
       - name: Install deps
@@ -167,7 +167,7 @@ jobs:
     if: startsWith(github.ref, 'refs/tags')
     steps:
       - uses: actions/checkout@v4
-      - uses: conda-incubator/setup-miniconda@v2
+      - uses: conda-incubator/setup-miniconda@v3
         with:
           python-version: "3.8"
       - name: Install dependencies

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,7 +6,7 @@
 
 #### Improvements
 
-- Upgrade setup-miniconda to v3 due to deprecation ({pr}`463`)
+- Upgrade setup-miniconda to v3 due to deprecation ({pr}`464`)
 
 ## 0.7.1
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,13 @@
 # History
 
+## (Forthcoming)
+
+### Changelog
+
+#### Improvements
+
+- Upgrade setup-miniconda to v3 due to deprecation ({pr}`463`)
+
 ## 0.7.1
 
 This release introduces the


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the PR's purpose here. -->

Seems setup-miniconda@v2 uses Node 16 which raises a deprecation warning in GitHub Actions. Upgrading to v3 since that seems to be available.

## Status

- [x] I have read the guidelines in
      [CONTRIBUTING.md](https://github.com/icaros-usc/pyribs/blob/master/CONTRIBUTING.md)
- [x] I have formatted my code using `yapf`
- [x] I have tested my code by running `pytest`
- [x] I have linted my code with `pylint`
- [x] I have added a one-line description of my change to the changelog in
      `HISTORY.md`
- [x] This PR is ready to go
