### PR TITLE
Note quotation marks for installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ pyribs supports Python 3.8 and above. The vast majority of users can install
 pyribs by running:
 
 ```bash
+# If you are on Mac, you may need to use quotations, e.g., pip install "ribs[visualize]"
 pip install ribs[visualize]
 ```
 


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the PR's purpose here. -->

Mac users may need to put quotation marks around their installation commands due to zsh interpreting the square brackets differently. This PR adds a note on that in the installation command.

We also have installation commands in other files like the examples, but I think adding the note here should cover most people. At any rate, we have not yet received any issues about this, so people seem to be figuring it out.

I also updated this on the website.

## Status

- [x] I have read the guidelines in
      [CONTRIBUTING.md](https://github.com/icaros-usc/pyribs/blob/master/CONTRIBUTING.md)
- [x] I have formatted my code using `yapf`
- [x] I have tested my code by running `pytest`
- [x] I have linted my code with `pylint`
- [N/A] I have added a one-line description of my change to the changelog in
      `HISTORY.md`
- [x] This PR is ready to go
