### PR TITLE
Support diversity optimization in Scheduler.tell

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,6 +6,7 @@
 
 #### API
 
+- Support diversity optimization in scheduler ({pr}`473`)
 - Allow specifying separate dtypes for solution, objective, and measures
   ({pr}`471`)
 - Replace archive.dtype with archive.dtypes dict that holds dtype of every field

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,7 +6,7 @@
 
 #### API
 
-- Support diversity optimization in scheduler ({pr}`473`)
+- Support diversity optimization in Scheduler.tell ({pr}`473`)
 - Allow specifying separate dtypes for solution, objective, and measures
   ({pr}`471`)
 - Replace archive.dtype with archive.dtypes dict that holds dtype of every field

--- a/ribs/schedulers/_scheduler.py
+++ b/ribs/schedulers/_scheduler.py
@@ -218,6 +218,11 @@ class Scheduler:
     def _validate_tell_data(self, data):
         """Preprocesses data passed into tell methods."""
         for name, arr in data.items():
+            # Fields are allowed to be None to indicate they are not present,
+            # e.g., `objective` is None in diversity optimization.
+            if arr is None:
+                continue
+
             data[name] = np.asarray(arr)
             self._check_length(name, arr)
 
@@ -284,8 +289,10 @@ class Scheduler:
             objective, measures, and jacobian for ``solution[i]``.
 
         Args:
