### PR TITLE
Refactor ProximityArchive

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -16,7 +16,8 @@
 - Add proximity_archive_plot for visualizing ProximityArchive ({pr}`476`,
   {pr}`480`)
 - Support novelty search with local competition in ProximityArchive ({pr}`481`)
-- Add ProximityArchive for novelty search ({pr}`472`, {pr}`479`, {pr}`484`)
+- Add ProximityArchive for novelty search ({pr}`472`, {pr}`479`, {pr}`484`,
+  {pr}`521`)
 - Support diversity optimization in Scheduler.tell ({pr}`473`)
 - Allow specifying separate dtypes for solution, objective, and measures
   ({pr}`471`)
@@ -31,7 +32,6 @@
 
 #### Documentation
 
-- Refactor archives into single-file implementations ({pr}`518`)
 - Update sphere example for consistency ({pr}`505`)
 - DQD tutorial edits ({pr}`500`)
 - Add version selector to docs ({pr}`495`)
@@ -44,6 +44,7 @@
 
 #### Improvements
 
+- Refactor archives into single-file implementations ({pr}`518`, {pr}`521`)
 - Migrate to pyproject.toml ({pr}`514`)
 - Set vmin and vmax to None if archive is empty in ribs.visualize ({pr}`513`)
 - Update QDax visualizations to match QDax 0.5.0 ({pr}`502`)

--- a/ribs/archives/_proximity_archive.py
+++ b/ribs/archives/_proximity_archive.py
@@ -5,7 +5,6 @@ from scipy.spatial import cKDTree
 from ribs._utils import (check_batch_shape, check_finite, check_shape,
                          np_scalar, validate_batch, validate_single)
 from ribs.archives._archive_base_2 import ArchiveBase
-from ribs.archives._archive_data_frame import ArchiveDataFrame
 from ribs.archives._archive_stats import ArchiveStats
 from ribs.archives._array_store import ArrayStore
 from ribs.archives._transforms import (batch_entries_with_threshold,
@@ -178,8 +177,6 @@ class ProximityArchive(ArchiveBase):
         # add().
         self._cur_kd_tree = cKDTree(self._store.data("measures"),
                                     **self._ckdtree_kwargs)
-
-        # TODO: Refactor stats?
 
         # Set up statistics.
         self._stats = None
@@ -709,7 +706,6 @@ class ProximityArchive(ArchiveBase):
     ## Methods for reading from the archive ##
     ## Refer to ArchiveBase for documentation of these methods. ##
 
-    # TODO: Refactor?
     def retrieve(self, measures):
         measures = np.asarray(measures)
         check_batch_shape(measures, "measures", self.measure_dim, "measure_dim")

--- a/ribs/archives/_proximity_archive.py
+++ b/ribs/archives/_proximity_archive.py
@@ -520,13 +520,13 @@ class ProximityArchive(ArchiveBase):
               values in CMA-ME (`Fontaine 2020
               <https://arxiv.org/abs/1912.02400>`_):
 
-              - ``0`` (not added): The value is the "negative improvement," i.e.
-                the objective of the solution passed in minus the objective of
-                the nearest neighbor (this value is negative because the
-                solution did not have a high enough objective to be added to the
-                archive).
+              - ``0`` (not added): The value is the "negative improvement,"
+                i.e., the objective of the solution passed in minus the
+                objective of the nearest neighbor (this value is negative
+                because the solution did not have a high enough objective to be
+                added to the archive).
               - ``1`` (replace/improve existing solution): The value is the
-                "improvement," i.e. the objective of the solution passed in
+                "improvement," i.e., the objective of the solution passed in
                 minus the objective of the elite that was replaced.
               - ``2`` (new solution): The value is just the objective of the
                 solution.

--- a/ribs/archives/_proximity_archive.py
+++ b/ribs/archives/_proximity_archive.py
@@ -742,10 +742,7 @@ class ProximityArchive(ArchiveBase):
         return occupied[0], {field: arr[0] for field, arr in data.items()}
 
     def data(self, fields=None, return_type="dict"):
-        data = self._store.data(fields, return_type)
-        if return_type == "pandas":
-            data = ArchiveDataFrame(data)
-        return data
+        return self._store.data(fields, return_type)
 
     def sample_elites(self, n):
         if self.empty:

--- a/ribs/archives/_proximity_archive.py
+++ b/ribs/archives/_proximity_archive.py
@@ -1,6 +1,4 @@
 """Contains the ProximityArchive."""
-from functools import cached_property
-
 import numpy as np
 from scipy.spatial import cKDTree
 
@@ -329,7 +327,6 @@ class ProximityArchive(ArchiveBase):
                                dtype=self.dtypes["objective"]),
         )
 
