### PR TITLE
Add tutorial links to patch release instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -247,6 +247,8 @@ from `master` into the corresponding release branch.
 1. On the release branch, edit `HISTORY.md` to remove any irrelevant history,
    e.g., if there are upcoming changes that will be included only in the next
    version.
+1. If any tutorials were added in this release, run `make tutorial_links` to
+   make the links point to the stable version of pyribs.
 1. (Optional) On the release branch, run `make release-test`. This uploads the
    code to TestPyPI to check that the deployment works. If this fails, make
    fixes as appropriate.


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the PR's purpose here. -->

Forgot to do this for 0.7.1 but will leave as is since it is relatively minor.

## Status

- [x] I have read the guidelines in
      [CONTRIBUTING.md](https://github.com/icaros-usc/pyribs/blob/master/CONTRIBUTING.md)
- [x] I have formatted my code using `yapf`
- [x] I have tested my code by running `pytest`
- [x] I have linted my code with `pylint`
- [N/A] I have added a one-line description of my change to the changelog in
      `HISTORY.md`
- [x] This PR is ready to go
