### PR TITLE
Remove as_pandas from ArchiveBase due to deprecation

### DIFF
--- a/ribs/archives/_archive_base.py
+++ b/ribs/archives/_archive_base.py
@@ -786,15 +786,6 @@ class ArchiveBase(ABC):
             data = ArchiveDataFrame(data)
         return data
 
-    def as_pandas(self, include_solutions=True, include_metadata=False):
-        """DEPRECATED."""
-        # pylint: disable = unused-argument
-        raise RuntimeError(
-            "as_pandas has been deprecated. Please use "
-            "archive.data(..., return_type='pandas') instead, or consider "
-            "retrieving individual fields, e.g., "
-            "objective = archive.data('objective')")
-
     def cqd_score(self,
                   iterations,
                   target_points,


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the PR's purpose here. -->

`as_pandas` was deprecated a while ago. This PR removes the method completely.

## Status

- [x] I have read the guidelines in
      [CONTRIBUTING.md](https://github.com/icaros-usc/pyribs/blob/master/CONTRIBUTING.md)
- [x] I have formatted my code using `yapf`
- [x] I have tested my code by running `pytest`
- [x] I have linted my code with `pylint`
- [N/A] I have added a one-line description of my change to the changelog in
      `HISTORY.md`
- [x] This PR is ready to go