-            objective ((batch_size,) array): Each entry of this array contains
-                the objective function evaluation of a solution.
+            objective ((batch_size,) array or None): Each entry of this array
+                contains the objective function evaluation of a solution. This
+                can also be None to indicate there is no objective -- this would
+                be the case in diversity optimization problems.
             measures ((batch_size, measure_dim) array): Each row of this array
                 contains a solution's coordinates in measure space.
             jacobian (numpy.ndarray): ``(batch_size, 1 + measure_dim,
@@ -323,7 +330,8 @@ class Scheduler:
             end = pos + n
             emitter.tell_dqd(
                 **{
-                    name: arr[pos:end] for name, arr in data.items()
+                    name: None if arr is None else arr[pos:end]
+                    for name, arr in data.items()
                 },
                 jacobian=jacobian[pos:end],
                 add_info={
@@ -341,8 +349,10 @@ class Scheduler:
             ``solution[i]``.
 
         Args:
-            objective ((batch_size,) array): Each entry of this array contains
-                the objective function evaluation of a solution.
+            objective ((batch_size,) array or None): Each entry of this array
+                contains the objective function evaluation of a solution. This
+                can also be None to indicate there is no objective -- this would
+                be the case in diversity optimization problems.
             measures ((batch_size, measures_dm) array): Each row of this array
                 contains a solution's coordinates in measure space.
             fields (keyword arguments): Additional data for each solution. Each
@@ -371,7 +381,8 @@ class Scheduler:
             end = pos + n
             emitter.tell(
                 **{
-                    name: arr[pos:end] for name, arr in data.items()
+                    name: None if arr is None else arr[pos:end]
+                    for name, arr in data.items()
                 },
                 add_info={
                     name: arr[pos:end] for name, arr in add_info.items()

--- a/tests/schedulers/scheduler_test.py
+++ b/tests/schedulers/scheduler_test.py
@@ -256,8 +256,16 @@ def test_tell_with_fields(add_mode):
     )
 
 
-def test_tell_with_none_objective(scheduler_fixture):
-    scheduler, _, _ = scheduler_fixture
+@pytest.mark.parametrize("scheduler_type", ["Scheduler", "BanditScheduler"])
+def test_tell_with_none_objective(scheduler_type):
+    archive = GridArchive(solution_dim=2,
+                          dims=[100, 100],
+                          ranges=[(-1, 1), (-1, 1)])
+    emitters = [GaussianEmitter(archive, sigma=1, x0=[0.0, 0.0], batch_size=4)]
+    if scheduler_type == "Scheduler":
+        scheduler = Scheduler(archive, emitters)
+    else:
+        scheduler = BanditScheduler(archive, emitters, 1)
 
     solutions = scheduler.ask()
 

--- a/tests/schedulers/scheduler_test.py
+++ b/tests/schedulers/scheduler_test.py
@@ -1,4 +1,4 @@
-"""Tests for the Scheduler."""
+"""Tests for Scheduler and BanditScheduler."""
 import numpy as np
 import pytest
 
@@ -254,6 +254,21 @@ def test_tell_with_fields(add_mode):
         measures_batch=measures_batch,
         metadata_batch=["a", "b", "c", "d"],
     )
+
+
+def test_tell_with_none_objective(scheduler_fixture):
+    scheduler, _, _ = scheduler_fixture
+
+    solutions = scheduler.ask()
+
+    # TODO: Switch this to a proper test once we have an archive that supports
+    # diversity optimization. Right now, GridArchive throws an error since it
+    # expects an objective.
+    with pytest.raises(
+            ValueError,
+            match="Expected objective to be a 1D array but it had shape ()",
+    ):
+        scheduler.tell(None, [[0, 0]] * len(solutions))
 
 
 ### TESTS FOR OUT-OF-ORDER ASK-TELL ###


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the PR's purpose here. -->

We are working on supporting diversity optimization algorithms such as novelty search (see #472). One difference from other algorithms is that such algorithms do not require objectives. However, the current API to Scheduler.tell() is:

```
tell(objective, measures, **fields)
```

i.e., it assumes objective and measures will be provided. This PR seeks to make it possible to call `scheduler.tell(measures)` in addition to the current `scheduler.tell(objective, measures)`.

### Use Cases

There are a couple of use cases that the scheduler must satisfy:

1. QD optimization (i.e., current behavior should not break):
    - Positional arguments: `scheduler.tell(objective, measures)`
    - Keyword arguments: `scheduler.tell(objective=objective, measures=measures)`
    - Mixed (a rather extreme case): `scheduler.tell(objective, measures=measures)`
2. Diversity optimization:
    - Positional arguments: `scheduler.tell(measures)`
    - Keyword arguments: `scheduler.tell(measures=measures)`
3. Diversity optimization but where an objective has been added as an extra field:
    - Positional arguments: `scheduler.tell(measures, objective=objective)`
    - Keyword arguments: `scheduler.tell(measures=measures, objective=objective)`

Ideally, we would also be robust to a case where we need to only have objectives in the future:

4. Objective optimization:
   - Positional arguments: `scheduler.tell(objective)`
   - Keyword arguments: `scheduler.tell(objective=objective)`

### Potential Solutions

1. Change scheduler API to `tell(*args, **kwargs)` and add a `problem_type` to each archive.
    - args and kwargs are interpreted based on the type of the archive. If the problem type is quality_diversity, then the args are interpreted as objectives and measures. If the problem type is diversity_optimization, then the args are interpreted as measures. If the problem type is single_objective, the args are interpreted as objective. kwargs will be treated the same as fields in all cases.
    - Pros: Backwards-compatible and handles all 4 use cases above.
    - Cons: Makes the archives a bit more complex, may be a bit confusing to users because the signature will not be very informative. However, I think we can get away with this with good docstrings and documentation.
2. Allow the current objective argument to be treated as measures, and assign a default argument of None to the current objective and measures -> i.e., `tell(objective=None, measures=None, **fields)`
    - Inspired by how numpy's `integers` can be either `rng.integers(high)` or `rng.integers(low, high)` -> see [here](https://numpy.org/doc/stable/reference/random/generated/numpy.random.Generator.integers.html)
    - Pros: Minimal changes to current API, and still quite interpretable for users.
    - Cons: On the other hand, it may be confusing to see that objective can be set to measures. This will also fail case 3 above, i.e., `scheduler.tell(measures, objective=objective)` will throw an error because `measures` is actually `objective` due to the positional argument, so `objective` is being passed in twice.
3. **Require the user to pass in `objective=None` when performing diversity optimization and maintain the same `scheduler.tell` API.**
    - Pros: This requires the fewest changes to the API. It also provides a good model for what EvolutionStrategyEmitter and other emitters should do -- all these classes can now implement behavior for `objective=None`. It also does not require modifying the archives to have a `problem_type` or `archive_type` attribute. Furthermore, `objective` can still be provided if that is a field in the archive.
    - Cons: It is a bit verbose to have `scheduler.tell(None, measures)` or `scheduler.tell(objective=None, measures=measures)` but I think users can understand that.
    - Optionally, we can also set a default of `objective=None` and `measures=None` so that one can pass just measures, e.g., `scheduler.tell(measures=...)` or just objectives `scheduler.tell(objective=)`. However, I think we may not want to add this feature for now as it requires adding default values to a lot of places.
4. Add a new parameter to `scheduler.tell` called `mode` or something similar to indicate diversity optimization is in effect, i.e., `scheduler.tell(measures, mode="diversity")`
    - Pros: This is very explicit and makes it clear that diversity optimization is happening without objectives.
    - Cons: Rather verbose.

### Decision

I believe **Solution 3** is the best solution, since it involves the fewest changes to the API and also contains the changes to the scheduler.

## TODO

<!-- Notable points that this PR has either accomplished or will accomplish. -->

- [x] Implement behavior for when `objective=None` in `Scheduler.tell` -- specifically, the scheduler will now allow any field to be None, and when the field is None, the scheduler will simply pass None down to the emitter tell functions.
- [x] Write test for passing `objective=None` to the scheduler, both with positional and keyword arguments. This test will be updated once the UnstructuredArchive is implemented.

## Status

- [x] I have read the guidelines in
      [CONTRIBUTING.md](https://github.com/icaros-usc/pyribs/blob/master/CONTRIBUTING.md)
- [x] I have formatted my code using `yapf`
- [x] I have tested my code by running `pytest`
- [x] I have linted my code with `pylint`
- [x] I have added a one-line description of my change to the changelog in
      `HISTORY.md`
- [x] This PR is ready to go
