### PR TITLE
BanditScheduler: Add emitter_pool and active attr; remove emitters attr

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,7 +6,7 @@
 
 #### API
 
-- BanditScheduler: Rename `emitters` to `emitter_pool` and add `active` attr
+- BanditScheduler: Add emitter_pool and active attr; remove emitters attr
   ({pr}`494`)
 - Add DensityRanker for density descent search ({pr}`483`)
 - Add NoveltyRanker for novelty search ({pr}`477`)

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,6 +6,8 @@
 
 #### API
 
+- BanditScheduler: Rename `emitters` to `emitter_pool` and add `active` attr
+  ({pr}`494`)
 - Add DensityRanker for density descent search ({pr}`483`)
 - Add NoveltyRanker for novelty search ({pr}`477`)
 - Add proximity_archive_plot for visualizing ProximityArchive ({pr}`476`,

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,8 +6,8 @@
 
 #### API
 
-- BanditScheduler: Add emitter_pool and active attr; remove emitters attr
-  ({pr}`494`)
+- **Backwards-incompatible:** BanditScheduler: Add emitter_pool and active attr;
+  remove emitters attr ({pr}`494`)
 - Add DensityRanker for density descent search ({pr}`483`)
 - Add NoveltyRanker for novelty search ({pr}`477`)
 - Add proximity_archive_plot for visualizing ProximityArchive ({pr}`476`,

--- a/ribs/schedulers/_bandit_scheduler.py
+++ b/ribs/schedulers/_bandit_scheduler.py
@@ -4,6 +4,7 @@ from collections import defaultdict
 
 import numpy as np
 
+from ribs._utils import readonly
 from ribs.schedulers._scheduler import Scheduler
 
 
@@ -172,10 +173,16 @@ class BanditScheduler:
         return self._archive
 
     @property
-    def emitters(self):
-        """list of ribs.archives.EmitterBase: Emitters for generating solutions
-        in this scheduler."""
-        return self._active_arr
+    def emitter_pool(self):
+        """list of ribs.archives.EmitterBase: The pool of emitters available in
+        the scheduler."""
+        return self._emitter_pool
+
+    @property
+    def active(self):
+        """numpy.ndarray: Boolean array indicating which emitters in the
+        :attr:`emitter_pool` are currently active."""
+        return readonly(self._active_arr)
 
     @property
     def result_archive(self):

--- a/ribs/schedulers/_bandit_scheduler.py
+++ b/ribs/schedulers/_bandit_scheduler.py
@@ -182,7 +182,7 @@ class BanditScheduler:
     def active(self):
         """numpy.ndarray: Boolean array indicating which emitters in the
         :attr:`emitter_pool` are currently active."""
-        return readonly(self._active_arr)
+        return readonly(self._active_arr.view())
 
     @property
     def result_archive(self):

--- a/tests/schedulers/scheduler_test.py
+++ b/tests/schedulers/scheduler_test.py
@@ -34,6 +34,29 @@ def add_mode(request):
     return request.param
 
 
+@pytest.mark.parametrize("scheduler_type", ["Scheduler", "BanditScheduler"])
+def test_attributes(scheduler_type):
+    archive = GridArchive(solution_dim=2,
+                          dims=[100, 100],
+                          ranges=[(-1, 1), (-1, 1)],
+                          threshold_min=1.0,
+                          learning_rate=1.0)
+    emitters = [GaussianEmitter(archive, sigma=1, x0=[0.0, 0.0], batch_size=4)]
+
+    if scheduler_type == "Scheduler":
+        scheduler = Scheduler(archive, emitters)
+
+        assert scheduler.archive == archive
+        assert scheduler.emitters == emitters
+    else:
+        scheduler = BanditScheduler(archive, emitters, 1)
+
+        assert scheduler.archive == archive
+        assert scheduler.emitter_pool == emitters
+        assert len(scheduler.active) == len(scheduler.emitter_pool)
+        assert not np.any(scheduler.active)
+
+
 def test_init_fails_with_non_list():
     archive = GridArchive(solution_dim=2,
                           dims=[100, 100],

--- a/tests/schedulers/scheduler_test.py
+++ b/tests/schedulers/scheduler_test.py
@@ -384,11 +384,11 @@ def test_constant_active_emitters_bandit_scheduler():
 
     for _ in range(num_loops):
         solutions = scheduler.ask()
-        assert scheduler.emitters.sum() == expected_active
+        assert scheduler.active.sum() == expected_active
 
         # Mock objective and measures for tell
         objective = rng.random(len(solutions))
         measures = rng.random((len(solutions), 2))
         scheduler.tell(objective, measures)
 
-        assert scheduler.emitters.sum() == expected_active
+        assert scheduler.active.sum() == expected_active


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the PR's purpose here. -->

Currently, the BanditScheduler has an `emitters` attr that returns the `_active_arr` variable. This does not make much sense since BanditScheduler does not have `emitters` as input, and `_active_arr` gives `emitters` a different meaning from the `emitters` attribute of Scheduler.

Thus, this PR removes the `emitters` attr and instead adds `emitter_pool` and `active` to indicate the pool of emitters in the scheduler and which ones are currently active, respectively.

## TODO

<!-- Notable points that this PR has either accomplished or will accomplish. -->

- [x] Remove `BanditScheduler.emitters`
- [x] Add `BanditScheduler.emitter_pool`
- [x] Add `BanditScheduler.active`

## Status

- [x] I have read the guidelines in
      [CONTRIBUTING.md](https://github.com/icaros-usc/pyribs/blob/master/CONTRIBUTING.md)
- [x] I have formatted my code using `yapf`
- [x] I have tested my code by running `pytest`
- [x] I have linted my code with `pylint`
- [x] I have added a one-line description of my change to the changelog in
      `HISTORY.md`
- [x] This PR is ready to go
