### PR TITLE
Fix issue bandit scheduler

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -18,6 +18,11 @@
 - Replace archive.dtype with archive.dtypes dict that holds dtype of every field
   ({pr}`470`)
 
+#### Bugs
+
+- Fix `BanditScheduler` behaviour: the number of active emitters remains stable
+  ({pr}`489`)
+
 #### Documentation
 
 - Switch from std to var in arm tutorial ({pr}`486`)
@@ -27,8 +32,6 @@
 
 #### Improvements
 
-- Fix `BanditScheduler` behaviour: the number of active emitters remains stable
-  ({pr}`489`)
 - Skip qdax tests if qdax not installed ({pr}`491`)
 - Move yapf after isort in pre-commit ({pr}`490`)
 - Remove `_cells` attribute from ArchiveBase ({pr}`475`)

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -31,6 +31,7 @@
 - Move yapf after isort in pre-commit ({pr}`490`)
 - Remove `_cells` attribute from ArchiveBase ({pr}`475`)
 - Upgrade setup-miniconda to v3 due to deprecation ({pr}`464`)
+- Fix `BanditScheduler` behaviour: the number of active emitters remains stable ({pr}`489`)
 
 ## 0.7.1
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -27,11 +27,12 @@
 
 #### Improvements
 
+- Fix `BanditScheduler` behaviour: the number of active emitters remains stable
+  ({pr}`489`)
 - Skip qdax tests if qdax not installed ({pr}`491`)
 - Move yapf after isort in pre-commit ({pr}`490`)
 - Remove `_cells` attribute from ArchiveBase ({pr}`475`)
 - Upgrade setup-miniconda to v3 due to deprecation ({pr}`464`)
-- Fix `BanditScheduler` behaviour: the number of active emitters remains stable ({pr}`489`)
 
 ## 0.7.1
 

--- a/ribs/schedulers/_bandit_scheduler.py
+++ b/ribs/schedulers/_bandit_scheduler.py
@@ -245,13 +245,13 @@ class BanditScheduler:
 
         # If not enough emitters are active, activate the first num_active.
         # This always happens on the first iteration(s).
-        nb_activated = self._num_active - self._active_arr.sum()
+        num_needed = self._num_active - self._active_arr.sum()
         i = 0
-        while nb_activated > 0:
+        while num_needed > 0:
             reselect[i] = False
             if not self._active_arr[i]:
                 self._active_arr[i] = True
-                nb_activated -= 1
+                num_needed -= 1
             i += 1
 
         # Deactivate emitters to be reselected.

--- a/ribs/schedulers/_bandit_scheduler.py
+++ b/ribs/schedulers/_bandit_scheduler.py
@@ -277,11 +277,13 @@ class BanditScheduler:
             # Activate top emitters based on UCB1, until there are num_active
             # active emitters. Activate only inactive emitters.
             activate = np.argsort(ucb1)[::-1]
+            cur_active = self._active_arr.sum()
             for i in activate:
-                if self._active_arr.sum() == self._num_active:
+                if cur_active >= self._num_active:
                     break
                 if not self._active_arr[i]:
                     self._active_arr[i] = True
+                    cur_active += 1
 
         self._cur_solutions = []
 

--- a/ribs/schedulers/_bandit_scheduler.py
+++ b/ribs/schedulers/_bandit_scheduler.py
@@ -20,7 +20,7 @@ class BanditScheduler:
         for more details.
 
     .. note::
-        The main num_needederence between :class:`BanditScheduler` and
+        The main difference between :class:`BanditScheduler` and
         :class:`Scheduler` is that, unlike :class:`Scheduler`, DQD emitters are
         not supported by :class:`BanditScheduler`.
 
@@ -72,7 +72,7 @@ class BanditScheduler:
         ValueError: Invalid value for ``add_mode``.
         ValueError: The ``result_archive`` and ``archive`` are the same object
             (``result_archive`` should not be passed in in this case).
-        ValueError: The ``result_archive`` and ``archive`` have num_needederent
+        ValueError: The ``result_archive`` and ``archive`` have different
             fields.
     """
 

--- a/ribs/schedulers/_bandit_scheduler.py
+++ b/ribs/schedulers/_bandit_scheduler.py
@@ -20,7 +20,7 @@ class BanditScheduler:
         for more details.
 
     .. note::
-        The main difference between :class:`BanditScheduler` and
+        The main num_needederence between :class:`BanditScheduler` and
         :class:`Scheduler` is that, unlike :class:`Scheduler`, DQD emitters are
         not supported by :class:`BanditScheduler`.
 
@@ -72,7 +72,7 @@ class BanditScheduler:
         ValueError: Invalid value for ``add_mode``.
         ValueError: The ``result_archive`` and ``archive`` are the same object
             (``result_archive`` should not be passed in in this case).
-        ValueError: The ``result_archive`` and ``archive`` have different
+        ValueError: The ``result_archive`` and ``archive`` have num_needederent
             fields.
     """
 
@@ -244,13 +244,13 @@ class BanditScheduler:
             reselect = self._active_arr.copy()
 
         # If not enough emitters are active, activate the first num_active.
-        diff = self._num_active - self._active_arr.sum()
+        num_needed = self._num_active - self._active_arr.sum()
         i = 0
-        while diff > 0:
-            reselect[:] = False
+        while num_needed > 0:
+            reselect[i] = False
             if not self._active_arr[i]:
                 self._active_arr[i] = True
