### PR TITLE
Support novelty search with local competition in ProximityArchive

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -56,7 +56,7 @@ confidence=
 # --enable=similarities". If you want to run only the classes checker, but have
 # no Warning level messages displayed, use"--disable=all --enable=classes
 # --disable=W"
-disable=suppressed-message,arguments-differ,wildcard-import,locally-disabled,duplicate-code,no-else-return
+disable=suppressed-message,arguments-differ,wildcard-import,locally-disabled,duplicate-code,no-else-return,no-else-raise
 
 
 [REPORTS]

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -9,7 +9,7 @@
 - Add NoveltyRanker for novelty search ({pr}`477`)
 - Add proximity_archive_plot for visualizing ProximityArchive ({pr}`476`,
   {pr}`480`)
-- Add ProximityArchive for novelty search ({pr}`472`, {pr}`479`)
+- Add ProximityArchive for novelty search ({pr}`472`, {pr}`479`, {pr}`481`)
 - Support diversity optimization in Scheduler.tell ({pr}`473`)
 - Allow specifying separate dtypes for solution, objective, and measures
   ({pr}`471`)

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -9,7 +9,8 @@
 - Add NoveltyRanker for novelty search ({pr}`477`)
 - Add proximity_archive_plot for visualizing ProximityArchive ({pr}`476`,
   {pr}`480`)
-- Add ProximityArchive for novelty search ({pr}`472`, {pr}`479`, {pr}`481`)
+- Support novelty search with local competition in ProximityArchive ({pr}`481`)
+- Add ProximityArchive for novelty search ({pr}`472`, {pr}`479`)
 - Support diversity optimization in Scheduler.tell ({pr}`473`)
 - Allow specifying separate dtypes for solution, objective, and measures
   ({pr}`471`)

--- a/ribs/archives/_proximity_archive.py
+++ b/ribs/archives/_proximity_archive.py
@@ -388,7 +388,16 @@ class ProximityArchive(ArchiveBase):
             ValueError: The array arguments do not match their specified shapes.
             ValueError: ``objective`` is non-finite (inf or NaN) or ``measures``
                 has non-finite values.
