### PR TITLE
Make emitter bounds dtype match solution dtype

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -25,6 +25,7 @@
 
 #### Bugs
 
+- Make emitter bounds dtype match solution dtype ({pr}`519`)
 - Fix `BanditScheduler` behaviour: the number of active emitters remains stable
   ({pr}`489`)
 

--- a/ribs/emitters/_emitter_base.py
+++ b/ribs/emitters/_emitter_base.py
@@ -33,7 +33,7 @@ class EmitterBase(ABC):
         self._solution_dim = solution_dim
         (self._lower_bounds,
          self._upper_bounds) = self._process_bounds(bounds, self._solution_dim,
-                                                    archive.dtypes["measures"])
+                                                    archive.dtypes["solution"])
 
     @staticmethod
     def _process_bounds(bounds, solution_dim, dtype):


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the PR's purpose here. -->

Previously, we used the `measures` dtype for the emitter bounds, but the emitter operates in _solution_ space.

## Status

- [x] I have read the guidelines in
      [CONTRIBUTING.md](https://github.com/icaros-usc/pyribs/blob/master/CONTRIBUTING.md)
- [x] I have formatted my code using `yapf`
- [x] I have tested my code by running `pytest`
- [x] I have linted my code with `pylint`
- [x] I have added a one-line description of my change to the changelog in
      `HISTORY.md`
- [x] This PR is ready to go
