### PR TITLE
Tidy up operator implementation

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -82,7 +82,7 @@ https://docs.pyribs.org/en/stable/whats-new.html
 
 #### API
 
-- Add GeneticAlgorithmEmitter that uses operators ({pr} `427`)
+- Add GeneticAlgorithmEmitter with Internal Operator Support ({pr} `427`)
 - Support alternative centroid generation methods in CVTArchive ({pr}`417`,
   {pr}`437`)
 - Add PyCMAEvolutionStrategy for using pycma in ES emitters ({pr}`434`)

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -82,6 +82,7 @@ https://docs.pyribs.org/en/stable/whats-new.html
 
 #### API
 
+- Add GeneticAlgorithmEmitter with Internal Operator Support ({pr} `427`)
 - Support alternative centroid generation methods in CVTArchive ({pr}`417`,
   {pr}`437`)
 - Add PyCMAEvolutionStrategy for using pycma in ES emitters ({pr}`434`)

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -82,7 +82,7 @@ https://docs.pyribs.org/en/stable/whats-new.html
 
 #### API
 
-- Add GeneticAlgorithmEmitter with Internal Operator Support ({pr} `427`)
+- Add GeneticAlgorithmEmitter that uses operators ({pr} `427`)
 - Support alternative centroid generation methods in CVTArchive ({pr}`417`,
   {pr}`437`)
 - Add PyCMAEvolutionStrategy for using pycma in ES emitters ({pr}`434`)

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,6 +6,7 @@
 
 #### API
 
+- **Backwards-incompatible:** Tidy up operator implementation ({pr}`507`)
 - Drop Python 3.8 support and remove pinned requirements {{pr}`497`)
 - **Backwards-incompatible:** BanditScheduler: Add emitter_pool and active attr;
   remove emitters attr ({pr}`494`)

--- a/ribs/emitters/_gaussian_emitter.py
+++ b/ribs/emitters/_gaussian_emitter.py
@@ -7,21 +7,17 @@ from ribs.emitters.operators import GaussianOperator
 
 
 class GaussianEmitter(EmitterBase):
-    """Emits solutions by adding Gaussian noise to existing archive solutions.
+    """Emits solutions by adding Gaussian noise to existing elites.
 
-    If the archive is empty and ``self._initial_solutions`` is set, a call to
-    :meth:`ask` will return ``self._initial_solutions``. If
-    ``self._initial_solutions`` is not set, we draw from a Gaussian distribution
-    centered at ``self.x0`` with standard deviation ``self.sigma``. Otherwise,
-    each solution is drawn from a distribution centered at a randomly chosen
-    elite with standard deviation ``self.sigma``.
-
-    This is the classic variation operator presented in `Mouret 2015
-    <https://arxiv.org/pdf/1504.04909.pdf>`_.
+    If the archive is empty and ``initial_solutions`` is set, a call to
+    :meth:`ask` will return ``initial_solutions``. If ``initial_solutions`` is
+    not set, we draw solutions from a Gaussian distribution centered at ``x0``
+    with standard deviation ``sigma``. Otherwise, each solution is drawn from a
+    distribution centered at a randomly chosen elite with standard deviation
+    ``sigma``.
 
     Args:
-        archive (ribs.archives.ArchiveBase): An archive to use when creating and
-            inserting solutions. For instance, this can be
+        archive (ribs.archives.ArchiveBase): Archive of solutions, e.g.,
             :class:`ribs.archives.GridArchive`.
         sigma (float or array-like): Standard deviation of the Gaussian
             distribution. Note we assume the Gaussian is diagonal, so if this
@@ -56,6 +52,13 @@ class GaussianEmitter(EmitterBase):
                  bounds=None,
                  batch_size=64,
                  seed=None):
+        EmitterBase.__init__(
+            self,
+            archive,
+            solution_dim=archive.solution_dim,
+            bounds=bounds,
+        )
+
         self._batch_size = batch_size
         self._sigma = np.array(sigma, dtype=archive.dtypes["solution"])
         self._x0 = None
@@ -77,16 +80,7 @@ class GaussianEmitter(EmitterBase):
             check_batch_shape(self._initial_solutions, "initial_solutions",
                               archive.solution_dim, "archive.solution_dim")
 
