### PR TITLE
Replace archive.dtype with archive.dtypes dict that holds dtype of every field

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,6 +4,11 @@
 
 ### Changelog
 
+#### API
+
+- Replace archive.dtype with archive.dtypes dict that holds dtype of every field
+  ({pr}`470`)
+
 #### Improvements
 
 - Upgrade setup-miniconda to v3 due to deprecation ({pr}`464`)

--- a/ribs/_utils.py
+++ b/ribs/_utils.py
@@ -25,6 +25,21 @@ def parse_float_dtype(dtype):
     raise ValueError("Unsupported dtype. Must be np.float32 or np.float64")
 
 
+def np_scalar(scalar, dtype):
+    """Casts the scalar to the given numpy dtype.
+
+    This is useful for making sure all our scalars are in the correct dtype.
+
+    It is possible to just use np.array(scalar, dtype=dtype) since
+    zero-dimensional arrays behave like scalars, but the scalar would still show
+    up as an array if calling type().
+
+    It is also possible to use np.array(scalar, dtype=dtype).item(), but item()
+    converts outputs to standard Python objects, not numpy scalars.
+    """
+    return np.array([scalar], dtype=dtype)[0]
+
+
 def check_finite(x, name):
     """Checks that x is finite (i.e. not infinity or NaN).
 
@@ -203,7 +218,8 @@ def validate_single(archive, data):
     check_shape(data["solution"], "solution", archive.solution_dim,
                 "solution_dim")
 
-    data["objective"] = archive.dtype(data["objective"])
+    data["objective"] = np_scalar(data["objective"],
+                                  archive.dtypes["objective"])
     check_finite(data["objective"], "objective")
 
     data["measures"] = np.asarray(data["measures"])

--- a/ribs/archives/_archive_base.py
+++ b/ribs/archives/_archive_base.py
@@ -212,7 +212,10 @@ class ArchiveBase(ABC):
     @property
     def dtype(self):
         """data-type: The dtype of the solutions, objective, and measures."""
-        return self._dtype
+        raise RuntimeError(
+            "The dtype property has been deprecated. Please use "
+            "archive.dtypes instead, which returns a mapping from field name "
+            "to dtype for all the fields in the archive.")
 
     @property
     def dtypes(self):

--- a/ribs/archives/_archive_base.py
+++ b/ribs/archives/_archive_base.py
@@ -213,7 +213,7 @@ class ArchiveBase(ABC):
 
     @property
     def dtype(self):
-        """data-type: The dtype of the solutions, objective, and measures."""
+        """DEPRECATED."""
         raise RuntimeError(
             "The dtype property has been deprecated. Please use "
             "archive.dtypes instead, which returns a mapping from field name "

--- a/ribs/archives/_archive_base.py
+++ b/ribs/archives/_archive_base.py
@@ -4,8 +4,8 @@ from abc import ABC, abstractmethod
 import numpy as np
 
 from ribs._utils import (check_batch_shape, check_finite, check_is_1d,
-                         check_shape, parse_float_dtype, validate_batch,
-                         validate_single)
+                         check_shape, np_scalar, parse_float_dtype,
+                         validate_batch, validate_single)
 from ribs.archives._archive_data_frame import ArchiveDataFrame
 from ribs.archives._archive_stats import ArchiveStats
 from ribs.archives._array_store import ArrayStore
@@ -96,13 +96,28 @@ class ArchiveBase(ABC):
                  dtype=np.float64,
                  extra_fields=None):
 
-        self._dtype = parse_float_dtype(dtype)
         self._seed = seed
         self._rng = np.random.default_rng(seed)
         self._cells = cells
         self._solution_dim = solution_dim
         self._measure_dim = measure_dim
-        self._qd_score_offset = self._dtype(qd_score_offset)
+
+        extra_fields = extra_fields or {}
+        if _ARCHIVE_FIELDS & extra_fields.keys():
+            raise ValueError("The following names are not allowed in "
+                             f"extra_fields: {_ARCHIVE_FIELDS}")
+
+        dtype = parse_float_dtype(dtype)
+        self._store = ArrayStore(
+            field_desc={
+                "solution": ((solution_dim,), dtype),
+                "objective": ((), dtype),
+                "measures": ((measure_dim,), dtype),
+                "threshold": ((), dtype),
+                **extra_fields,
+            },
+            capacity=self._cells,
+        )
 
         if threshold_min != -np.inf and learning_rate is None:
             raise ValueError(
@@ -116,8 +131,11 @@ class ArchiveBase(ABC):
         if threshold_min == -np.inf and learning_rate != 1.0:
             raise ValueError("threshold_min can only be -np.inf if "
                              "learning_rate is 1.0")
-        self._learning_rate = self._dtype(learning_rate)
-        self._threshold_min = self._dtype(threshold_min)
+        self._learning_rate = np_scalar(learning_rate, self.dtypes["threshold"])
+        self._threshold_min = np_scalar(threshold_min, self.dtypes["threshold"])
+
+        self._qd_score_offset = np_scalar(qd_score_offset,
+                                          self.dtypes["objective"])
 
         self._stats = None
         self._best_elite = None
@@ -125,22 +143,6 @@ class ArchiveBase(ABC):
         # qd_score and obj_mean.
         self._objective_sum = None
         self._stats_reset()
-
-        extra_fields = extra_fields or {}
-        if _ARCHIVE_FIELDS & extra_fields.keys():
-            raise ValueError("The following names are not allowed in "
-                             f"extra_fields: {_ARCHIVE_FIELDS}")
-
-        self._store = ArrayStore(
-            field_desc={
-                "solution": ((solution_dim,), self.dtype),
-                "objective": ((), self.dtype),
-                "measures": ((measure_dim,), self.dtype),
-                "threshold": ((), self.dtype),
-                **extra_fields,
-            },
-            capacity=self._cells,
-        )
 
     @property
     def field_list(self):
@@ -294,16 +296,18 @@ class ArchiveBase(ABC):
 
     def _stats_reset(self):
         """Resets the archive stats."""
+        zero = np_scalar(0.0, dtype=self.dtypes["objective"])
+
         self._stats = ArchiveStats(
             num_elites=0,
-            coverage=self.dtype(0.0),
-            qd_score=self.dtype(0.0),
-            norm_qd_score=self.dtype(0.0),
+            coverage=zero,
+            qd_score=zero,
+            norm_qd_score=zero,
             obj_max=None,
             obj_mean=None,
         )
         self._best_elite = None
-        self._objective_sum = self.dtype(0.0)
+        self._objective_sum = zero
 
     def _stats_update(self, new_objective_sum, new_best_index):
         """Updates statistics based on a new sum of objective values
