### PR TITLE
Add novelty search with CMA-ES to sphere example

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -15,6 +15,10 @@
 - Replace archive.dtype with archive.dtypes dict that holds dtype of every field
   ({pr}`470`)
 
+#### Documentation
+
+- Add novelty search with CMA-ES to sphere example ({pr}`478`)
+
 #### Improvements
 
 - Remove `_cells` attribute from ArchiveBase ({pr}`475`)

--- a/examples/sphere.py
+++ b/examples/sphere.py
@@ -45,6 +45,8 @@ The supported algorithms are:
   using ImprovementRanker.
 - `cma_maega`: GridArchive (learning_rate = 0.01) with
   GradientArborescenceEmitter using ImprovementRanker.
+- `ns_cma`: Novelty Search with CMA-ES; implemented using a ProximityArchive
+  with EvolutionStrategyEmitter.
 
 The parameters for each algorithm are stored in CONFIG. The parameters
 reproduce the experiments presented in the paper in which each algorithm is
@@ -84,7 +86,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 import tqdm
 
-from ribs.archives import CVTArchive, GridArchive
+from ribs.archives import CVTArchive, GridArchive, ProximityArchive
 from ribs.emitters import (EvolutionStrategyEmitter, GaussianEmitter,
                            GradientArborescenceEmitter, GradientOperatorEmitter,
                            IsoLineEmitter)
@@ -595,7 +597,36 @@ CONFIG = {
             "class": Scheduler,
             "kwargs": {}
         }
-    }
+    },
+    "ns_cma": {
+        "dim": 100,
+        "iters": 5000,
+        "archive_dims": (100, 100),
+        "use_result_archive": True,
+        "is_dqd": False,
+        "batch_size": 36,
+        "archive": {
+            "class": ProximityArchive,
+            "kwargs": {
+                "k_neighbors": 15,
+                "novelty_threshold": 0.037 * 512,
+            }
+        },
+        "emitters": [{
+            "class": EvolutionStrategyEmitter,
+            "kwargs": {
+                "sigma0": 0.5,
+                "ranker": "nov",
+                "selection_rule": "mu",
+                "restart_rule": "basic",
+            },
+            "num_emitters": 15
+        }],
+        "scheduler": {
+            "class": Scheduler,
+            "kwargs": {}
+        }
+    },
 }
 
 
@@ -685,6 +716,11 @@ def create_scheduler(config, algorithm, seed=None):
         archive = archive_class(solution_dim=solution_dim,
                                 ranges=bounds,
                                 dims=archive_dims,
+                                seed=seed,
+                                **config["archive"]["kwargs"])
+    elif archive_class == ProximityArchive:
+        archive = archive_class(solution_dim=solution_dim,
+                                measure_dim=len(bounds),
                                 seed=seed,
                                 **config["archive"]["kwargs"])
     else:

--- a/examples/sphere.py
+++ b/examples/sphere.py
@@ -46,7 +46,7 @@ The supported algorithms are:
 - `cma_maega`: GridArchive (learning_rate = 0.01) with
   GradientArborescenceEmitter using ImprovementRanker.
 - `ns_cma`: Novelty Search with CMA-ES; implemented using a ProximityArchive
-  with EvolutionStrategyEmitter.
+  with EvolutionStrategyEmitter. Results are stored in a passive GridArchive.
 
 The parameters for each algorithm are stored in CONFIG. The parameters
 reproduce the experiments presented in the paper in which each algorithm is

--- a/tests/examples.sh
+++ b/tests/examples.sh
@@ -48,6 +48,7 @@ python examples/sphere.py cma_mega_adam --dim 20 --itrs 10 --outdir "${SPHERE_OU
 
 python examples/sphere.py cma_mae --dim 20 --itrs 10 --learning_rate 0.01 --outdir "${SPHERE_OUTPUT}"
 python examples/sphere.py cma_maega --dim 20 --itrs 10 --learning_rate 0.01 --outdir "${SPHERE_OUTPUT}"
+python examples/sphere.py ns_cma --dim 20 --itrs 10 --outdir "${SPHERE_OUTPUT}"
 
 # lunar_lander.py
 install_deps examples/lunar_lander.py


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the PR's purpose here. -->

Add `ns_cma` to sphere example. Usage is `python examples/sphere.py ns_cma`. This is novelty search with CMA-ES, which is achieved with a `ProximityArchive` and an `EvolutionStrategyEmitter` that uses `NoveltyRanker`.

## Status

- [x] I have read the guidelines in
      [CONTRIBUTING.md](https://github.com/icaros-usc/pyribs/blob/master/CONTRIBUTING.md)
- [x] I have formatted my code using `yapf`
- [x] I have tested my code by running `pytest`
- [x] I have linted my code with `pylint`
- [x] I have added a one-line description of my change to the changelog in
      `HISTORY.md`
- [x] This PR is ready to go
