### PR TITLE
Add DensityRanker for density descent search

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,6 +6,7 @@
 
 #### API
 
+- Add DensityRanker for density descent search ({pr}`483`)
 - Add NoveltyRanker for novelty search ({pr}`477`)
 - Add proximity_archive_plot for visualizing ProximityArchive ({pr}`476`,
   {pr}`480`)
@@ -19,7 +20,7 @@
 
 #### Documentation
 
-- Add novelty search with CMA-ES to sphere example ({pr}`478`)
+- Add novelty search with CMA-ES to sphere example ({pr}`478`, {pr}`482`)
 
 #### Improvements
 


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the PR's purpose here. -->

Added the DensityRanker, which will be used with DensityArchive for Density Descent Search. Also did a tiny bit of refactoring by alphabetizing the names in `ribs.emitters.rankers`.

## Status

- [x] I have read the guidelines in
      [CONTRIBUTING.md](https://github.com/icaros-usc/pyribs/blob/master/CONTRIBUTING.md)
- [x] I have formatted my code using `yapf`
- [x] I have tested my code by running `pytest`
- [x] I have linted my code with `pylint`
- [x] I have added a one-line description of my change to the changelog in
      `HISTORY.md`
- [x] This PR is ready to go