@@ -311,7 +315,8 @@ class ArchiveBase(ABC):
         (new_best_index)."""
         self._objective_sum = new_objective_sum
         new_qd_score = (self._objective_sum -
-                        self.dtype(len(self)) * self._qd_score_offset)
+                        np_scalar(len(self), dtype=self.dtypes["objective"]) *
+                        self._qd_score_offset)
 
         _, new_best_elite = self._store.retrieve([new_best_index])
 
@@ -327,11 +332,12 @@ class ArchiveBase(ABC):
 
         self._stats = ArchiveStats(
             num_elites=len(self),
-            coverage=self.dtype(len(self) / self.cells),
+            coverage=np_scalar(len(self) / self.cells,
+                               dtype=self.dtypes["objective"]),
             qd_score=new_qd_score,
-            norm_qd_score=self.dtype(new_qd_score / self.cells),
+            norm_qd_score=new_qd_score / self.cells,
             obj_max=new_obj_max,
-            obj_mean=self._objective_sum / self.dtype(len(self)),
+            obj_mean=self._objective_sum / len(self),
         )
 
     def add(self, solution, objective, measures, **fields):
@@ -440,7 +446,7 @@ class ArchiveBase(ABC):
             self.index_of(data["measures"]),
             data,
             {
-                "dtype": self._dtype,
+                "dtype": self.dtypes["threshold"],
                 "learning_rate": self._learning_rate,
                 "threshold_min": self._threshold_min,
                 "objective_sum": self._objective_sum,
@@ -507,7 +513,7 @@ class ArchiveBase(ABC):
             np.expand_dims(self.index_of_single(measures), axis=0),
             data,
             {
-                "dtype": self._dtype,
+                "dtype": self.dtypes["threshold"],
                 "learning_rate": self._learning_rate,
                 "threshold_min": self._threshold_min,
                 "objective_sum": self._objective_sum,

--- a/ribs/archives/_archive_base.py
+++ b/ribs/archives/_archive_base.py
@@ -215,6 +215,12 @@ class ArchiveBase(ABC):
         return self._dtype
 
     @property
+    def dtypes(self):
+        """dict: Mapping from field name to dtype for all fields in the
+        archive."""
+        return self._store.dtypes
+
+    @property
     def empty(self):
         """bool: Whether the archive is empty."""
         return len(self._store) == 0

--- a/ribs/archives/_array_store.py
+++ b/ribs/archives/_array_store.py
@@ -184,7 +184,7 @@ class ArrayStore:
 
                 store.field_desc == {
                     "objective": ((), np.float32),
-                    "measures": ((10,), np.float32)
+                    "measures": ((10,), np.float32),
                 }
 
         See the constructor ``field_desc`` parameter for more info. Unlike in
@@ -197,6 +197,21 @@ class ArrayStore:
             name: (arr.shape[1:], arr.dtype)
             for name, arr in self._fields.items()
         }
+
+    @cached_property
+    def dtypes(self):
+        """dict: Data types of fields in the store.
+
+        Example:
+
+            ::
+
+                store.dtypes == {
+                    "objective": np.float32,
+                    "measures": np.float32,
+                }
+        """
+        return {name: arr.dtype for name, arr in self._fields.items()}
 
     @cached_property
     def field_list(self):

--- a/ribs/archives/_cvt_archive.py
+++ b/ribs/archives/_cvt_archive.py
@@ -159,8 +159,8 @@ class CVTArchive(ArchiveBase):
         )
 
         ranges = list(zip(*ranges))
-        self._lower_bounds = np.array(ranges[0], dtype=self.dtype)
-        self._upper_bounds = np.array(ranges[1], dtype=self.dtype)
+        self._lower_bounds = np.array(ranges[0], dtype=self.dtypes["measures"])
+        self._upper_bounds = np.array(ranges[1], dtype=self.dtypes["measures"])
         self._interval_size = self._upper_bounds - self._lower_bounds
 
         # Apply default args for k-means. Users can easily override these,
@@ -183,7 +183,7 @@ class CVTArchive(ArchiveBase):
             if centroid_method == "kmeans":
                 if not isinstance(samples, numbers.Integral):
                     # Validate shape of custom samples.
-                    samples = np.asarray(samples, dtype=self.dtype)
+                    samples = np.asarray(samples, dtype=self.dtypes["measures"])
                     if samples.shape[1] != self._measure_dim:
                         raise ValueError(
                             f"Samples has shape {samples.shape} but must be of "
@@ -195,7 +195,7 @@ class CVTArchive(ArchiveBase):
                         self._lower_bounds,
                         self._upper_bounds,
                         size=(samples, self._measure_dim),
-                    ).astype(self.dtype)
+                    ).astype(self.dtypes["measures"])
 
                 self._centroids = k_means(self._samples, self._cells,
                                           **self._k_means_kwargs)[0]
@@ -233,7 +233,8 @@ class CVTArchive(ArchiveBase):
                                    (self._upper_bounds - self._lower_bounds))
         else:
             # Validate shape of `custom_centroids` when they are provided.
-            custom_centroids = np.asarray(custom_centroids, dtype=self.dtype)
+            custom_centroids = np.asarray(custom_centroids,
+                                          dtype=self.dtypes["measures"])
             if custom_centroids.shape != (cells, self._measure_dim):
                 raise ValueError(
                     f"custom_centroids has shape {custom_centroids.shape} but "

--- a/ribs/archives/_grid_archive.py
+++ b/ribs/archives/_grid_archive.py
@@ -1,7 +1,7 @@
 """Contains the GridArchive."""
 import numpy as np
 
-from ribs._utils import check_batch_shape, check_finite, check_is_1d
+from ribs._utils import check_batch_shape, check_finite, check_is_1d, np_scalar
 from ribs.archives._archive_base import ArchiveBase
 
 
@@ -97,10 +97,10 @@ class GridArchive(ArchiveBase):
         )
 
         ranges = list(zip(*ranges))
-        self._lower_bounds = np.array(ranges[0], dtype=self.dtype)
-        self._upper_bounds = np.array(ranges[1], dtype=self.dtype)
+        self._lower_bounds = np.array(ranges[0], dtype=self.dtypes["measures"])
+        self._upper_bounds = np.array(ranges[1], dtype=self.dtypes["measures"])
         self._interval_size = self._upper_bounds - self._lower_bounds
-        self._epsilon = self.dtype(epsilon)
+        self._epsilon = np_scalar(epsilon, dtype=self.dtypes["measures"])
 
         self._boundaries = []
         for dim, lower_bound, upper_bound in zip(self._dims, self._lower_bounds,
@@ -131,7 +131,7 @@ class GridArchive(ArchiveBase):
 
     @property
     def epsilon(self):
-        """:attr:`dtype`: Epsilon for computing archive indices. Refer to
+        """dtypes["measures"]: Epsilon for computing archive indices. Refer to
         the documentation for this class."""
         return self._epsilon
 

