### PR TITLE
Remove transforms from archive add operations

### DIFF
--- a/ribs/archives/_array_store.py
+++ b/ribs/archives/_array_store.py
@@ -390,6 +390,51 @@ class ArrayStore:
         """
         return self.retrieve(self.occupied_list, fields, return_type)[1]
 
+    def add_2(self, indices, new_data):
+        # TODO: docstring
+        """Adds new data to the store at the given indices."""
+        self._props["updates"][Update.ADD] += 1
+
+        # Shortcut when there is nothing to add to the store.
+        # TODO: Check needed?
+        if len(indices) == 0:
+            return
+
+        # Verify that the array shapes match the indices.
+        for name, arr in new_data.items():
+            if len(arr) != len(indices):
+                raise ValueError(
+                    f"In `new_data`, the array for `{name}` has length "
+                    f"{len(arr)} but should be the same length as indices "
+                    f"({len(indices)})")
+
+        # Verify that new_data ends up with the correct fields after the
+        # transforms.
+        if new_data.keys() != self._fields.keys():
+            raise ValueError(
+                f"`new_data` had keys {new_data.keys()} but should have the "
+                f"same keys as this ArrayStore, i.e., {self._fields.keys()}. "
+                "You may be seeing this error if your archive has "
+                "extra_fields but the fields were not passed into "
+                "archive.add() or scheduler.tell().")
+
+        # Update occupancy data.
+        unique_indices = np.where(aggregate(indices, 1, func="len") != 0)[0]
+        cur_occupied = self._props["occupied"][unique_indices]
+        new_indices = unique_indices[~cur_occupied]
+        n_occupied = self._props["n_occupied"]
+        self._props["occupied"][new_indices] = True
+        self._props["occupied_list"][n_occupied:n_occupied +
+                                     len(new_indices)] = new_indices
+        self._props["n_occupied"] = n_occupied + len(new_indices)
+
+        # Insert into the ArrayStore. Note that we do not assume indices are
+        # unique. Hence, when updating occupancy data above, we computed the
+        # unique indices. In contrast, here we let NumPy's default behavior
+        # handle duplicate indices.
+        for name, arr in self._fields.items():
+            arr[indices] = new_data[name]
+
     def add(self, indices, new_data, extra_args, transforms):
         """Adds new data to the store at the given indices.
 

--- a/ribs/archives/_array_store.py
+++ b/ribs/archives/_array_store.py
@@ -391,12 +391,10 @@ class ArrayStore:
         return self.retrieve(self.occupied_list, fields, return_type)[1]
 
     def add_2(self, indices, new_data):
-        # TODO: docstring
         """Adds new data to the store at the given indices."""
         self._props["updates"][Update.ADD] += 1
 
         # Shortcut when there is nothing to add to the store.
-        # TODO: Check needed?
         if len(indices) == 0:
             return
 

--- a/ribs/archives/_grid_archive.py
+++ b/ribs/archives/_grid_archive.py
@@ -10,8 +10,7 @@ from ribs.archives._array_store import ArrayStore
 from ribs.archives._cqd_score_result import CQDScoreResult
 from ribs.archives._transforms import (batch_entries_with_threshold,
                                        compute_best_index,
-                                       compute_objective_sum,
-                                       single_entry_with_threshold)
+                                       compute_objective_sum)
 from ribs.archives._utils import parse_dtype, validate_cma_mae_settings
 
 
@@ -584,10 +583,9 @@ class GridArchive(ArchiveBase):
         also updated if the solution was inserted.
 
         .. note::
-            To make it more amenable to modifications, this method's
-            implementation is designed to be readable at the cost of
-            performance, e.g., none of its operations are modified. :meth:`add`
-            should be used if performance is required.
+            This method is provided as an easier-to-understand implementation
+            that has less performance due to inserting only one solution at a
+            time. For better performance, see :meth:`add`.
 
         Args:
             solution (array-like): Parameters of the solution.
@@ -618,22 +616,27 @@ class GridArchive(ArchiveBase):
         # Delete these so that we only use the clean, validated data in `data`.
         del solution, objective, measures, fields
 
+        # Information to return about the addition.
+        add_info = {}
+
         # Identify the archive cell.
         index = self.index_of_single(data["measures"])
 
-        # Retrieve current data of the cell, namely, whether it is occupied, and
-        # if so, its current threshold.
+        # Retrieve current data of the cell.
         cur_occupied, cur_data = self._store.retrieve([index])
         cur_occupied = cur_occupied[0]
-        cur_threshold = cur_data["threshold"][0]
 
-        # If the cell is not currently occupied, the threshold needs special
-        # settings.
-        if not cur_occupied:
+        if cur_occupied:
+            # If the cell is currently occupied, the threshold comes from the
+            # cell's current data.
+            cur_threshold = cur_data["threshold"][0]
+        else:
+            # If the cell is not currently occupied, the threshold needs special
+            # settings.
+            #
             # If threshold_min is -inf, then we want CMA-ME behavior, which
             # computes the improvement value with a threshold of zero for new
-            # solutions. Otherwise, we will compute with a threshold of
-            # threshold_min.
+            # solutions. Otherwise, we will set cur_threshold to threshold_min.
             cur_threshold = (np_scalar(0.0, dtype=self.dtypes["threshold"])
                              if self.threshold_min == -np.inf else
                              self.threshold_min)
@@ -642,65 +645,51 @@ class GridArchive(ArchiveBase):
         objective = data["objective"]
 
         # Compute status and threshold.