-        EmitterBase.__init__(
-            self,
-            archive,
-            solution_dim=archive.solution_dim,
-            bounds=bounds,
-        )
-        self._operator = GaussianOperator(sigma=self._sigma,
-                                          lower_bounds=self._lower_bounds,
-                                          upper_bounds=self._upper_bounds,
-                                          seed=seed)
+        self._operator = GaussianOperator(sigma=self._sigma, seed=seed)
 
     @property
     def x0(self):
@@ -112,28 +106,32 @@ class GaussianEmitter(EmitterBase):
         """int: Number of solutions to return in :meth:`ask`."""
         return self._batch_size
 
+    def _clip(self, solutions):
+        """Clips solutions to the bounds of the solution space."""
+        return np.clip(solutions, self.lower_bounds, self.upper_bounds)
+
     def ask(self):
         """Creates solutions by adding Gaussian noise to elites in the archive.
 
-        If the archive is empty and ``self._initial_solutions`` is set, we
-        return ``self._initial_solutions``. If ``self._initial_solutions`` is
-        not set, we draw from Gaussian distribution centered at ``self.x0``
-        with standard deviation ``self.sigma``. Otherwise, each solution is
+        If the archive is empty and ``initial_solutions`` is set, a call to
+        :meth:`ask` will return ``initial_solutions``. If ``initial_solutions``
+        is not set, we draw solutions from a Gaussian distribution centered at
+        ``x0`` with standard deviation ``sigma``. Otherwise, each solution is
         drawn from a distribution centered at a randomly chosen elite with
-        standard deviation ``self.sigma``.
+        standard deviation ``sigma``.
 
         Returns:
-            If the archive is not empty, ``(batch_size, solution_dim)`` array
-            -- contains ``batch_size`` new solutions to evaluate. If the
-            archive is empty, we return ``self._initial_solutions``, which
-            might not have ``batch_size`` solutions.
+            If the archive is not empty, ``(batch_size, solution_dim)`` array --
+            contains ``batch_size`` new solutions to evaluate. If the archive is
+            empty, we return ``initial_solutions``, which might not have
+            ``batch_size`` solutions.
         """
+        if self.archive.empty and self._initial_solutions is not None:
+            return self._clip(self.initial_solutions)
+
         if self.archive.empty:
-            if self._initial_solutions is not None:
-                return np.clip(self._initial_solutions, self.lower_bounds,
-                               self.upper_bounds)
             parents = np.repeat(self.x0[None], repeats=self._batch_size, axis=0)
         else:
             parents = self.archive.sample_elites(self._batch_size)["solution"]
 
-        return self._operator.ask(parents=parents)
+        return self._clip(self._operator.ask(parents))

--- a/ribs/emitters/_genetic_algorithm_emitter.py
+++ b/ribs/emitters/_genetic_algorithm_emitter.py
@@ -7,27 +7,23 @@ from ribs.emitters.operators import _get_op
 
 
 class GeneticAlgorithmEmitter(EmitterBase):
-    """Emits solutions by using operator provided.
+    """Creates solutions with a genetic algorithm.
 
-    If the archive is empty and ``self._initial_solutions`` is set, a call to
-    :meth:`ask` will return ``self._initial_solutions``. If
-    ``self._initial_solutions`` is not set, we operate on self.x0.
-
+    If the archive is empty and ``initial_solutions`` is set, a call to
+    :meth:`ask` will return ``initial_solutions``. If ``initial_solutions`` is
+    not set, we pass ``x0`` through the operator.
 
     Args:
-        archive (ribs.archives.ArchiveBase): An archive to use when creating and
-            inserting solutions. For instance, this can be
+        archive (ribs.archives.ArchiveBase): Archive of solutions, e.g.,
             :class:`ribs.archives.GridArchive`.
-        x0 (numpy.ndarray): Initial solution.
-        operator (str): Internal Operator Class used to Mutate Solutions
-            in ask method.
+        operator (str): Internal operator for mutating solutions. See
+            :mod:`ribs.emitters.operators` for the list of allowed names.
         operator_kwargs (dict): Additional arguments to pass to the operator.
             See :mod:`ribs.emitters.operators` for the arguments allowed by each
             operator.
+        x0 (numpy.ndarray): Initial solution.
         initial_solutions (array-like): An (n, solution_dim) array of solutions
-            to be used when the archive is empty. If this argument is None, then
-            solutions will be sampled from a Gaussian distribution centered at
-            ``x0`` with standard deviation ``sigma``.
+            to be used when the archive is empty, in lieu of ``x0``.
         bounds (None or array-like): Bounds of the solution space. Solutions are
             clipped to these bounds. Pass None to indicate there are no bounds.
             Alternatively, pass an array-like to specify the bounds for each