--- a/ribs/archives/_sliding_boundaries_archive.py
+++ b/ribs/archives/_sliding_boundaries_archive.py
@@ -5,8 +5,8 @@ from collections import deque
 import numpy as np
 from sortedcontainers import SortedList
 
-from ribs._utils import (check_batch_shape, check_finite, validate_batch,
-                         validate_single)
+from ribs._utils import (check_batch_shape, check_finite, np_scalar,
+                         validate_batch, validate_single)
 from ribs.archives._archive_base import ArchiveBase
 from ribs.archives._grid_archive import GridArchive
 
@@ -180,10 +180,10 @@ class SlidingBoundariesArchive(ArchiveBase):
         )
 
         ranges = list(zip(*ranges))
-        self._lower_bounds = np.array(ranges[0], dtype=self.dtype)
-        self._upper_bounds = np.array(ranges[1], dtype=self.dtype)
+        self._lower_bounds = np.array(ranges[0], dtype=self.dtypes["measures"])
+        self._upper_bounds = np.array(ranges[1], dtype=self.dtypes["measures"])
         self._interval_size = self._upper_bounds - self._lower_bounds
-        self._epsilon = self.dtype(epsilon)
+        self._epsilon = np_scalar(epsilon, dtype=self.dtypes["measures"])
 
         # Specifics for sliding boundaries.
         self._remap_frequency = remap_frequency