-        add_info["status"] = np.array([0])  # NOT_ADDED
+        add_info["status"] = 0  # NOT_ADDED
 
-        # In CMA-ME,
-        # For CMA-ME behavior, threshold_arr[index] is -inf for new cells, which
-        # satisfies this if condition.
+        # Now we check whether a solution should be added to the archive. We use
+        # the addition rule from MAP-Elites (Fig. 2 of Mouret 2015
+        # https://arxiv.org/pdf/1504.04909.pdf), with modifications for CMA-MAE.
 
-        # TODO: Reference MAP-Elites rules here?
-        if ((not cur_occupied and threshold_min < objective) or
-            (cur_occupied and cur_threshold < objective)):
-            if cur_occupied:
-                add_info["status"] = np.array([1])  # IMPROVE_EXISTING
+        # This checks if a new solution is discovered in the archive. Note that
+        # regular MAP-Elites only checks `not cur_occupied`. CMA-MAE has an
+        # additional `threshold_min` that the objective must exceed for new
+        # cells. If CMA-MAE is not being used, then `threshold_min` is -np.inf,
+        # making this check identical to that of MAP-Elites.
+        is_new = not cur_occupied and self.threshold_min < objective
+
+        # This checks whether the solution improves an existing cell in the
+        # archive, i.e., whether it performs better than the current solution in
+        # this cell. Vanilla MAP-Elites compares to the objective of the cell's
+        # current solution. CMA-MAE compares to a threshold value that updates
+        # over time. When learning_rate is set to 1.0 (the default value), we
+        # recover the same rule as in MAP-Elites because cur_threshold is
+        # equivalent to the objective of the solution in the cell.
+        improve_existing = cur_occupied and cur_threshold < objective
+
+        if is_new or improve_existing:
+            if improve_existing:
+                add_info["status"] = 1  # IMPROVE_EXISTING
             else:
-                add_info["status"] = np.array([2])  # NEW
+                add_info["status"] = 2  # NEW
 
-            # This calculation works in the case where threshold_min is -inf because
-            # cur_threshold will be set to 0.0 instead.
-            data["threshold"] = [(cur_threshold * (1.0 - learning_rate) +
-                                  objective * learning_rate)]
+            # This calculation works in the case where threshold_min is -inf
+            # because cur_threshold will be set to 0.0 instead.
+            data["threshold"] = [(cur_threshold * (1.0 - self.learning_rate) +
+                                  objective * self.learning_rate)]
 
-            # TODO: Call store.add?
+            self._store.add_2(index[None], {
+                name: np.expand_dims(arr, axis=0) for name, arr in data.items()
+            })
+
+            # Update stats.
+            cur_objective = (cur_data["objective"] if cur_occupied else
+                             np_scalar(0.0, self.dtypes["objective"]))
+            self._stats_update(self._objective_sum + objective - cur_objective,
+                               index)
 
         # Value is the improvement over the current threshold (can be negative).
-        add_info["value"] = np.array([objective - cur_threshold])
-
-        if add_info["status"]:
-            return indices, new_data, add_info
-        else:
-            # new_data is ignored, so make it an empty dict.
-            return np.array([], dtype=np.int32), {}, add_info
-
-        # ----------------------------------------------------
-
-        for name, arr in data.items():
-            data[name] = np.expand_dims(arr, axis=0)
-
-        add_info = self._store.add(
-            np.expand_dims(self.index_of_single(measures), axis=0),
-            data,
-            {
-                "dtype": self.dtypes["threshold"],
-                "learning_rate": self._learning_rate,
-                "threshold_min": self._threshold_min,
-                "objective_sum": self._objective_sum,
-            },
-            [
-                single_entry_with_threshold,
-                compute_objective_sum,
-                compute_best_index,
-            ],
-        )
-
-        objective_sum = add_info.pop("objective_sum")
-        best_index = add_info.pop("best_index")
-
-        for name, arr in add_info.items():
-            add_info[name] = arr[0]
-
-        if add_info["status"]:
-            self._stats_update(objective_sum, best_index)
+        add_info["value"] = objective - cur_threshold
 
         return add_info
 


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the PR's purpose here. -->

Previously, the add methods were refactored into "transforms" that were part of ArrayStore. The original purpose was to make addition operations more flexible, but I think the transforms have overall made addition too complicated. This PR moves the logic for addition back into the `add` and `add_single` methods (specifically in GridArchive) and simplifies `ArrayStore.add` to no longer consider transforms. To ensure backwards compatibility during the ongoing archive refactoring (#518), I also copied the `add` and `add_single` logic into `ArchiveBase`.

## TODO

<!-- Notable points that this PR has either accomplished or will accomplish. -->

- [ ] Move `add` logic into GridArchive
- [x] Move `add_single` logic into GridArchive
- [ ] Copy `add` and `add_single` into ArchiveBase
- [ ] Simplify `ArrayStore.add` (backwards-incompatible) -- I think this change is alright since ArrayStore is an internal class
- [ ] Remove transforms

## Status

- [x] I have read the guidelines in
      [CONTRIBUTING.md](https://github.com/icaros-usc/pyribs/blob/master/CONTRIBUTING.md)
- [x] I have formatted my code using `yapf`
- [x] I have tested my code by running `pytest`
- [x] I have linted my code with `pylint`
- [ ] I have added a one-line description of my change to the changelog in
      `HISTORY.md`
- [ ] This PR is ready to go