@@ -35,6 +31,8 @@ class GeneticAlgorithmEmitter(EmitterBase):
             bound, or a tuple of ``(lower_bound, upper_bound)``, where
             ``lower_bound`` or ``upper_bound`` may be None to indicate no bound.
         batch_size (int): Number of solutions to return in :meth:`ask`.
+        seed (int): Value to seed the random number generator. Set to None to
+            avoid a fixed seed.
     Raises:
         ValueError: There is an error in x0 or initial_solutions.
         ValueError: There is an error in the bounds configuration.
@@ -43,16 +41,13 @@ class GeneticAlgorithmEmitter(EmitterBase):
     def __init__(self,
                  archive,
                  *,
+                 operator,
+                 operator_kwargs=None,
                  x0=None,
                  initial_solutions=None,
                  bounds=None,
                  batch_size=64,
-                 operator_kwargs=None,
-                 operator=None):
-        self._batch_size = batch_size
-        self._x0 = x0
-        self._initial_solutions = None
-
+                 seed=None):
         EmitterBase.__init__(
             self,
             archive,
@@ -60,8 +55,9 @@ class GeneticAlgorithmEmitter(EmitterBase):
             bounds=bounds,
         )
 
-        if operator is None:
-            raise ValueError("Operator must be provided.")
+        self._batch_size = batch_size
+        self._x0 = x0
+        self._initial_solutions = None
 
         if x0 is None and initial_solutions is None:
             raise ValueError("Either x0 or initial_solutions must be provided.")
@@ -79,14 +75,15 @@ class GeneticAlgorithmEmitter(EmitterBase):
             check_batch_shape(self._initial_solutions, "initial_solutions",
                               archive.solution_dim, "archive.solution_dim")
 
-        self._operator = _get_op(operator)(
-            lower_bounds=self._lower_bounds,
-            upper_bounds=self._upper_bounds,
-            **(operator_kwargs if operator_kwargs is not None else {}))
+        operator_class = _get_op(operator)
+        self._operator = operator_class(
+            **(operator_kwargs if operator_kwargs is not None else {}),
+            seed=seed,
+        )
 
     @property
     def x0(self):
-        """numpy.ndarray: Initial Solution (if initial_solutions is not
+        """numpy.ndarray: Initial Solution (if ``initial_solutions`` is not
         set)."""
         return self._x0
 
@@ -101,38 +98,30 @@ class GeneticAlgorithmEmitter(EmitterBase):
         """int: Number of solutions to return in :meth:`ask`."""
         return self._batch_size
 
-    def ask(self):
-        """Creates solutions with operator provided.
+    def _clip(self, solutions):
+        """Clips solutions to the bounds of the solution space."""
+        return np.clip(solutions, self.lower_bounds, self.upper_bounds)
 
-        If the archive is empty and ``self._initial_solutions`` is set, we
-        return ``self._initial_solutions``. If ``self._initial_solutions`` is
-        not set and the archive is still empty, we operate on the initial
-        solution (x0) provided. Otherwise, we sample parents from the archive
-        to be used as input to the operator
+    def ask(self):
+        """Creates solutions with the provided operator.
+
+        If the archive is empty and ``initial_solutions`` is set, a call to
+        :meth:`ask` will return ``initial_solutions``. If ``initial_solutions``
+        is not set, we pass ``x0`` through the operator. Otherwise, we sample
+        parents from the archive to be passed to the operator.
 
         Returns:
             numpy.ndarray: If the archive is not empty, ``(batch_size,
             solution_dim)`` array -- contains ``batch_size`` new solutions to
-            evaluate. If the archive is empty, we return
-            ``self._initial_solutions``, which might not have ``batch_size``
-            solutions.
+            evaluate. If the archive is empty, we return ``initial_solutions``,
+            which might not have ``batch_size`` solutions.
+        Raises:
+            ValueError: The ``parent_type`` of the operator is unknown.
         """
-
         if self.archive.empty and self._initial_solutions is not None:
-            return np.clip(self._initial_solutions, self.lower_bounds,
-                           self.upper_bounds)
+            return self._clip(self.initial_solutions)
 