@@ -192,7 +192,7 @@ class SlidingBoundariesArchive(ArchiveBase):
         # the end.
         self._boundaries = np.full((self.measure_dim, np.max(self._dims) + 1),
                                    np.nan,
-                                   dtype=self.dtype)
+                                   dtype=self.dtypes["measures"])
 
         # Initialize the boundaries.
         for i, (dim, lower_bound, upper_bound) in enumerate(
@@ -229,7 +229,7 @@ class SlidingBoundariesArchive(ArchiveBase):
 
     @property
     def epsilon(self):
-        """:attr:`dtype`: Epsilon for computing archive indices. Refer to
+        """dtypes["measures"]: Epsilon for computing archive indices. Refer to
         the documentation for this class."""
         return self._epsilon
 

--- a/ribs/archives/_transforms.py
+++ b/ribs/archives/_transforms.py
@@ -6,6 +6,8 @@ public in the future once it becomes more stable.
 import numpy as np
 from numpy_groupies import aggregate_nb as aggregate
 
+from ribs._utils import np_scalar
+
 
 def single_entry_with_threshold(indices, new_data, add_info, extra_args,
                                 occupied, cur_data):
@@ -47,7 +49,7 @@ def single_entry_with_threshold(indices, new_data, add_info, extra_args,
         # If threshold_min is -inf, then we want CMA-ME behavior, which will
         # compute the improvement value w.r.t. zero for new solutions.
         # Otherwise, we will compute w.r.t. threshold_min.
-        cur_threshold = (dtype(0)
+        cur_threshold = (np_scalar(0.0, dtype=dtype)
                          if threshold_min == -np.inf else threshold_min)
 
     # Retrieve candidate objective.
@@ -115,7 +117,7 @@ def _compute_thresholds(indices, objective, cur_threshold, learning_rate,
     # -np.inf. This is because the case with threshold_min = -np.inf is handled
     # separately since we compute the new threshold based on the max objective
     # in each cell in that case.
-    ratio = dtype(1.0 - learning_rate)**objective_sizes
+    ratio = np_scalar(1.0 - learning_rate, dtype=dtype)**objective_sizes
     new_threshold = (ratio * cur_threshold +
                      (objective_sums / objective_sizes) * (1 - ratio))
 
@@ -166,7 +168,7 @@ def batch_entries_with_threshold(indices, new_data, add_info, extra_args,
     # If threshold_min is -inf, then we want CMA-ME behavior, which will compute
     # the improvement value of new solutions w.r.t zero. Otherwise, we will
     # compute improvement with respect to threshold_min.
-    cur_threshold[is_new] = (dtype(0)
+    cur_threshold[is_new] = (np_scalar(0.0, dtype=dtype)
                              if threshold_min == -np.inf else threshold_min)
     add_info["value"] = new_data["objective"] - cur_threshold
 
@@ -274,5 +276,4 @@ def compute_best_index(indices, new_data, add_info, extra_args, occupied,
     else:
         item_idx = np.argmax(new_data["objective"])
         add_info["best_index"] = indices[item_idx]
-
     return indices, new_data, add_info

--- a/ribs/emitters/_emitter_base.py
+++ b/ribs/emitters/_emitter_base.py
@@ -34,7 +34,7 @@ class EmitterBase(ABC):
         self._solution_dim = solution_dim
         (self._lower_bounds,
          self._upper_bounds) = self._process_bounds(bounds, self._solution_dim,
-                                                    archive.dtype)
+                                                    archive.dtypes["measures"])
 
     @staticmethod
     def _process_bounds(bounds, solution_dim, dtype):
@@ -101,7 +101,8 @@ class EmitterBase(ABC):
 
         Returns an empty array by default.
         """
-        return np.empty((0, self.solution_dim), dtype=self.archive.dtype)
+        return np.empty((0, self.solution_dim),
+                        dtype=self.archive.dtypes["solution"])
 
     def tell(self, solution, objective, measures, add_info, **fields):
         """Gives the emitter results from evaluating solutions.
@@ -130,7 +131,8 @@ class EmitterBase(ABC):
         This method only needs to be implemented by emitters used in DQD. The
         method returns an empty array by default.
         """
-        return np.empty((0, self.solution_dim), dtype=self.archive.dtype)
+        return np.empty((0, self.solution_dim),
+                        dtype=self.archive.dtypes["solution"])
 
     def tell_dqd(self, solution, objective, measures, jacobian, add_info,
                  **fields):

--- a/ribs/emitters/_evolution_strategy_emitter.py
+++ b/ribs/emitters/_evolution_strategy_emitter.py
@@ -103,7 +103,7 @@ class EvolutionStrategyEmitter(EmitterBase):
                          np.random.SeedSequence(seed))
         opt_seed, ranker_seed = seed_sequence.spawn(2)
 
