### PR TITLE
Skip qdax tests if qdax not installed

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -27,6 +27,7 @@
 
 #### Improvements
 
+- Skip qdax tests if qdax not installed ({pr}`491`)
 - Move yapf after isort in pre-commit ({pr}`490`)
 - Remove `_cells` attribute from ArchiveBase ({pr}`475`)
 - Upgrade setup-miniconda to v3 due to deprecation ({pr}`464`)

--- a/tests/visualize_qdax/visualize_qdax_test.py
+++ b/tests/visualize_qdax/visualize_qdax_test.py
@@ -8,10 +8,16 @@ import jax.numpy as jnp
 import matplotlib.pyplot as plt
 import pytest
 from matplotlib.testing.decorators import image_comparison
-from qdax.core.containers.mapelites_repertoire import (MapElitesRepertoire,
-                                                       compute_cvt_centroids)
 
 from ribs.visualize import qdax_repertoire_3d_plot, qdax_repertoire_heatmap
+
+try:
+    # This is an edge case where yapf and isort disagree.
+    # yapf: disable
+    from qdax.core.containers.mapelites_repertoire import (
+        MapElitesRepertoire, compute_cvt_centroids)
+except ImportError:
+    pytest.skip(allow_module_level=True)
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the PR's purpose here. -->

Right now, when running `make tests` as described in `CONTRIBUTING.md`, the tests in `tests/visualize_qdax/` fail because qdax is not installed. Thus, this PR adds a check to see if `qdax` is installed and skips the tests if it is not.

Thanks @Tekexa for raising this issue!

## Status

- [x] I have read the guidelines in
      [CONTRIBUTING.md](https://github.com/icaros-usc/pyribs/blob/master/CONTRIBUTING.md)
- [x] I have formatted my code using `yapf`
- [x] I have tested my code by running `pytest`
- [x] I have linted my code with `pylint`
- [x] I have added a one-line description of my change to the changelog in
      `HISTORY.md`
- [x] This PR is ready to go