-        if self._operator.parent_type == 2:
-            if self.archive.empty:
-                parents = np.repeat(self.x0[None],
-                                    repeats=2 * self._batch_size,
-                                    axis=0)
-            else:
-                parents = self.archive.sample_elites(
-                    2 * self._batch_size)["solution"]
-            return self._operator.ask(
-                parents=parents.reshape(2, self._batch_size, -1))
-        else:  # self._operator.parent_type == 1, gaussian
+        if self._operator.parent_type == 1:
             if self.archive.empty:
                 parents = np.repeat(self.x0[None],
                                     repeats=self._batch_size,
@@ -140,5 +129,19 @@ class GeneticAlgorithmEmitter(EmitterBase):
             else:
                 parents = self.archive.sample_elites(
                     self._batch_size)["solution"]
+            return self._clip(self._operator.ask(parents))
 
-            return self._operator.ask(parents=parents)
+        elif self._operator.parent_type == 2:
+            if self.archive.empty:
+                parents = np.repeat(self.x0[None],
+                                    repeats=2 * self._batch_size,
+                                    axis=0)
+            else:
+                parents = self.archive.sample_elites(
+                    2 * self._batch_size)["solution"]
+            return self._clip(
+                self._operator.ask(parents.reshape(2, self._batch_size, -1)))
+
+        else:
+            raise ValueError(
+                f"Unknown operator `parent_type` {self._operator.parent_type}")

--- a/ribs/emitters/_iso_line_emitter.py
+++ b/ribs/emitters/_iso_line_emitter.py
@@ -7,14 +7,14 @@ from ribs.emitters.operators import IsoLineOperator
 
 
 class IsoLineEmitter(EmitterBase):
-    """Emits solutions that are nudged towards other archive solutions.
+    """Emits solutions by leveraging correlations between existing elites.
 
-    If the archive is empty and ``self._initial_solutions`` is set, a call to
-    :meth:`ask` will return ``self._initial_solutions``. If
-    ``self._initial_solutions`` is not set, we draw solutions from an isotropic
-    Gaussian distribution centered at ``self.x0`` with standard deviation
-    ``self.iso_sigma``. Otherwise, to generate each new solution, the emitter
-    selects a pair of elites :math:`x_i` and :math:`x_j` and samples from
+    If the archive is empty and ``initial_solutions`` is set, a call to
+    :meth:`ask` will return ``initial_solutions``. If ``initial_solutions`` is
+    not set, we draw solutions from an isotropic Gaussian distribution centered
+    at ``x0`` with standard deviation ``iso_sigma``. Otherwise, to generate each
+    new solution, the emitter selects a pair of elites :math:`x_i` and
+    :math:`x_j` and samples from
 
     .. math::
 
@@ -25,8 +25,7 @@ class IsoLineEmitter(EmitterBase):
     2018 <https://arxiv.org/abs/1804.03906>`_.
 
     Args:
-        archive (ribs.archives.ArchiveBase): An archive to use when creating and
-            inserting solutions. For instance, this can be
+        archive (ribs.archives.ArchiveBase): Archive of solutions, e.g.,
             :class:`ribs.archives.GridArchive`.
         iso_sigma (float): Scale factor for the isotropic distribution used to
             generate solutions.
@@ -63,12 +62,16 @@ class IsoLineEmitter(EmitterBase):
                  bounds=None,
                  batch_size=64,
                  seed=None):
-        self._rng = np.random.default_rng(seed)
-        self._batch_size = batch_size
+        EmitterBase.__init__(
+            self,
+            archive,
+            solution_dim=archive.solution_dim,
+            bounds=bounds,
+        )
 
+        self._batch_size = batch_size
         self._iso_sigma = np_scalar(iso_sigma, dtype=archive.dtypes["solution"])
         self._line_sigma = np_scalar(line_sigma, archive.dtypes["solution"])
-
         self._x0 = None
         self._initial_solutions = None
 
@@ -88,17 +91,8 @@ class IsoLineEmitter(EmitterBase):
             check_batch_shape(self._initial_solutions, "initial_solutions",
                               archive.solution_dim, "archive.solution_dim")
 