-        self._x0 = np.array(x0, dtype=archive.dtype)
+        self._x0 = np.array(x0, dtype=archive.dtypes["solution"])
         check_shape(self._x0, "x0", archive.solution_dim,
                     "archive.solution_dim")
         self._sigma0 = sigma0
@@ -125,7 +125,7 @@ class EvolutionStrategyEmitter(EmitterBase):
             batch_size=batch_size,
             solution_dim=self._solution_dim,
             seed=opt_seed,
-            dtype=self.archive.dtype,
+            dtype=self.archive.dtypes["solution"],
             lower_bounds=self.lower_bounds,
             upper_bounds=self.upper_bounds,
             **(es_kwargs if es_kwargs is not None else {}),

--- a/ribs/emitters/_gaussian_emitter.py
+++ b/ribs/emitters/_gaussian_emitter.py
@@ -57,7 +57,7 @@ class GaussianEmitter(EmitterBase):
                  batch_size=64,
                  seed=None):
         self._batch_size = batch_size
-        self._sigma = np.array(sigma, dtype=archive.dtype)
+        self._sigma = np.array(sigma, dtype=archive.dtypes["solution"])
         self._x0 = None
         self._initial_solutions = None
 
@@ -68,12 +68,12 @@ class GaussianEmitter(EmitterBase):
                 "x0 and initial_solutions cannot both be provided.")
 
         if x0 is not None:
-            self._x0 = np.array(x0, dtype=archive.dtype)
+            self._x0 = np.array(x0, dtype=archive.dtypes["solution"])
             check_shape(self._x0, "x0", archive.solution_dim,
                         "archive.solution_dim")
         elif initial_solutions is not None:
-            self._initial_solutions = np.asarray(initial_solutions,
-                                                 dtype=archive.dtype)
+            self._initial_solutions = np.asarray(
+                initial_solutions, dtype=archive.dtypes["solution"])
             check_batch_shape(self._initial_solutions, "initial_solutions",
                               archive.solution_dim, "archive.solution_dim")
 

--- a/ribs/emitters/_genetic_algorithm_emitter.py
+++ b/ribs/emitters/_genetic_algorithm_emitter.py
@@ -70,12 +70,12 @@ class GeneticAlgorithmEmitter(EmitterBase):
                 "x0 and initial_solutions cannot both be provided.")
 
         if x0 is not None:
-            self._x0 = np.array(x0, dtype=archive.dtype)
+            self._x0 = np.array(x0, dtype=archive.dtypes["solution"])
             check_shape(self._x0, "x0", archive.solution_dim,
                         "archive.solution_dim")
         elif initial_solutions is not None:
-            self._initial_solutions = np.asarray(initial_solutions,
-                                                 dtype=archive.dtype)
+            self._initial_solutions = np.asarray(
+                initial_solutions, dtype=archive.dtypes["solution"])
             check_batch_shape(self._initial_solutions, "initial_solutions",
                               archive.solution_dim, "archive.solution_dim")
 

--- a/ribs/emitters/_gradient_arborescence_emitter.py
+++ b/ribs/emitters/_gradient_arborescence_emitter.py
@@ -165,7 +165,7 @@ class GradientArborescenceEmitter(EmitterBase):
         opt_seed, ranker_seed = seed_sequence.spawn(2)
 
         self._epsilon = epsilon
-        self._x0 = np.array(x0, dtype=archive.dtype)
+        self._x0 = np.array(x0, dtype=archive.dtypes["solution"])
         check_shape(self._x0, "x0", archive.solution_dim,
                     "archive.solution_dim")
         self._sigma0 = sigma0
@@ -203,7 +203,7 @@ class GradientArborescenceEmitter(EmitterBase):
             batch_size=batch_size,
             solution_dim=self._num_coefficients,
             seed=opt_seed,
-            dtype=self.archive.dtype,
+            dtype=self.archive.dtypes["solution"],
             lower_bounds=-np.inf,  # No bounds for gradient coefficients.
             upper_bounds=np.inf,
             **(es_kwargs if es_kwargs is not None else {}),

--- a/ribs/emitters/_iso_line_emitter.py
+++ b/ribs/emitters/_iso_line_emitter.py
@@ -1,7 +1,7 @@
 """Provides the IsoLineEmitter."""
 import numpy as np
 
