### PR TITLE
Make ArrayStore.data return ArchiveDataFrame instead of DataFrame

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -44,6 +44,7 @@
 
 #### Improvements
 
+- Make ArrayStore.data return ArchiveDataFrame instead of DataFrame ({pr}`522`)
 - Migrate to pyproject.toml ({pr}`514`)
 - Set vmin and vmax to None if archive is empty in ribs.visualize ({pr}`513`)
 - Update QDax visualizations to match QDax 0.5.0 ({pr}`502`)

--- a/ribs/archives/_archive_base.py
+++ b/ribs/archives/_archive_base.py
@@ -6,7 +6,6 @@ import numpy as np
 from ribs._utils import (check_batch_shape, check_finite, check_is_1d,
                          check_shape, np_scalar, validate_batch,
                          validate_single)
-from ribs.archives._archive_data_frame import ArchiveDataFrame
 from ribs.archives._archive_stats import ArchiveStats
 from ribs.archives._array_store import ArrayStore
 from ribs.archives._cqd_score_result import CQDScoreResult
@@ -781,10 +780,7 @@ class ArchiveBase(ABC):
             All data returned by this method will be a copy, i.e., the data will
             not update as the archive changes.
         """ # pylint: disable = line-too-long
-        data = self._store.data(fields, return_type)
-        if return_type == "pandas":
-            data = ArchiveDataFrame(data)
-        return data
+        return self._store.data(fields, return_type)
 
     def cqd_score(self,
                   iterations,

--- a/ribs/archives/_array_store.py
+++ b/ribs/archives/_array_store.py
@@ -6,9 +6,9 @@ from functools import cached_property
 
 import numpy as np
 from numpy_groupies import aggregate_nb as aggregate
-from pandas import DataFrame
 
 from ribs._utils import readonly
+from ribs.archives._archive_data_frame import ArchiveDataFrame
 
 
 class Update(IntEnum):
@@ -286,8 +286,9 @@ class ArrayStore:
                 tuple will be ordered according to the ``field_desc`` argument
                 in the constructor, along with ``index`` as the last field.
 
-              - ``return_type="pandas"``: A :class:`pandas.DataFrame` with the
-                following columns (by default):
+              - ``return_type="pandas"``: An
+                :class:`~ribs.archives.ArchiveDataFrame` with the following
+                columns (by default):
 
                 - For fields that are scalars, a single column with the field
                   name. For example, ``objective`` would have a single column
@@ -371,7 +372,7 @@ class ArrayStore:
             data = tuple(data)
         elif return_type == "pandas":
             # Data above are already copied, so no need to copy again.
-            data = DataFrame(data, copy=False)
+            data = ArchiveDataFrame(data, copy=False)
 
         return occupied, data
 

--- a/ribs/archives/_grid_archive.py
+++ b/ribs/archives/_grid_archive.py
@@ -5,7 +5,6 @@ from ribs._utils import (check_batch_shape, check_finite, check_is_1d,
                          check_shape, np_scalar, validate_batch,
                          validate_single)
 from ribs.archives._archive_base_2 import ArchiveBase
-from ribs.archives._archive_data_frame import ArchiveDataFrame
 from ribs.archives._archive_stats import ArchiveStats
 from ribs.archives._array_store import ArrayStore
 from ribs.archives._cqd_score_result import CQDScoreResult
@@ -684,10 +683,7 @@ class GridArchive(ArchiveBase):
         return occupied[0], {field: arr[0] for field, arr in data.items()}
 
     def data(self, fields=None, return_type="dict"):
-        data = self._store.data(fields, return_type)
-        if return_type == "pandas":
-            data = ArchiveDataFrame(data)
-        return data
+        return self._store.data(fields, return_type)
 
     def sample_elites(self, n):
         if self.empty:


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the PR's purpose here. -->

Previously, ArrayStore returned `pandas.DataFrame`. However, since we never use a regular `DataFrame`, I think it is alright to just return `ArchiveDataFrame`. This also makes it easier to implement `archive.data()` since we don't have to cast to ArchiveDataFrame.

## TODO

<!-- Notable points that this PR has either accomplished or will accomplish. -->

- [x] Return `ArchiveDataFrame` in `ArrayStore.data`
- [x] Update implementation in `GridArchive.data`
- [x] Update implementation in `ArchiveBase.data`

## Status

- [x] I have read the guidelines in
      [CONTRIBUTING.md](https://github.com/icaros-usc/pyribs/blob/master/CONTRIBUTING.md)
- [x] I have formatted my code using `yapf`
- [x] I have tested my code by running `pytest`
- [x] I have linted my code with `pylint`
- [x] I have added a one-line description of my change to the changelog in
      `HISTORY.md`
- [x] This PR is ready to go