-        EmitterBase.__init__(
-            self,
-            archive,
-            solution_dim=archive.solution_dim,
-            bounds=bounds,
-        )
-
-        self._operator = IsoLineOperator(line_sigma=self._line_sigma,
-                                         iso_sigma=self._iso_sigma,
-                                         lower_bounds=self._lower_bounds,
-                                         upper_bounds=self._upper_bounds,
+        self._operator = IsoLineOperator(iso_sigma=self._iso_sigma,
+                                         line_sigma=self._line_sigma,
                                          seed=seed)
 
     @property
@@ -131,25 +125,33 @@ class IsoLineEmitter(EmitterBase):
         """int: Number of solutions to return in :meth:`ask`."""
         return self._batch_size
 
+    def _clip(self, solutions):
+        """Clips solutions to the bounds of the solution space."""
+        return np.clip(solutions, self.lower_bounds, self.upper_bounds)
+
     def ask(self):
         """Generates ``batch_size`` solutions.
 
-        If the archive is empty and ``self._initial_solutions`` is set, we
-        return ``self._initial_solutions``. If ``self._initial_solutions`` is
-        not set, we draw solutions from an isotropic Gaussian distribution
-        centered at ``self.x0`` with standard deviation ``self.iso_sigma``.
-        Otherwise, each solution is drawn from a distribution centered at
-        a randomly chosen elite with standard deviation ``self.iso_sigma``.
+        If the archive is empty and ``initial_solutions`` is set, a call to
+        :meth:`ask` will return ``initial_solutions``. If ``initial_solutions``
+        is not set, we draw solutions from an isotropic Gaussian distribution
+        centered at ``x0`` with standard deviation ``iso_sigma``. Otherwise, to
+        generate each new solution, the emitter selects a pair of elites
+        :math:`x_i` and :math:`x_j` and samples from
+
+        .. math::
+
+            x_i + \\sigma_{iso} \\mathcal{N}(0,\\mathcal{I}) +
+                \\sigma_{line}(x_j - x_i)\\mathcal{N}(0,1)
 
         Returns:
-            If the archive is not empty, ``(batch_size, solution_dim)`` array
-            -- contains ``batch_size`` new solutions to evaluate. If the
-            archive is empty, we return ``self._initial_solutions``, which
-            might not have ``batch_size`` solutions.
+            If the archive is not empty, ``(batch_size, solution_dim)`` array --
+            contains ``batch_size`` new solutions to evaluate. If the archive is
+            empty, we return ``initial_solutions``, which might not have
+            ``batch_size`` solutions.
         """
         if self.archive.empty and self._initial_solutions is not None:
-            return np.clip(self._initial_solutions, self.lower_bounds,
-                           self.upper_bounds)
+            return self._clip(self.initial_solutions)
 
         if self.archive.empty:
             parents = np.repeat(self.x0[None],
@@ -158,5 +160,6 @@ class IsoLineEmitter(EmitterBase):
         else:
             parents = self.archive.sample_elites(2 *
                                                  self._batch_size)["solution"]
-        return self._operator.ask(
-            parents=parents.reshape(2, self._batch_size, -1))
+
+        return self._clip(
+            self._operator.ask(parents.reshape(2, self._batch_size, -1)))

--- a/ribs/emitters/operators/__init__.py
+++ b/ribs/emitters/operators/__init__.py
@@ -3,7 +3,7 @@
 Operators take in one or more parent solutions and output new solutions via
 operations such as mutation and crossover. When specifying operators for an
 emitter, one can pass in the operator class itself, or the string name of the
-operator, or an abbreviated name. The supported abbreviations are as follows.
+operator, or an abbreviated name. The supported abbreviations are:
 
 * ``gaussian``: :class:`GaussianOperator`
 * ``isoline``: :class:`IsoLineOperator`

--- a/ribs/emitters/operators/__init__.py
+++ b/ribs/emitters/operators/__init__.py
@@ -1,7 +1,12 @@
-"""Various operators which are employed across emitters.
+"""Various operators that are employed across emitters.
 
 Operators take in one or more parent solutions and output new solutions via
-operators such as mutation and crossover.
+operations such as mutation and crossover. When specifying operators for an
+emitter, one can pass in the operator class itself, or the string name of the
+operator, or an abbreviated name. The supported abbreviations are as follows.
+
+* ``gaussian``: :class:`GaussianOperator`
+* ``isoline``: :class:`IsoLineOperator`
 
 .. autosummary::
     :toctree:

--- a/ribs/emitters/operators/_gaussian.py
+++ b/ribs/emitters/operators/_gaussian.py
@@ -1,4 +1,4 @@
-"""Gaussian Operator"""
+"""Provides GaussianOperator."""
 import numpy as np
 
 from ribs.emitters.operators._operator_base import OperatorBase
@@ -11,19 +11,12 @@ class GaussianOperator(OperatorBase):
         sigma (float or array-like): Standard deviation of the Gaussian
             distribution. Note we assume the Gaussian is diagonal, so if this
             argument is an array, it must be 1D.
-        lower_bounds (array-like): Upper bounds of the solution space. Passed in
-            by emitter
-        upper_bounds (array-like): Upper bounds of the solution space. Passed in
-            by emitter
         seed (int): Value to seed the random number generator. Set to None to
             avoid a fixed seed.
     """
 
-    def __init__(self, sigma, lower_bounds, upper_bounds, seed=None):
+    def __init__(self, sigma, seed=None):
         self._sigma = sigma
-        self._lower_bounds = lower_bounds
-        self._upper_bounds = upper_bounds
-
         self._rng = np.random.default_rng(seed)
 
     @property
@@ -43,10 +36,9 @@ class GaussianOperator(OperatorBase):
             ``batch_size`` mutated solutions.
         """
         parents = np.asarray(parents)
-
         noise = self._rng.normal(
             scale=self._sigma,
             size=(parents.shape[0], parents.shape[1]),
         ).astype(parents.dtype)
 
-        return np.clip(parents + noise, self._lower_bounds, self._upper_bounds)
+        return parents + noise

--- a/ribs/emitters/operators/_iso_line.py
+++ b/ribs/emitters/operators/_iso_line.py
@@ -15,28 +15,13 @@ class IsoLineOperator(OperatorBase):
             generate solutions.
         line_sigma (float): Scale factor for the line distribution used when
             generating solutions.
-        sigma (float or array-like): Standard deviation of the Gaussian
-            distribution. Note we assume the Gaussian is diagonal, so if this
-            argument is an array, it must be 1D.
-        lower_bounds (array-like): Upper bounds of the solution space. Passed in
-            by emitter
-        upper_bounds (array-like): Upper bounds of the solution space. Passed in
-            by emitter
         seed (int): Value to seed the random number generator. Set to None to
             avoid a fixed seed.
     """
 
-    def __init__(self,
-                 lower_bounds,
-                 upper_bounds,
-                 iso_sigma,
-                 line_sigma,
-                 seed=None):
+    def __init__(self, iso_sigma, line_sigma, seed=None):
         self._iso_sigma = iso_sigma
         self._line_sigma = line_sigma
-        self._lower_bounds = lower_bounds
-        self._upper_bounds = upper_bounds
-
         self._rng = np.random.default_rng(seed)
 
     @property
@@ -73,4 +58,4 @@ class IsoLineOperator(OperatorBase):
         ).astype(elites.dtype)
         solution_batch = elites + iso_gaussian + line_gaussian * directions
 
-        return np.clip(solution_batch, self._lower_bounds, self._upper_bounds)
+        return solution_batch

--- a/ribs/emitters/operators/_operator_base.py
+++ b/ribs/emitters/operators/_operator_base.py
@@ -5,8 +5,7 @@ from abc import ABC, abstractmethod
 class OperatorBase(ABC):
     """Base class for operators.
 
-    Operators take in parents and output new solutions when their ask method
-    is called. They can also be instantiated with any arguments.
+    Operators output new solutions when passed parents.
     """
 
     @abstractmethod

--- a/tests/emitters/genetic_algorithm_emitter_test.py
+++ b/tests/emitters/genetic_algorithm_emitter_test.py
@@ -27,11 +27,16 @@ def test_properties_are_correct(archive_fixture):
 def test_initial_solutions_is_correct(archive_fixture):
     archive, _ = archive_fixture
     initial_solutions = [[0, 1, 2, 3], [-1, -2, -3, -4]]
-    operator_kwargs = {'iso_sigma': 0, 'line_sigma': 0}
-    emitter = GeneticAlgorithmEmitter(archive,
-                                      initial_solutions=initial_solutions,
-                                      operator="isoline",
-                                      operator_kwargs=operator_kwargs)
+    emitter = GeneticAlgorithmEmitter(
+        archive,
+        batch_size=36,
+        operator="isoline",
+        operator_kwargs={
+            'iso_sigma': 0.1,
+            'line_sigma': 0.2,
+        },
+        initial_solutions=initial_solutions,
+    )
 
     assert np.all(emitter.ask() == initial_solutions)
     assert np.all(emitter.initial_solutions == initial_solutions)
@@ -39,75 +44,107 @@ def test_initial_solutions_is_correct(archive_fixture):
 
 def test_initial_solutions_shape(archive_fixture):
     archive, _ = archive_fixture
-    initial_solutions = [[0, 0, 0], [1, 1, 1]]
 
-    # archive.solution_dim = 4
     with pytest.raises(ValueError):
-        GeneticAlgorithmEmitter(archive,
-                                initial_solutions=initial_solutions,
-                                operator="isoline")
+        GeneticAlgorithmEmitter(
+            archive,
+            batch_size=36,
+            # archive.solution_dim = 4, but these are 3D.
+            initial_solutions=[[0, 0, 0], [1, 1, 1]],
+            operator="isoline",
+            operator_kwargs={
+                'iso_sigma': 0.1,
+                'line_sigma': 0.2,
+            },
+        )
 
 
 def test_neither_x0_nor_initial_solutions_provided(archive_fixture):
     archive, _ = archive_fixture
     with pytest.raises(ValueError):
-        GeneticAlgorithmEmitter(archive)
+        GeneticAlgorithmEmitter(archive, batch_size=36, operator="gaussian")
 
 
 def test_both_x0_and_initial_solutions_provided(archive_fixture):
     archive, x0 = archive_fixture
-    initial_solutions = [[0, 1, 2, 3], [-1, -2, -3, -4]]
     with pytest.raises(ValueError):
-        GeneticAlgorithmEmitter(archive,
-                                x0=x0,
-                                initial_solutions=initial_solutions,
-                                operator="isoline")
+        GeneticAlgorithmEmitter(
+            archive,
+            batch_size=36,
+            x0=x0,
+            initial_solutions=[[0, 1, 2, 3], [-1, -2, -3, -4]],
+            operator="isoline",
+            operator_kwargs={
+                'iso_sigma': 0.1,
+                'line_sigma': 0.2,
+            },
+        )
 
 
 def test_upper_bounds_enforced(archive_fixture):
     archive, _ = archive_fixture
-    operator_kwargs = {'iso_sigma': 0, 'line_sigma': 0}
-    emitter = GeneticAlgorithmEmitter(archive,
-                                      x0=[2, 2, 2, 2],
-                                      bounds=[(-1, 1)] * 4,
-                                      operator="isoline",
-                                      operator_kwargs=operator_kwargs)
+    emitter = GeneticAlgorithmEmitter(
+        archive,
+        batch_size=36,
+        x0=[2, 2, 2, 2],
+        bounds=[(-1, 1)] * 4,
+        operator="isoline",
+        operator_kwargs={
+            'iso_sigma': 0.1,
+            'line_sigma': 0.2,
+        },
+    )
     sols = emitter.ask()
     assert np.all(sols <= 1)
 
 
 def test_lower_bounds_enforced(archive_fixture):
     archive, _ = archive_fixture
-    operator_kwargs = {'iso_sigma': 0, 'line_sigma': 0}
-    emitter = GeneticAlgorithmEmitter(archive,
-                                      x0=[-2, -2, -2, -2],
-                                      bounds=[(-1, 1)] * 4,
-                                      operator="isoline",
-                                      operator_kwargs=operator_kwargs)
+    emitter = GeneticAlgorithmEmitter(
+        archive,
+        batch_size=36,
+        x0=[-2, -2, -2, -2],
+        bounds=[(-1, 1)] * 4,
+        operator="isoline",
+        operator_kwargs={
+            'iso_sigma': 0.1,
+            'line_sigma': 0.2,
+        },
+    )
     sols = emitter.ask()
     assert np.all(sols >= -1)
 
 
 def test_degenerate_iso_gauss_emits_x0(archive_fixture):
     archive, x0 = archive_fixture
-    operator_kwargs = {'iso_sigma': 0, 'line_sigma': 0}
-    emitter = GeneticAlgorithmEmitter(archive,
-                                      x0=x0,
-                                      batch_size=2,
-                                      operator="isoline",
-                                      operator_kwargs=operator_kwargs)
+    emitter = GeneticAlgorithmEmitter(
+        archive,
+        batch_size=36,
+        x0=x0,
+        operator="isoline",
+        operator_kwargs={
+            # Degenerate.
+            'iso_sigma': 0.0,
+            'line_sigma': 0.2,
+        },
+    )
     solutions = emitter.ask()
     assert (solutions == np.expand_dims(x0, axis=0)).all()
 
 
 def test_degenerate_iso_gauss_emits_parent(archive_fixture):
     archive, x0 = archive_fixture
-    operator_kwargs = {'iso_sigma': 0, 'line_sigma': 0}
-    emitter = GeneticAlgorithmEmitter(archive,
-                                      x0=x0,
-                                      batch_size=2,
-                                      operator="isoline",
-                                      operator_kwargs=operator_kwargs)
+    emitter = GeneticAlgorithmEmitter(
+        archive,
+        batch_size=36,
+        x0=x0,
+        operator="isoline",
+        operator_kwargs={
+            # Degenerate.
+            'iso_sigma': 0.0,
+            'line_sigma': 0.2,
+        },
+    )
     archive.add_single(x0, 1, np.array([0, 0]))
 
     solutions = emitter.ask()
@@ -117,12 +154,16 @@ def test_degenerate_iso_gauss_emits_parent(archive_fixture):
 
 def test_degenerate_iso_gauss_emits_along_line(archive_fixture):
     archive, x0 = archive_fixture
-    operator_kwargs = {'iso_sigma': 0, 'line_sigma': 0}
-    emitter = GeneticAlgorithmEmitter(archive,
-                                      x0=x0,
-                                      batch_size=100,
-                                      operator="isoline",
-                                      operator_kwargs=operator_kwargs)
+    emitter = GeneticAlgorithmEmitter(
+        archive,
+        batch_size=36,
+        x0=x0,
+        operator="isoline",
+        operator_kwargs={
+            'iso_sigma': 0.0,
+            'line_sigma': 0.2,
+        },
+    )
     archive.add_single(np.array([0, 0, 0, 0]), 1, np.array([0, 0]))
     archive.add_single(np.array([10, 0, 0, 0]), 1, np.array([1, 1]))
 
@@ -139,12 +180,13 @@ def test_degenerate_iso_gauss_emits_along_line(archive_fixture):
 
 def test_degenerate_gauss_emits_x0(archive_fixture):
     archive, x0 = archive_fixture
-    operator_kwargs = {'sigma': 0}
-    emitter = GeneticAlgorithmEmitter(archive,
-                                      x0=x0,
-                                      batch_size=2,
-                                      operator="gaussian",
-                                      operator_kwargs=operator_kwargs)
+    emitter = GeneticAlgorithmEmitter(
+        archive,
+        batch_size=36,
+        x0=x0,
+        operator="gaussian",
+        operator_kwargs={"sigma": 0.0},
+    )
     solutions = emitter.ask()
     assert (solutions == np.expand_dims(x0, axis=0)).all()
 
@@ -153,12 +195,13 @@ def test_degenerate_gauss_emits_parent(archive_fixture):
     archive, x0 = archive_fixture
     parent_sol = x0 * 5
     archive.add_single(parent_sol, 1, np.array([0, 0]))
-    operator_kwargs = {'sigma': 0}
-    emitter = GeneticAlgorithmEmitter(archive,
-                                      x0=x0,
-                                      batch_size=2,
-                                      operator="gaussian",
-                                      operator_kwargs=operator_kwargs)
+    emitter = GeneticAlgorithmEmitter(
+        archive,
+        batch_size=36,
+        x0=x0,
+        operator="gaussian",
+        operator_kwargs={"sigma": 0.0},
+    )
 
     # All solutions should be generated "around" the single parent solution in
     # the archive.


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the PR's purpose here. -->

Clean up miscellaneous parts of the operator implementation and related emitters.

## TODO

<!-- Notable points that this PR has either accomplished or will accomplish. -->

- [x] List operator abbreviations in `OperatorBase`
- [x] Remove `lower_bounds` and `upper_bounds` from the operators and call `clip` in the emitters instead
- [x] Update GaussianEmitter, IsoLineEmitter, and GeneticAlgorithmEmitter to clip the solutions returned from operators
- [x] Make `operator` a required argument for GeneticAlgorithmEmitter
- [x] Add `seed` to GeneticAlgorithmEmitter
  - [x] Check we get consistent results with the same seed -> I set it up in `sphere.py` and ran it with the same seed
- [x] Tidy up GeneticAlgorithmEmitter tests
- [x] Add a history entry that was missed during development in #427
- [x] Miscellaneous docstring edits across GaussianEmitter, IsoLineEmitter, and GeneticAlgorithmEmitter

## Status

- [x] I have read the guidelines in
      [CONTRIBUTING.md](https://github.com/icaros-usc/pyribs/blob/master/CONTRIBUTING.md)
- [x] I have formatted my code using `yapf`
- [x] I have tested my code by running `pytest`
- [x] I have linted my code with `pylint`
- [x] I have added a one-line description of my change to the changelog in
      `HISTORY.md`
- [x] This PR is ready to go