-from ribs._utils import check_batch_shape, check_shape
+from ribs._utils import check_batch_shape, check_shape, np_scalar
 from ribs.emitters._emitter_base import EmitterBase
 from ribs.emitters.operators import IsoLineOperator
 
@@ -66,8 +66,8 @@ class IsoLineEmitter(EmitterBase):
         self._rng = np.random.default_rng(seed)
         self._batch_size = batch_size
 
-        self._iso_sigma = archive.dtype(iso_sigma)
-        self._line_sigma = archive.dtype(line_sigma)
+        self._iso_sigma = np_scalar(iso_sigma, dtype=archive.dtypes["solution"])
+        self._line_sigma = np_scalar(line_sigma, archive.dtypes["solution"])
 
         self._x0 = None
         self._initial_solutions = None
@@ -79,12 +79,12 @@ class IsoLineEmitter(EmitterBase):
                 "x0 and initial_solutions cannot both be provided.")
 
         if x0 is not None:
-            self._x0 = np.array(x0, dtype=archive.dtype)
+            self._x0 = np.array(x0, dtype=archive.dtypes["solution"])
             check_shape(self._x0, "x0", archive.solution_dim,
                         "archive.solution_dim")
         elif initial_solutions is not None:
-            self._initial_solutions = np.asarray(initial_solutions,
-                                                 dtype=archive.dtype)
+            self._initial_solutions = np.asarray(
+                initial_solutions, dtype=archive.dtypes["solution"])
             check_batch_shape(self._initial_solutions, "initial_solutions",
                               archive.solution_dim, "archive.solution_dim")
 

--- a/tests/archives/archive_base_test.py
+++ b/tests/archives/archive_base_test.py
@@ -19,7 +19,10 @@ from .conftest import ARCHIVE_NAMES, get_archive_data
 def test_str_dtype_float(name, dtype):
     str_dtype, np_dtype = dtype
     archive = get_archive_data(name, str_dtype).archive
-    assert archive.dtype == np_dtype
+    assert archive.dtypes["solution"] == np_dtype
+    assert archive.dtypes["objective"] == np_dtype
+    assert archive.dtypes["measures"] == np_dtype
+    assert archive.dtypes["threshold"] == np_dtype
 
 
 def test_invalid_dtype():


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the PR's purpose here. -->

Previously, the archives had a `dtype` property that held the dtype of the solution, objectives, and measures. However, these three may not always have the same dtype; furthermore, this excludes the threshold field and other additional fields provided by the user. Thus, this PR replaces `dtype` with `dtypes`, a dict that maps from field name to dtype of the associated field.

## TODO

<!-- Notable points that this PR has either accomplished or will accomplish. -->

- [x] Deprecate `ArchiveBase.dtype` -- now, calling archive.dtype will raise a RuntimeError with a deprecation notice
- [x] Add `ArchvieBase.dtypes`
- [x] Update calls to `archive.dtype`. In particular, we now use `archive.dtypes["XXXX"]`, with XXXX being the field name that is appropriate to the use case, e.g., `x0` in an emitter would be cast to `archive.dtypes["solution"]`.
- [x] Note that it was previously common to call `archive.dtype(some_scalar_value)`. This is not very correct. To elaborate, `archive.dtype` was a numpy scalar type, e.g., `np.float32` or `np.float64`, which is indeed callable. However, the actual dtype of an array, e.g., `np.arange(5).dtype` is an instance of `numpy.dtype`, which is _not_ callable. Thus, a utility called `np_scalar` was introduced, which casts a provided value to a provided dtype, e.g., `np_scalar(5.0, dtype=archive.dtypes["solution"])`

## Status

- [x] I have read the guidelines in
      [CONTRIBUTING.md](https://github.com/icaros-usc/pyribs/blob/master/CONTRIBUTING.md)
- [x] I have formatted my code using `yapf`
- [x] I have tested my code by running `pytest`
- [x] I have linted my code with `pylint`
- [x] I have added a one-line description of my change to the changelog in
      `HISTORY.md`
- [x] This PR is ready to go
