### PR TITLE
Move novelty computation into a separate method

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -11,7 +11,7 @@
 - Add proximity_archive_plot for visualizing ProximityArchive ({pr}`476`,
   {pr}`480`)
 - Support novelty search with local competition in ProximityArchive ({pr}`481`)
-- Add ProximityArchive for novelty search ({pr}`472`, {pr}`479`)
+- Add ProximityArchive for novelty search ({pr}`472`, {pr}`479`, {pr}`484`)
 - Support diversity optimization in Scheduler.tell ({pr}`473`)
 - Allow specifying separate dtypes for solution, objective, and measures
   ({pr}`471`)

--- a/ribs/archives/_proximity_archive.py
+++ b/ribs/archives/_proximity_archive.py
@@ -249,8 +249,8 @@ class ProximityArchive(ArchiveBase):
             local_competition = True
 
         if self.empty:
-            # If there are no neighbors for computing nearest neighbors, there
-            # is infinite novelty and all solutions are added.
+            # Set default values for novelty and local competition when archive
+            # is empty.
             novelty = np.full(batch_size,
                               self.novelty_threshold,
                               dtype=self.dtypes["measures"])
@@ -278,6 +278,8 @@ class ProximityArchive(ArchiveBase):
                     indices.ravel(), "objective")[1]
                 neighbor_objectives = neighbor_objectives.reshape(indices.shape)
 
+                # Local competition is the number of neighbors who have a lower
+                # objective.
                 local_competition_scores = np.sum(
                     neighbor_objectives < objectives[:, None],
                     axis=1,

--- a/ribs/archives/_proximity_archive.py
+++ b/ribs/archives/_proximity_archive.py
@@ -220,6 +220,75 @@ class ProximityArchive(ArchiveBase):
         _, indices = self._cur_kd_tree.query(measures)
         return indices.astype(np.int32)
 
+    def compute_novelty(self, measures, local_competition=None):
+        """Computes the novelty and local competition of the given measures.
+
+        Args:
+            measures (array-like): (batch_size, :attr:`measure_dim`) array of
+                coordinates in measure space.
+            local_competition (None or array-like): This can be None to
+                indicate not to compute local competition. Otherwise, it can be
+                a (batch_size,) array of objective values to use as references
+                for computing objective values.
+        Returns:
+            numpy.ndarray or tuple: Either one value or a tuple of two values:
+
+            - numpy.ndarray: (batch_size,) array holding the novelty score of
+              each measure. If the archive is empty, the novelty is set to the
+              :attr:`novelty_threshold`.
+            - numpy.ndarray: If ``local_competition`` is passed in, a
+              (batch_size,) array holding the local competition of each solution
+              will also be returned. If the archive is empty, the local
+              competition will be set to 0.
+        """
+        measures = np.asarray(measures)
+        batch_size = len(measures)
+
+        if local_competition is not None:
+            objectives = np.asarray(local_competition)
+            local_competition = True
+
+        if self.empty:
+            # If there are no neighbors for computing nearest neighbors, there
+            # is infinite novelty and all solutions are added.
+            novelty = np.full(batch_size,
+                              self.novelty_threshold,
+                              dtype=self.dtypes["measures"])
+
+            if local_competition:
+                local_competition_scores = np.zeros(len(novelty),
+                                                    dtype=np.int32)
+        else:
+            # Compute nearest neighbors.
+            k_neighbors = min(len(self), self.k_neighbors)
+            dists, indices = self._cur_kd_tree.query(measures, k=k_neighbors)
+
+            # Expand since query() automatically squeezes the last dim when k=1.
+            dists = dists[:, None] if k_neighbors == 1 else dists
+
+            novelty = np.mean(dists, axis=1)
+
+            if local_competition:
+                indices = indices[:, None] if k_neighbors == 1 else indices
+
+                # The first item returned by `retrieve` is `occupied` -- all
+                # these indices are occupied since they are indices of solutions
+                # in the archive.
+                neighbor_objectives = self._store.retrieve(
+                    indices.ravel(), "objective")[1]
+                neighbor_objectives = neighbor_objectives.reshape(indices.shape)
+
+                local_competition_scores = np.sum(
+                    neighbor_objectives < objectives[:, None],
+                    axis=1,
+                    dtype=np.int32,
+                )
+
+        if local_competition:
+            return novelty, local_competition_scores
+        else:
+            return novelty
+
     def add(self, solution, objective, measures, **fields):
         """Inserts a batch of solutions into the archive.
 
@@ -330,42 +399,13 @@ class ProximityArchive(ArchiveBase):
             },
         )
 
-        # Compute novelty and local competition.
-        if self.empty:
-            # If there are no neighbors for computing nearest neighbors, there
-            # is infinite novelty and all solutions are added.
-            novelty = np.full(len(data["measures"]),
-                              self.novelty_threshold,
-                              dtype=self.dtypes["measures"])
-
-            if self.local_competition:
-                local_competition = np.zeros(len(novelty), dtype=np.int32)
+        if self.local_competition:
+            novelty, local_competition = self.compute_novelty(
+                measures=data["measures"],
+                local_competition=data["objective"],
+            )
         else:
-            # Compute nearest neighbors.
-            k_neighbors = min(len(self), self.k_neighbors)
-            dists, indices = self._cur_kd_tree.query(data["measures"],
-                                                     k=k_neighbors)
-
-            # Expand since query() automatically squeezes the last dim when k=1.
-            dists = dists[:, None] if k_neighbors == 1 else dists
-
-            novelty = np.mean(dists, axis=1)
-
-            if self.local_competition:
-                indices = indices[:, None] if k_neighbors == 1 else indices
-
-                # The first item returned by `retrieve` is `occupied` -- all
-                # these indices are occupied since they are indices of solutions
-                # in the archive.
-                neighbor_objectives = self._store.retrieve(
-                    indices.ravel(), "objective")[1]
-                neighbor_objectives = neighbor_objectives.reshape(indices.shape)
-
-                local_competition = np.sum(
-                    neighbor_objectives < data["objective"][:, None],
-                    axis=1,
-                    dtype=np.int32,
-                )
+            novelty = self.compute_novelty(measures=data["measures"])
 
         novel_enough = novelty >= self.novelty_threshold
         n_novel_enough = np.sum(novel_enough)


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the PR's purpose here. -->

Adds a new public `compute_novelty` method to `ProximityArchive` to allow computing the novelty and local competition scores of arbitrary measures, not just of solutions that are passed into `add`. Previously, the operations in this method were part of `add`.

Regarding API, I allow the `local_competition` argument to either be None or an array of objectives to use during the local competition computation. I also considered an API that passed in objectives separately to be a bit more consistent with the `add` API, eg, `compute_novelty(objective, measures, local_competition)` but it seemed clunky to always require calling `compute_novelty(None, measures)`.

## Status

- [x] I have read the guidelines in
      [CONTRIBUTING.md](https://github.com/icaros-usc/pyribs/blob/master/CONTRIBUTING.md)
- [x] I have formatted my code using `yapf`
- [x] I have tested my code by running `pytest`
- [x] I have linted my code with `pylint`
- [x] I have added a one-line description of my change to the changelog in
      `HISTORY.md`
- [x] This PR is ready to go