-    # TODO: We no longer need index_of?
     def index_of(self, measures) -> np.ndarray:
         """Returns the index of the closest solution to the given measures.
 

--- a/ribs/visualize/_proximity_archive_plot.py
+++ b/ribs/visualize/_proximity_archive_plot.py
@@ -162,10 +162,10 @@ def proximity_archive_plot(archive,
         objective_batch = df.get_field("objective")
     x = measures_batch[:, 0]
     y = measures_batch[:, 1]
-    lower_bounds = archive.lower_bounds - 0.01 if lower_bounds is None \
-                        else lower_bounds
-    upper_bounds = archive.upper_bounds + 0.01 if upper_bounds is None \
-                        else upper_bounds
+    lower_bounds = np.min(measures_batch, axis=0) - 0.01 \
+                     if lower_bounds is None else lower_bounds
+    upper_bounds = np.min(measures_batch, axis=0) + 0.01 \
+                     if upper_bounds is None else upper_bounds
 
     if transpose_measures:
         # Since the archive is 2D, transpose by swapping the x and y measures

--- a/ribs/visualize/_proximity_archive_plot.py
+++ b/ribs/visualize/_proximity_archive_plot.py
@@ -164,7 +164,7 @@ def proximity_archive_plot(archive,
     y = measures_batch[:, 1]
     lower_bounds = np.min(measures_batch, axis=0) - 0.01 \
                      if lower_bounds is None else lower_bounds
-    upper_bounds = np.min(measures_batch, axis=0) + 0.01 \
+    upper_bounds = np.max(measures_batch, axis=0) + 0.01 \
                      if upper_bounds is None else upper_bounds
 
     if transpose_measures:

--- a/tests/archives/archive_base_test.py
+++ b/tests/archives/archive_base_test.py
@@ -339,11 +339,13 @@ def test_solution_dim_correct(data):
 
 
 def test_learning_rate_correct(data):
-    assert data.archive.learning_rate == 1.0  # Default value.
+    if not isinstance(data.archive, ProximityArchive):
+        assert data.archive.learning_rate == 1.0  # Default value.
 
 
 def test_threshold_min_correct(data):
-    assert data.archive.threshold_min == -np.inf  # Default value.
+    if not isinstance(data.archive, ProximityArchive):
+        assert data.archive.threshold_min == -np.inf  # Default value.
 
 
 def test_qd_score_offset_correct(data):

--- a/tests/archives/proximity_archive_test.py
+++ b/tests/archives/proximity_archive_test.py
@@ -76,11 +76,6 @@ def test_properties_are_correct(data):
     assert data.archive.empty
     assert data.archive.k_neighbors == data.k_neighbors
     assert data.archive.novelty_threshold == data.novelty_threshold
-    # Undefined when there are no solutions.
-    with pytest.raises(RuntimeError):
-        data.archive.lower_bounds  # pylint: disable = pointless-statement
-    with pytest.raises(RuntimeError):
-        data.archive.upper_bounds  # pylint: disable = pointless-statement
 
     # With elite.
     assert data.archive_with_elite.capacity == data.capacity
@@ -89,8 +84,6 @@ def test_properties_are_correct(data):
     assert not data.archive_with_elite.empty
     assert data.archive_with_elite.k_neighbors == data.k_neighbors
     assert data.archive_with_elite.novelty_threshold == data.novelty_threshold
-    assert_allclose(data.archive_with_elite.lower_bounds, data.measures)
-    assert_allclose(data.archive_with_elite.upper_bounds, data.measures)
 
 
 def test_initial_capacity_less_than_1():
@@ -102,28 +95,6 @@ def test_initial_capacity_less_than_1():
             novelty_threshold=1.0,
             initial_capacity=0,
         )
-
-
-def test_bounds(data):
-    data.archive.add(
-        solution=[[1, 2, 3]] * 2,
-        objective=None,
-        measures=[[0, 0], [2, 2]],
-    )
-
-    # Boundaries should reflect min/max measures.
-    assert np.all(data.archive.lower_bounds == [0, 0])
-    assert np.all(data.archive.upper_bounds == [2, 2])
-
-    data.archive.add(
-        solution=[[1, 2, 3]] * 2,
-        objective=None,
-        measures=[[-2, -2], [4, 4]],
-    )
-
-    # Boundaries should update to the new min/max measures.
-    assert np.all(data.archive.lower_bounds == [-2, -2])
-    assert np.all(data.archive.upper_bounds == [4, 4])
 
 
 def test_resizing_with_add_one_at_a_time():


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the PR's purpose here. -->

Refactor ProximityArchive to use the new ArchiveBase.

## TODO

<!-- Notable points that this PR has either accomplished or will accomplish. -->

- [x] Refactor to use new ArchiveBase
- [x] Remove `lower_bounds` and `upper_bounds` properties -- they are not truly required in ProximityArchive
  - [x] Remove calls to these properties in `proximity_archive_plot`
- [x] Remove `learning_rate` and `threshold_min` properties as they are not used at all
- [x] Update tests
- [x] Review docstrings

## Status

- [x] I have read the guidelines in
      [CONTRIBUTING.md](https://github.com/icaros-usc/pyribs/blob/master/CONTRIBUTING.md)
- [x] I have formatted my code using `yapf`
- [x] I have tested my code by running `pytest`
- [x] I have linted my code with `pylint`
- [x] I have added a one-line description of my change to the changelog in
      `HISTORY.md`
- [x] This PR is ready to go
