### PR TITLE
Make DensityRanker use add_info

### DIFF
--- a/ribs/emitters/rankers.py
+++ b/ribs/emitters/rankers.py
@@ -2,15 +2,13 @@
 
 The rankers implemented in this file are intended to be used with emitters.
 Specifically, a ranker object should be initialized or passed in the emitters.
-The ``Ranker`` object will define the :meth:`~RankerBase.rank` method which
+The ``Ranker`` object will define the :meth:`~RankerBase.rank` method that
 returns the result of a descending argsort of the solutions. It will also define
-a :meth:`~RankerBase.reset` method which resets the internal state of the
-object.
+a :meth:`~RankerBase.reset` method that resets the internal state of the object.
 
 When specifying which ranker to use for each emitter, one could either pass in
-the full name of a ranker, e.g. "ImprovementRanker", or the abbreviated name of
-a ranker, e.g. "imp".
-The supported abbreviations are:
+the full name of a ranker, e.g., "ImprovementRanker", or the abbreviated name of
+a ranker, e.g., "imp". The supported abbreviations are:
 
 * ``density``: :class:`DensityRanker`
 * ``imp``: :class:`ImprovementRanker`
@@ -366,19 +364,14 @@ Ranks solutions based on novelty scores.
 class DensityRanker(RankerBase):
     """Ranks solutions based on density in measure space.
 
-    The archive must be a :class:`~ribs.archives.DensityArchive` or have a
-    ``compute_density`` method.
+    This ranker can only be used with archives that return the ``density`` field
+    from their ``add`` method, such as
+    :meth:`ribs.archives.DensityArchive.add`.
     """
 
     def rank(self, emitter, archive, data, add_info):
-        try:
-            density = archive.compute_density(data["measures"])
-        except AttributeError as e:
-            raise AttributeError("DensityRanker requires that the archive have"
-                                 "a compute_density method.") from e
-
         # Lower density is better, so we sort as normal (i.e., ascending order).
-        return np.argsort(density), density
+        return np.argsort(add_info["density"]), add_info["density"]
 
     rank.__doc__ = f"""
 Ranks solutions based on density in measure space.

--- a/tests/emitters/rankers_test.py
+++ b/tests/emitters/rankers_test.py
@@ -200,16 +200,14 @@ def test_two_stage_objective_ranker(archive_fixture, emitter):
 
 
 def test_novelty_ranker():
-    solution_batch = [[1, 2, 3]] * 4
-    measures_batch = [[0, 0], [1.2, 1.2], [0.1, 0.1], [1.5, 1.5]]
-
     ranker = NoveltyRanker()
+
     indices, ranking_values = ranker.rank(
         emitter=None,
         archive=None,
         data={
-            "solution": solution_batch,
-            "measures": measures_batch,
+            "solution": [[1, 2, 3]] * 4,
+            "measures": [[0, 0], [1.2, 1.2], [0.1, 0.1], [1.5, 1.5]],
         },
         add_info={
             "novelty": [1.0, 0.5, 0.9, 0.4],
@@ -221,26 +219,18 @@ def test_novelty_ranker():
 
 
 def test_density_ranker():
-    solution_batch = [[1, 2, 3]] * 4
-    measures_batch = [[0, 0], [1.2, 1.2], [0.1, 0.1], [1.5, 1.5]]
-
-    class FakeDensityArchive:
-        """Mock density archive for testing."""
-
-        def compute_density(self,
-                            measures):  # pylint: disable = unused-argument
-            """Returns fake densities for the four solutions."""
-            return [0.5, 0.3, 0.7, 0.1]
-
     ranker = DensityRanker()
+
     indices, ranking_values = ranker.rank(
         emitter=None,
-        archive=FakeDensityArchive(),
+        archive=None,
         data={
-            "solution": solution_batch,
-            "measures": measures_batch,
+            "solution": [[1, 2, 3]] * 4,
+            "measures": [[0, 0], [1.2, 1.2], [0.1, 0.1], [1.5, 1.5]],
         },
-        add_info={},
+        add_info={
+            "density": [0.5, 0.3, 0.7, 0.1],
+        },
     )
 
     assert (indices == [3, 1, 0, 2]).all()


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the PR's purpose here. -->

Previously, `DensityRanker` called `compute_density` on the (soon-to-be-implemented) `DensityArchive`. 

Here are some considerations -- there are two places where we can call `compute_density`, either in the ranker, or in `DensityArchive.add`:

- If we have 15 emitters with 15 rankers, each ranker will call `compute_density` on its own, which seems inefficient. If we put `compute_density` in `add`, we only call it once.
- If we call `compute_density` on its own, we do get the most up-to-date density information, but I don't foresee the archive changing in between addition of solutions and the emitters updating their rankings.
- We keep the rankers simple since we keep the call to `compute_density` out of them.
- `ProximityArchive` computes novelty in `add`, so calling in `add` would maintain consistency with `ProximityArchive`.

Overall, to maintain consistency and also make the calls be centralized, I think this change makes sense.

## Status

- [x] I have read the guidelines in
      [CONTRIBUTING.md](https://github.com/icaros-usc/pyribs/blob/master/CONTRIBUTING.md)
- [x] I have formatted my code using `yapf`
- [x] I have tested my code by running `pytest`
- [x] I have linted my code with `pylint`
- [x] I have added a one-line description of my change to the changelog in
      `HISTORY.md`
- [x] This PR is ready to go
