### PR TITLE
Allow specifying separate dtypes for solution, objective, and measures

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,6 +4,11 @@
 
 ### Changelog
 
+#### API
+
+- Allow specifying separate dtypes for solution, objective, and measures
+  ({pr}`470`)
+
 #### Improvements
 
 - Upgrade setup-miniconda to v3 due to deprecation ({pr}`464`)

--- a/ribs/_utils.py
+++ b/ribs/_utils.py
@@ -4,27 +4,6 @@ import numbers
 import numpy as np
 
 
-def parse_float_dtype(dtype):
-    """Parses a floating point dtype.
-
-    Returns:
-        np.float32 or np.float64
-    Raises:
-        ValueError: There is an error in the bounds configuration.
-    """
-    # First convert str dtype's to np.dtype.
-    if isinstance(dtype, str):
-        dtype = np.dtype(dtype)
-
-    # np.dtype is not np.float32 or np.float64, but it compares equal.
-    if dtype == np.float32:
-        return np.float32
-    if dtype == np.float64:
-        return np.float64
-
-    raise ValueError("Unsupported dtype. Must be np.float32 or np.float64")
-
-
 def np_scalar(scalar, dtype):
     """Casts the scalar to the given numpy dtype.
 

--- a/ribs/archives/_archive_base.py
+++ b/ribs/archives/_archive_base.py
@@ -61,9 +61,11 @@ class ArchiveBase(ABC):
             ``objective - (-300)``.
         seed (int): Value to seed the random number generator. Set to None to
             avoid a fixed seed.
-        dtype (str or data-type): Data type of the solutions, objectives,
-            and measures. We only support ``"f"`` / ``np.float32`` and ``"d"`` /
-            ``np.float64``.
+        dtype (str or data-type or dict): Data type of the solutions,
+            objectives, and measures. We only support ``"f"`` / ``np.float32``
+            and ``"d"`` / ``np.float64``. Alternatively, this can be a dict
+            specifying separate dtypes, of the form ``{"solution": <dtype>,
+            "objective": <dtype>, "measures": <dtype>}``.
         extra_fields (dict): Description of extra fields of data that is stored
             next to elite data like solutions and objectives. The description is
             a dict mapping from a field name (str) to a tuple of ``(shape,

--- a/ribs/archives/_cvt_archive.py
+++ b/ribs/archives/_cvt_archive.py
@@ -83,9 +83,11 @@ class CVTArchive(ArchiveBase):
             ``objective - (-300)``.
         seed (int): Value to seed the random number generator as well as
             :func:`~sklearn.cluster.k_means`. Set to None to avoid a fixed seed.
-        dtype (str or data-type): Data type of the solutions, objectives,
-            and measures. We only support ``"f"`` / ``np.float32`` and ``"d"`` /
-            ``np.float64``.
+        dtype (str or data-type or dict): Data type of the solutions,
+            objectives, and measures. We only support ``"f"`` / ``np.float32``
+            and ``"d"`` / ``np.float64``. Alternatively, this can be a dict
+            specifying separate dtypes, of the form ``{"solution": <dtype>,
+            "objective": <dtype>, "measures": <dtype>}``.
         extra_fields (dict): Description of extra fields of data that is stored
             next to elite data like solutions and objectives. The description is
             a dict mapping from a field name (str) to a tuple of ``(shape,

--- a/ribs/archives/_grid_archive.py
+++ b/ribs/archives/_grid_archive.py
@@ -51,9 +51,11 @@ class GridArchive(ArchiveBase):
             ``objective - (-300)``.
         seed (int): Value to seed the random number generator. Set to None to
             avoid a fixed seed.
-        dtype (str or data-type): Data type of the solutions, objectives,
-            and measures. We only support ``"f"`` / ``np.float32`` and ``"d"`` /
-            ``np.float64``.
+        dtype (str or data-type or dict): Data type of the solutions,
+            objectives, and measures. We only support ``"f"`` / ``np.float32``
+            and ``"d"`` / ``np.float64``. Alternatively, this can be a dict
+            specifying separate dtypes, of the form ``{"solution": <dtype>,
+            "objective": <dtype>, "measures": <dtype>}``.
         extra_fields (dict): Description of extra fields of data that is stored
             next to elite data like solutions and objectives. The description is
             a dict mapping from a field name (str) to a tuple of ``(shape,

--- a/ribs/archives/_sliding_boundaries_archive.py
+++ b/ribs/archives/_sliding_boundaries_archive.py
@@ -133,9 +133,11 @@ class SlidingBoundariesArchive(ArchiveBase):
             ``objective - (-300)``.
         seed (int): Value to seed the random number generator. Set to None to
             avoid a fixed seed.
-        dtype (str or data-type): Data type of the solutions, objectives,
-            and measures. We only support ``"f"`` / ``np.float32`` and ``"d"`` /
-            ``np.float64``.
+        dtype (str or data-type or dict): Data type of the solutions,
+            objectives, and measures. We only support ``"f"`` / ``np.float32``
+            and ``"d"`` / ``np.float64``. Alternatively, this can be a dict
+            specifying separate dtypes, of the form ``{"solution": <dtype>,
+            "objective": <dtype>, "measures": <dtype>}``.
         extra_fields (dict): Description of extra fields of data that is stored
             next to elite data like solutions and objectives. The description is
             a dict mapping from a field name (str) to a tuple of ``(shape,

--- a/tests/archives/archive_base_test.py
+++ b/tests/archives/archive_base_test.py
@@ -25,6 +25,24 @@ def test_str_dtype_float(name, dtype):
     assert archive.dtypes["threshold"] == np_dtype
 
 
+def test_dict_dtype():
+    archive = GridArchive(
+        solution_dim=3,
+        dims=[10, 10],
+        ranges=[(-1, 1), (-2, 2)],
+        dtype={
+            "solution": object,
+            "objective": np.float32,
+            "measures": np.float32,
+        },
+    )
+
+    assert archive.dtypes["solution"] == object
+    assert archive.dtypes["objective"] == np.float32
+    assert archive.dtypes["measures"] == np.float32
+    assert archive.dtypes["threshold"] == np.float32
+
+
 def test_invalid_dtype():
     with pytest.raises(ValueError):
         GridArchive(solution_dim=0,

--- a/tests/archives/archive_base_test.py
+++ b/tests/archives/archive_base_test.py
@@ -51,6 +51,20 @@ def test_invalid_dtype():
                     dtype=np.int32)
 
 
+def test_invalid_dict_dtype():
+    with pytest.raises(ValueError):
+        GridArchive(
+            solution_dim=3,
+            dims=[10, 10],
+            ranges=[(-1, 1), (-2, 2)],
+            dtype={
+                "solution": object,
+                "objective": np.float32,
+                # Missing measures.
+            },
+        )
+
+
 #
 # Tests for iteration -- only GridArchive for simplicity.
 #

--- a/tests/archives/grid_archive_test.py
+++ b/tests/archives/grid_archive_test.py
@@ -55,12 +55,19 @@ def assert_archive_elites(
             if archive_covered[j]:
                 continue
 
-            solution_match = (solution_batch is None or np.isclose(
-                data["solution"][j], solution_batch[i]).all())
+            if solution_batch is not None:
+                if data["solution"].dtype.kind == "f":
+                    solution_match = np.allclose(data["solution"][j],
+                                                 solution_batch[i])
+                else:
+                    solution_match = np.all(
+                        data["solution"][j] == solution_batch[i])
+            else:
+                solution_match = True
             objective_match = (objective_batch is None or np.isclose(
                 data["objective"][j], objective_batch[i]))
-            measures_match = (measures_batch is None or np.isclose(
-                data["measures"][j], measures_batch[i]).all())
+            measures_match = (measures_batch is None or np.allclose(
+                data["measures"][j], measures_batch[i]))
             index_match = (grid_indices_batch is None or
                            data["index"][j] == index_batch[i])
 


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the PR's purpose here. -->

Previously, dtype in the archive could only be a single value specifying the dtype for the solution, objective, and measures all at once. Now, it is allowed to be a dict specifying separate dtypes for each of these, e.g.,

```python
    archive = GridArchive(
        solution_dim=3,
        dims=[10, 10],
        ranges=[(-1, 1), (-2, 2)],
        dtype={
            "solution": object,
            "objective": np.float32,
            "measures": np.float32,
        },
    )
```

Comments:

- This PR is a followup to #470 which allowed expressing the different dtypes present in the archive.
- Emitters used the dtype of their archive, e.g., `archive.dtype`. Now, they choose a specific field's dtype to use. The emitters implemented thus far all choose `archive.dtypes["solution"]`, i.e., they have the same dtype as the solution.

## TODO

<!-- Notable points that this PR has either accomplished or will accomplish. -->

- [x] Write docstrings
- [x] Implement change with parse_dtype function
- [x] Add tests

## Status

- [x] I have read the guidelines in
      [CONTRIBUTING.md](https://github.com/icaros-usc/pyribs/blob/master/CONTRIBUTING.md)
- [x] I have formatted my code using `yapf`
- [x] I have tested my code by running `pytest`
- [x] I have linted my code with `pylint`
- [x] I have added a one-line description of my change to the changelog in
      `HISTORY.md`
- [x] This PR is ready to go