+            ValueError: ``local_competition` is turned on but objective was not
+                passed in.
         """
+        if objective is None:
+            if self.local_competition:
+                raise ValueError("If local competition is turned on, objective "
+                                 "must be passed in to add_single().")
+            else:
+                objective = 0.0
+
         data = validate_single(
             self,
             {
@@ -397,12 +406,9 @@ class ProximityArchive(ArchiveBase):
                 "measures": measures,
                 **fields,
             },
-            none_objective_ok=True,
         )
 
-        return self.add(**{
-            key: val if val is None else [val] for key, val in data.items()
-        })
+        return self.add(**{key: [val] for key, val in data.items()})
 
     @cached_property
     def upper_bounds(self) -> np.ndarray:

--- a/ribs/archives/_proximity_archive.py
+++ b/ribs/archives/_proximity_archive.py
@@ -299,10 +299,10 @@ class ProximityArchive(ArchiveBase):
                 the nearest neighbor (this value is negative because the
                 solution did not have a high enough objective to be added to the
                 archive).
-              - ``1`` (replace/improve existing cell): The value is the
+              - ``1`` (replace/improve existing solution): The value is the
                 "improvement," i.e. the objective of the solution passed in
                 minus the objective of the elite that was replaced.
-              - ``2`` (new cell): The value is just the objective of the
+              - ``2`` (new solution): The value is just the objective of the
                 solution.
 
         Raises:
@@ -348,11 +348,12 @@ class ProximityArchive(ArchiveBase):
 
             # Expand since query() automatically squeezes the last dim when k=1.
             dists = dists[:, None] if k_neighbors == 1 else dists
-            indices = indices[:, None] if k_neighbors == 1 else indices
 
             novelty = np.mean(dists, axis=1)
 
             if self.local_competition:
+                indices = indices[:, None] if k_neighbors == 1 else indices
+
                 # The first item returned by `retrieve` is `occupied` -- all
                 # these indices are occupied since they are indices of solutions
                 # in the archive.
@@ -372,11 +373,14 @@ class ProximityArchive(ArchiveBase):
 
         if self.local_competition:
             # In the case of local competition, we consider all solutions for
-            # addition. Solutions that were not novel enough have the potential
-            # to replace their nearest neighbors in the archive.
+            # addition.
             add_indices = np.empty(len(novelty), dtype=np.int32)
+
+            # New solutions are assigned the new indices.
             add_indices[novel_enough] = np.arange(len(self), new_size)
 
+            # Solutions that were not novel enough have the potential to replace
+            # their nearest neighbors in the archive.
             not_novel_enough = ~novel_enough
             n_not_novel_enough = len(novelty) - n_novel_enough
             if n_not_novel_enough > 0:

--- a/tests/archives/proximity_archive_test.py
+++ b/tests/archives/proximity_archive_test.py
@@ -509,3 +509,22 @@ def test_cqd_score_with_max_dist():
     # For theta=0, the score should be 0.5 - 0 * 0.5 = 0.5
     # For theta=1, the score should be 0.5 - 1 * 0.5 = 0.0
     assert np.isclose(score, 0.5 + 0.0)
+
+
+#
+# Tests for local competition.
+#
+
+
+def test_add_none_to_nslc():
+    archive = ProximityArchive(
+        solution_dim=3,
+        measure_dim=2,
+        k_neighbors=1,
+        novelty_threshold=1.0,
+        initial_capacity=1,
+        local_competition=True,
+    )
+
+    with pytest.raises(ValueError):
+        archive.add_single([1, 2, 3], None, [0, 0])

--- a/tests/archives/proximity_archive_test.py
+++ b/tests/archives/proximity_archive_test.py
@@ -516,7 +516,7 @@ def test_cqd_score_with_max_dist():
 #
 
 
-def test_add_none_to_nslc():
+def test_lc_add_none():
     archive = ProximityArchive(
         solution_dim=3,
         measure_dim=2,
@@ -530,8 +530,148 @@ def test_add_none_to_nslc():
         archive.add_single([1, 2, 3], None, [0, 0])
 
 
+def test_lc_add_single(add_mode):
+    archive = ProximityArchive(
+        solution_dim=3,
+        measure_dim=2,
+        k_neighbors=2,
+        novelty_threshold=1.0,
+        initial_capacity=1,
+        local_competition=True,
+    )
+
+    solution = np.array([1., 2., 3.])
+    measures = np.array([0.25, 0.25])
+
+    if add_mode == "single":
+        add_info = archive.add_single(solution, 5.0, measures)
+    else:
+        add_info = archive.add([solution], [5.0], [measures])
+
+    assert_archive_elite(archive, solution, 5.0, measures)
+    assert add_info["status"] == AddStatus.NEW
+    assert add_info["novelty"] == archive.novelty_threshold
+    assert add_info["local_competition"] == 0
+    assert add_info["value"] == 5.0
+
+
+def test_lc_add_single_after_clear():
+    """After clearing, we should still get the same status and value when adding
+    to the archive.
+
+    https://github.com/icaros-usc/pyribs/pull/260
+    """
+    archive = ProximityArchive(
+        solution_dim=3,
+        measure_dim=2,
+        k_neighbors=2,
+        novelty_threshold=1.0,
+        initial_capacity=1,
+        local_competition=True,
+    )
+
+    solution = np.array([1., 2., 3.])
+    measures = np.array([0.25, 0.25])
+
+    add_info = archive.add_single(solution, 5.0, measures)
+
+    assert add_info["status"] == 2
+    assert add_info["novelty"] == archive.novelty_threshold
+    assert add_info["local_competition"] == 0
+    assert add_info["value"] == 5.0
+
+    archive.clear()
+
+    add_info = archive.add_single(solution, 5.0, measures)
+
+    assert add_info["status"] == 2
+    assert add_info["novelty"] == archive.novelty_threshold
+    assert add_info["local_competition"] == 0
+    assert add_info["value"] == 5.0
+
+
+def test_lc_add_novel_solution():
+    archive = ProximityArchive(
+        solution_dim=3,
+        measure_dim=2,
+        k_neighbors=1,
+        novelty_threshold=1.0,
+        initial_capacity=1,
+        local_competition=True,
+    )
+
+    archive.add_single([1, 2, 3], 1.0, [0, 0])
+
+    # Should be added since novelty threshold is 1.0.
+    add_info = archive.add_single([1, 2, 3], 2.0, [1, 0])
+
+    assert_archive_elites(archive,
+                          2,
+                          objective_batch=[1.0, 2.0],
+                          measures_batch=[[0, 0], [1, 0]])
+
+    assert add_info["status"] == 2
+    assert add_info["novelty"] == 1.0
+    assert add_info["local_competition"] == 1
+    assert add_info["value"] == 2.0
+
+
+def test_lc_add_non_novel_solution():
+    archive = ProximityArchive(
+        solution_dim=3,
+        measure_dim=2,
+        k_neighbors=1,
+        novelty_threshold=1.0,
+        initial_capacity=1,
+        local_competition=True,
+    )
+
+    archive.add_single([1, 2, 3], 1.0, [0, 0])
+
+    # Should replace other solution since threshold is 1.0 and distance is 0.5,
+    # but the objective is 2.0 over 1.0.
+    add_info = archive.add_single([1, 2, 3], 2.0, [0.5, 0])
+
+    assert_archive_elites(archive,
+                          1,
+                          objective_batch=[2.0],
+                          measures_batch=[[0.5, 0]])
+
+    assert add_info["status"] == 1
+    assert_allclose(add_info["novelty"], 0.5)
+    assert add_info["local_competition"] == 1
+    assert add_info["value"] == 1.0
+
+
+def test_lc_add_non_novel_low_performing_solution():
+    archive = ProximityArchive(
+        solution_dim=3,
+        measure_dim=2,
+        k_neighbors=1,
+        novelty_threshold=1.0,
+        initial_capacity=1,
+        local_competition=True,
+    )
+
+    archive.add_single([1, 2, 3], 1.0, [0, 0])
+
+    # Not novel enough because threshold is 1.0 and distance is 0.5, and not
+    # performant enough because objective is 0.0 when 1.0 is needed.
+    add_info = archive.add_single([1, 2, 3], 0.0, [0.5, 0])
+
+    assert_archive_elites(archive,
+                          1,
+                          objective_batch=[1.0],
+                          measures_batch=[[0, 0]])
+
+    assert add_info["status"] == 0
+    assert_allclose(add_info["novelty"], 0.5)
+    assert add_info["local_competition"] == 0
+    assert add_info["value"] == -1.0
+
+
 @pytest.mark.parametrize("point", [[0.1, 0], [0.5, 0], [0.9, 0], [-0.1, 0.1]])
-def test_add_with_multiple_neighbors_nslc(point):
+def test_lc_add_with_multiple_neighbors(point):
     archive = ProximityArchive(
         solution_dim=3,
         measure_dim=2,
@@ -548,7 +688,10 @@ def test_add_with_multiple_neighbors_nslc(point):
     # and [2, 0], so its average distance is always at least 1.0.
     add_info = archive.add_single([1, 2, 3], 1.0, point)
 
-    assert_archive_elites(archive, 3, measures_batch=[[0, 0], [2, 0], point])
+    assert_archive_elites(archive,
+                          3,
+                          objective_batch=[0.0, 2.0, 1.0],
+                          measures_batch=[[0, 0], [2, 0], point])
     assert add_info["status"] == 2
     assert_allclose(
         add_info["novelty"],
@@ -556,3 +699,155 @@ def test_add_with_multiple_neighbors_nslc(point):
                                axis=1)),
     )
     assert_equal(add_info["local_competition"], 1)
+    assert_allclose(add_info["value"], 1.0)
+
+
+def test_lc_add_batch_all_new():
+    archive = ProximityArchive(
+        solution_dim=3,
+        measure_dim=2,
+        k_neighbors=2,
+        novelty_threshold=1.0,
+        initial_capacity=1,
+        local_competition=True,
+    )
+
+    # Initial points.
+    archive.add([[1, 2, 3]] * 2, [0.0, 2.0], [[0, 0], [1, 0]])
+
+    add_info = archive.add(
+        solution=[[1, 2, 3]] * 3,
+        objective=[-1.0, 1.0, 3.0],
+        measures=[[-1, 0], [0, 1], [2, 0]],
+    )
+
+    assert_archive_elites(
+        archive=archive,
+        batch_size=5,
+        solution_batch=[[1, 2, 3]] * 5,
+        objective_batch=[0.0, 2.0, -1.0, 1.0, 3.0],
+        measures_batch=[[0, 0], [1, 0], [-1, 0], [0, 1], [2, 0]],
+    )
+
+    assert (add_info["status"] == 2).all()
+    assert_allclose(add_info["novelty"], [
+        np.mean([1, 2]),
+        np.mean([1, np.sqrt(2)]),
+        np.mean([2, 1]),
+    ])
+    assert_equal(add_info["local_competition"], [0, 1, 2])
+    assert_allclose(add_info["value"], [-1, 1, 3])
+
+
+def test_lc_add_batch_none_inserted():
+    archive = ProximityArchive(
+        solution_dim=3,
+        measure_dim=2,
+        k_neighbors=2,
+        novelty_threshold=1.0,
+        initial_capacity=1,
+        local_competition=True,
+    )
+
+    # Initial points.
+    archive.add([[1, 2, 3]] * 2, [0.0, 2.0], [[0, 0], [1, 0]])
+
+    add_info = archive.add(
+        solution=[[1, 2, 3]] * 2,
+        objective=[-1, -2],
+        measures=[[0.6, 0], [0, 0.1]],
+    )
+
+    assert_archive_elites(
+        archive=archive,
+        batch_size=2,
+        solution_batch=[[1, 2, 3]] * 2,
+        objective_batch=[0.0, 2.0],
+        measures_batch=[[0, 0], [1, 0]],
+    )
+
+    assert (add_info["status"] == 0).all()
+    assert_allclose(add_info["novelty"], [
+        np.mean([0.4, 0.6]),
+        np.mean([0.1, np.sqrt(0.1**2 + 1)]),
+    ])
+    assert_equal(add_info["local_competition"], [0, 0])
+    assert_allclose(add_info["value"], [-1 - 2, -2 - 0])
+
+
+def test_lc_add_batch_mixed_statuses():
+    archive = ProximityArchive(
+        solution_dim=3,
+        measure_dim=2,
+        k_neighbors=2,
+        novelty_threshold=1.0,
+        initial_capacity=1,
+        local_competition=True,
+    )
+
+    # Initial points.
+    archive.add([[1, 2, 3]] * 2, [0.0, 2.0], [[0, 0], [1, 0]])
+
+    add_info = archive.add(
+        solution=[[1, 2, 3]] * 5,
+        objective=[-2, -1, 1, -3, 5],
+        measures=[[-1, 0], [0.4, 0], [0, 0.5], [0, 0.1], [2, 0]],
+    )
+
+    assert_archive_elites(
+        archive=archive,
+        batch_size=4,
+        solution_batch=[[1, 2, 3]] * 4,
+        objective_batch=[2, -2, 1, 5],
+        measures_batch=[[1, 0], [-1, 0], [0, 0.5], [2, 0]],
+    )
+
+    assert (add_info["status"] == [2, 0, 1, 0, 2]).all()
+    assert_allclose(add_info["novelty"], [
+        np.mean([1, 2]),
+        np.mean([0.4, 0.6]),
+        np.mean([0.5, np.sqrt(1**2 + 0.5**2)]),
+        np.mean([0.1, np.sqrt(0.1**2 + 1)]),
+        np.mean([2, 1]),
+    ])
+    assert_equal(add_info["local_competition"], [0, 0, 1, 0, 2])
+    assert_allclose(add_info["value"], [-2, -1, 1, -3, 5])
+
+
+def test_lc_add_batch_replace_same_cell():
+    archive = ProximityArchive(
+        solution_dim=3,
+        measure_dim=2,
+        k_neighbors=2,
+        novelty_threshold=1.0,
+        initial_capacity=1,
+        local_competition=True,
+    )
+
+    # Initial points.
+    archive.add([[1, 2, 3]] * 2, [0.0, 2.0], [[0, 0], [1, 0]])
+
+    # First three solutions replace the solution at [0, 0]; last is just added.
+    add_info = archive.add(
+        solution=[[1, 2, 3]] * 4,
+        objective=[1.0, 2.0, 3.0, 0.0],
+        measures=[[0, 0.1], [0, 0.2], [0, 0.3], [3, 0]],
+    )
+
+    assert_archive_elites(
+        archive=archive,
+        batch_size=3,
+        solution_batch=[[1, 2, 3]] * 3,
+        objective_batch=[2, 3, 0],
+        measures_batch=[[1, 0], [0, 0.3], [3, 0]],
+    )
+
+    assert (add_info["status"] == [1, 1, 1, 2]).all()
+    assert_allclose(add_info["novelty"], [
+        np.mean([0.1, np.sqrt(1**2 + 0.1**2)]),
+        np.mean([0.2, np.sqrt(1**2 + 0.2**2)]),
+        np.mean([0.3, np.sqrt(1**2 + 0.3**2)]),
+        np.mean([3, 2]),
+    ])
+    assert_equal(add_info["local_competition"], [1, 1, 2, 0])
+    assert_allclose(add_info["value"], [1, 2, 3, 0])


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the PR's purpose here. -->

Support NSLC in the ProximityArchive. This involves modifying the `add` method in particular to compute local competition as well as value. It should be noted that the NSLC paper does not specify how replacement should be handled in the archive -- it would seem that the authors only use a regular novelty search archive. We have decided to implement a rule where if the solution is not novel enough for addition, it shall be compared to its nearest neighbor and added if it exceeds the objective value of its nearest neighbor.

## TODO

<!-- Notable points that this PR has either accomplished or will accomplish. -->

- [x] Add `local_competition` flag to ProximityArchive
- [x] Add tests

## Status

- [x] I have read the guidelines in
      [CONTRIBUTING.md](https://github.com/icaros-usc/pyribs/blob/master/CONTRIBUTING.md)
- [x] I have formatted my code using `yapf`
- [x] I have tested my code by running `pytest`
- [x] I have linted my code with `pylint`
- [x] I have added a one-line description of my change to the changelog in
      `HISTORY.md`
- [x] This PR is ready to go