-                diff -= 1
+                num_needed -= 1
             i += 1
 
         # Deactivate emitters to be reselected.

--- a/ribs/schedulers/_bandit_scheduler.py
+++ b/ribs/schedulers/_bandit_scheduler.py
@@ -243,10 +243,15 @@ class BanditScheduler:
             # Reselect all emitters.
             reselect = self._active_arr.copy()
 
-        # If no emitters are active, activate the first num_active.
-        if not self._active_arr.any():
+        # If not enough emitters are active, activate the first num_active.
+        diff = self._num_active - self._active_arr.sum()
+        i = 0
+        while diff > 0:
             reselect[:] = False
-            self._active_arr[:self._num_active] = True
+            if not self._active_arr[i]:
+                self._active_arr[i] = True
+                diff -= 1
+            i += 1
 
         # Deactivate emitters to be reselected.
         self._active_arr[reselect] = False
@@ -258,7 +263,9 @@ class BanditScheduler:
         #   terminated/restarted will be reselected. Otherwise, if reselect is
         #   "all", then all emitters are reselected.
         if reselect.any():
-            ucb1 = np.full_like(self._emitter_pool, np.inf)
+            ucb1 = np.full_like(
+                self._emitter_pool, np.inf
+            )  # np.inf forces to select emitters that were not yet selected
             update_ucb = self._selection != 0
             if update_ucb.any():
                 ucb1[update_ucb] = (
@@ -269,6 +276,16 @@ class BanditScheduler:
             # Activate top emitters based on UCB1.
             activate = np.argsort(ucb1)[-reselect.sum():]
             self._active_arr[activate] = True
+
+            # Deactivate emitters if there are too many active emitters.
+            nb_deactivate = self.emitters.sum() - self._num_active
+            deactivate = np.argsort(ucb1)
+            for i in deactivate:
+                if nb_deactivate == 0:
+                    break
+                if self._active_arr[i]:
+                    self._active_arr[i] = False
+                    nb_deactivate -= 1
 
         self._cur_solutions = []
 

--- a/tests/schedulers/scheduler_test.py
+++ b/tests/schedulers/scheduler_test.py
@@ -355,15 +355,17 @@ def test_constant_active_emitters_bandit_scheduler():
                         batch_size=num_solutions) for _ in range(10)
     ]
     scheduler = BanditScheduler(archive, emitters, num_active=expected_active)
-    num_loops = 5
+    num_loops = 10
+
+    rng = np.random.default_rng(42)
 
     for _ in range(num_loops):
         solutions = scheduler.ask()
         assert scheduler.emitters.sum() == expected_active
 
         # Mock objective and measures for tell
-        objective = np.random.rand(len(solutions))
-        measures = np.random.rand(len(solutions), 2)
+        objective = rng.random(len(solutions))
+        measures = rng.random((len(solutions), 2))
         scheduler.tell(objective, measures)
 
         assert scheduler.emitters.sum() == expected_active

--- a/tests/schedulers/scheduler_test.py
+++ b/tests/schedulers/scheduler_test.py
@@ -339,3 +339,31 @@ def test_tell_fails_with_wrong_shapes(scheduler_fixture, array):
             scheduler.tell(objective_batch[:-1], measures_batch)
         elif array == "measures_batch":
             scheduler.tell(objective_batch, measures_batch[:-1])
+
+
+def test_constant_active_emitters_bandit_scheduler():
+    solution_dim = 2
+    num_solutions = 4
+    expected_active = 3
+    archive = GridArchive(solution_dim=solution_dim,
+                          dims=[100, 100],
+                          ranges=[(-1, 1), (-1, 1)])
+    emitters = [
+        GaussianEmitter(archive,
+                        sigma=1,
+                        x0=[0.0, 0.0],
+                        batch_size=num_solutions) for _ in range(10)
+    ]
+    scheduler = BanditScheduler(archive, emitters, num_active=expected_active)
+    num_loops = 5
+
+    for _ in range(num_loops):
+        solutions = scheduler.ask()
+        assert scheduler.emitters.sum() == expected_active
+
+        # Mock objective and measures for tell
+        objective = np.random.rand(len(solutions))
+        measures = np.random.rand(len(solutions), 2)
+        scheduler.tell(objective, measures)
+
+        assert scheduler.emitters.sum() == expected_active


### PR DESCRIPTION
## Description

Fixes the `BanditScheduler` class because it could sometimes have unexpected number of active emitters.

## Done

<!-- Notable points that this PR has either accomplished or will accomplish. -->

- [x] Added a check that enough emitters are active (before PR: only checked if there was 0 active emitters)
- [x] Added a check that there are not too many active emitters
- [x] Both checks comply with the `BanditScheduler`'s expected behaviour, i.e.:
      - activate emitters that were never used, if there are none, those that are expected to perform better
      - deactivate least performing emitters first

## Questions

- [x] I am quite sure this is not the most efficient way to do this, which would slow down any use of the `BanditScheduler`. I would appreciate any feedback on how to improve this.
- [x] I added a test, but it seems more complicated than other tests of the file. Should I put it somewhere else? 

## Status

- [x] I have read the guidelines in
      [CONTRIBUTING.md](https://github.com/icaros-usc/pyribs/blob/master/CONTRIBUTING.md)
- [x] I have formatted my code using `yapf`
- [x] I have tested my code by running `pytest`
- [x] I have linted my code with `pylint`
- [x] I have added a one-line description of my change to the changelog in
      `HISTORY.md`
- [ ] This PR is ready to go