### PR TITLE
Fix documentation conf for readthedocs deprecations

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -20,6 +20,7 @@
 
 #### Documentation
 
+- Fix documentation conf for readthedocs deprecations ({pr}`485`)
 - Add novelty search with CMA-ES to sphere example ({pr}`478`, {pr}`482`)
 
 #### Improvements

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -32,10 +32,6 @@ sys.path.append(os.path.abspath("./_ext"))  # Detect extensions.
 # Set canonical URL from the Read the Docs Domain
 html_baseurl = os.environ.get("READTHEDOCS_CANONICAL_URL", "")
 
-# Tell Jinja2 templates the build is running on Read the Docs
-if os.environ.get("READTHEDOCS", "") == "True":
-    html_context["READTHEDOCS"] = True
-
 DEV_MODE = os.environ.get("DOCS_MODE", "regular") == "dev"
 READTHEDOCS_VERSION = os.environ.get("READTHEDOCS_VERSION", "stable")
 READTHEDOCS_LANGUAGE = os.environ.get("READTHEDOCS_LANGUAGE", "en")
@@ -142,6 +138,10 @@ html_logo = "_static/imgs/icon.svg"
 html_favicon = "_static/imgs/favicon.ico"
 html_title = (f"pyribs (stable - v{version})" if READTHEDOCS_VERSION == "stable"
               else f"pyribs ({READTHEDOCS_VERSION})")
+
+# Tell Jinja2 templates the build is running on Read the Docs
+if os.environ.get("READTHEDOCS", "") == "True":
+    html_context["READTHEDOCS"] = True
 
 # material theme options (see theme.conf for more information)
 html_theme_options = {

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -29,6 +29,13 @@ import ribs
 sys.path.insert(0, os.path.abspath(".."))  # Detect ribs.
 sys.path.append(os.path.abspath("./_ext"))  # Detect extensions.
 
+# Set canonical URL from the Read the Docs Domain
+html_baseurl = os.environ.get("READTHEDOCS_CANONICAL_URL", "")
+
+# Tell Jinja2 templates the build is running on Read the Docs
+if os.environ.get("READTHEDOCS", "") == "True":
+    html_context["READTHEDOCS"] = True
+
 DEV_MODE = os.environ.get("DOCS_MODE", "regular") == "dev"
 READTHEDOCS_VERSION = os.environ.get("READTHEDOCS_VERSION", "stable")
 READTHEDOCS_LANGUAGE = os.environ.get("READTHEDOCS_LANGUAGE", "en")


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the PR's purpose here. -->

See https://about.readthedocs.com/blog/2024/07/addons-by-default/

## Status

- [x] I have read the guidelines in
      [CONTRIBUTING.md](https://github.com/icaros-usc/pyribs/blob/master/CONTRIBUTING.md)
- [x] I have formatted my code using `yapf`
- [x] I have tested my code by running `pytest`
- [x] I have linted my code with `pylint`
- [x] I have added a one-line description of my change to the changelog in
      `HISTORY.md`
- [x] This PR is ready to go
