### PR TITLE
Add version selector to docs

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -27,6 +27,7 @@
 
 #### Documentation
 
+- Add version selector to docs ({pr}`495`)
 - Update gymnasium and lunar lander version ({pr}`493`)
 - Add tutorial page on Optuna integration ({pr}`492`)
 - Switch from std to var in arm tutorial ({pr}`486`)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -170,14 +170,12 @@ html_theme_options = {
         "index":
             "A bare-bones Python library for quality diversity optimization."
     },
-    "version_dropdown": False,
+    "version_dropdown": True,
     "version_json": None,
-    #  "version_info": {
-    #      "Release": "https://bashtage.github.io/sphinx-material/",
-    #      "Development": "https://bashtage.github.io/sphinx-material/devel/",
-    #      "Release (rel)": "/sphinx-material/",
-    #      "Development (rel)": "/sphinx-material/devel/",
-    #  },
+    "version_info": {
+        "Stable": "https://docs.pyribs.org/en/stable/",
+        "Latest": "https://docs.pyribs.org/en/latest/",
+    },
     "table_classes": ["plain"],
 }
 


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the PR's purpose here. -->

The ReadTheDocs version selector does not seem to work anymore. I have added the version selector that comes with the Material theme: https://bashtage.github.io/sphinx-material/customization.html?highlight=version#version-dropdown

## Status

- [x] I have read the guidelines in
      [CONTRIBUTING.md](https://github.com/icaros-usc/pyribs/blob/master/CONTRIBUTING.md)
- [x] I have formatted my code using `yapf`
- [x] I have tested my code by running `pytest`
- [x] I have linted my code with `pylint`
- [x] I have added a one-line description of my change to the changelog in
      `HISTORY.md`
- [x] This PR is ready to go
