### PR TITLE
Remove `_cells` attribute from ArchiveBase

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -14,6 +14,7 @@
 
 #### Improvements
 
+- Remove `_cells` attribute from ArchiveBase ({pr}`474`)
 - Upgrade setup-miniconda to v3 due to deprecation ({pr}`464`)
 
 ## 0.7.1

--- a/ribs/archives/_archive_base.py
+++ b/ribs/archives/_archive_base.py
@@ -132,7 +132,6 @@ class ArchiveBase(ABC):
 
         self._seed = seed
         self._rng = np.random.default_rng(seed)
-        self._cells = cells
         self._solution_dim = solution_dim
         self._measure_dim = measure_dim
 
@@ -152,7 +151,7 @@ class ArchiveBase(ABC):
                 "threshold": ((), dtype["objective"]),
                 **extra_fields,
             },
-            capacity=self._cells,
+            capacity=cells,
         )
 
         if threshold_min != -np.inf and learning_rate is None:
@@ -188,7 +187,7 @@ class ArchiveBase(ABC):
     @property
     def cells(self):
         """int: Total number of cells in the archive."""
-        return self._cells
+        return self._store.capacity
 
     @property
     def measure_dim(self):
@@ -442,12 +441,12 @@ class ArchiveBase(ABC):
               to :class:`AddStatus` e.g. with ``[AddStatus(s) for s in
               add_info["status"]]``.
 
-            - ``"value"`` (:class:`numpy.ndarray` of :attr:`dtype`): An array
-              with values for each solution in the batch. With the default
-              values of ``learning_rate = 1.0`` and ``threshold_min = -np.inf``,
-              the meaning of each value depends on the corresponding ``status``
-              and is identical to that in CMA-ME (`Fontaine 2020
-              <https://arxiv.org/abs/1912.02400>`_):
+            - ``"value"`` (:class:`numpy.ndarray` of
+              :attr:`dtypes` ["objective"]): An array with values for each
+              solution in the batch. With the default values of ``learning_rate
+              = 1.0`` and ``threshold_min = -np.inf``, the meaning of each value
+              depends on the corresponding ``status`` and is identical to that
+              in CMA-ME (`Fontaine 2020 <https://arxiv.org/abs/1912.02400>`_):
 
               - ``0`` (not added): The value is the "negative improvement," i.e.
                 the objective of the solution passed in minus the objective of

--- a/ribs/archives/_cvt_archive.py
+++ b/ribs/archives/_cvt_archive.py
@@ -199,38 +199,38 @@ class CVTArchive(ArchiveBase):
                         size=(samples, self._measure_dim),
                     ).astype(self.dtypes["measures"])
 
-                self._centroids = k_means(self._samples, self._cells,
+                self._centroids = k_means(self._samples, self.cells,
                                           **self._k_means_kwargs)[0]
 
-                if self._centroids.shape[0] < self._cells:
+                if self._centroids.shape[0] < self.cells:
                     raise RuntimeError(
                         "While generating the CVT, k-means clustering found "
                         f"{self._centroids.shape[0]} centroids, but this "
-                        f"archive needs {self._cells} cells. This most "
+                        f"archive needs {self.cells} cells. This most "
                         "likely happened because there are too few samples "
                         "and/or too many cells.")
             elif centroid_method == "random":
                 # Generates random centroids.
                 self._centroids = self._rng.uniform(self._lower_bounds,
                                                     self._upper_bounds,
-                                                    size=(self._cells,
+                                                    size=(self.cells,
                                                           self._measure_dim))
             elif centroid_method == "sobol":
                 # Generates centroids as a Sobol sequence.
                 sampler = Sobol(d=self._measure_dim, scramble=False)
-                sobol_nums = sampler.random(n=self._cells)
+                sobol_nums = sampler.random(n=self.cells)
                 self._centroids = (self._lower_bounds + sobol_nums *
                                    (self._upper_bounds - self._lower_bounds))
             elif centroid_method == "scrambled_sobol":
                 # Generates centroids as a scrambled Sobol sequence.
                 sampler = Sobol(d=self._measure_dim, scramble=True)
-                sobol_nums = sampler.random(n=self._cells)
+                sobol_nums = sampler.random(n=self.cells)
                 self._centroids = (self._lower_bounds + sobol_nums *
                                    (self._upper_bounds - self._lower_bounds))
             elif centroid_method == "halton":
                 # Generates centroids with a Halton sequence.
                 sampler = Halton(d=self._measure_dim)
-                halton_nums = sampler.random(n=self._cells)
+                halton_nums = sampler.random(n=self.cells)
                 self._centroids = (self._lower_bounds + halton_nums *
                                    (self._upper_bounds - self._lower_bounds))
         else:


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the PR's purpose here. -->

Removing this private attribute. It is confusing to allow usage of `_cells` because in UnstructuredArchive, the `cells` property will change over time while `_cells` is set to the initial capacity. When initially added, it was assumed that `_cells` would remain constant.

## Status

- [x] I have read the guidelines in
      [CONTRIBUTING.md](https://github.com/icaros-usc/pyribs/blob/master/CONTRIBUTING.md)
- [x] I have formatted my code using `yapf`
- [x] I have tested my code by running `pytest`
- [x] I have linted my code with `pylint`
- [x] I have added a one-line description of my change to the changelog in
      `HISTORY.md`
- [x] This PR is ready to go
