### PR TITLE
Move yapf after isort in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,15 +11,15 @@ repos:
       - id: end-of-file-fixer
       - id: mixed-line-ending
       - id: trailing-whitespace
-  - repo: https://github.com/google/yapf
-    rev: v0.40.1
-    hooks:
-      - id: yapf
   - repo: https://github.com/pycqa/isort
     rev: 5.11.5
     hooks:
       - id: isort
         name: isort (python)
+  - repo: https://github.com/google/yapf
+    rev: v0.40.1
+    hooks:
+      - id: yapf
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: v3.0.2
     hooks:

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -27,6 +27,7 @@
 
 #### Improvements
 
+- Move yapf after isort in pre-commit ({pr}`490`)
 - Remove `_cells` attribute from ArchiveBase ({pr}`475`)
 - Upgrade setup-miniconda to v3 due to deprecation ({pr}`464`)
 


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the PR's purpose here. -->

This ensures that yapf takes precedence over isort when formatting files.

## Status

- [x] I have read the guidelines in
      [CONTRIBUTING.md](https://github.com/icaros-usc/pyribs/blob/master/CONTRIBUTING.md)
- [x] I have formatted my code using `yapf`
- [x] I have tested my code by running `pytest`
- [x] I have linted my code with `pylint`
- [x] I have added a one-line description of my change to the changelog in
      `HISTORY.md`
- [x] This PR is ready to go
