### PR TITLE
Remove `np_scalar` util by making archive dtypes be numpy scalar types

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -51,6 +51,8 @@
 
 #### Improvements
 
+- Remove `np_scalar` util by making archive dtypes be numpy scalar types
+  ({pr}`534`)
 - Refactor archives into single-file implementations ({pr}`518`, {pr}`521`,
   {pr}`526`, {pr}`528`, {pr}`529`, {pr}`530`, {pr}`533`)
 - Make ArrayStore.data return ArchiveDataFrame instead of DataFrame ({pr}`522`)

--- a/ribs/_utils.py
+++ b/ribs/_utils.py
@@ -210,8 +210,7 @@ def validate_single(archive, data, none_objective_ok=False):
         if not none_objective_ok:
             raise ValueError("objective cannot be None")
     else:
-        data["objective"] = np_scalar(data["objective"],
-                                      archive.dtypes["objective"])
+        data["objective"] = archive.dtypes["objective"](data["objective"])
         check_finite(data["objective"], "objective")
 
     data["measures"] = np.asarray(data["measures"])

--- a/ribs/_utils.py
+++ b/ribs/_utils.py
@@ -4,21 +4,6 @@ import numbers
 import numpy as np
 
 
-def np_scalar(scalar, dtype):
-    """Casts the scalar to the given numpy dtype.
-
-    This is useful for making sure all our scalars are in the correct dtype.
-
-    It is possible to just use np.array(scalar, dtype=dtype) since
-    zero-dimensional arrays behave like scalars, but the scalar would still show
-    up as an array if calling type().
-
-    It is also possible to use np.array(scalar, dtype=dtype).item(), but item()
-    converts outputs to standard Python objects, not numpy scalars.
-    """
-    return np.array([scalar], dtype=dtype)[0]
-
-
 def check_finite(x, name):
     """Checks that x is finite (i.e. not infinity or NaN).
 

--- a/ribs/archives/_array_store.py
+++ b/ribs/archives/_array_store.py
@@ -211,7 +211,7 @@ class ArrayStore:
                     "measures": np.float32,
                 }
         """
-        return {name: arr.dtype for name, arr in self._fields.items()}
+        return {name: arr.dtype.type for name, arr in self._fields.items()}
 
     @cached_property
     def dtypes_with_index(self):

--- a/ribs/archives/_array_store.py
+++ b/ribs/archives/_array_store.py
@@ -211,6 +211,8 @@ class ArrayStore:
                     "measures": np.float32,
                 }
         """
+        # Calling `.type` retrieves the numpy scalar type; see:
+        # https://numpy.org/doc/stable/reference/arrays.scalars.html#arrays-scalars-built-in
         return {name: arr.dtype.type for name, arr in self._fields.items()}
 
     @cached_property

--- a/ribs/archives/_array_store.py
+++ b/ribs/archives/_array_store.py
@@ -211,8 +211,9 @@ class ArrayStore:
                     "measures": np.float32,
                 }
         """
-        # Calling `.type` retrieves the numpy scalar type; see:
-        # https://numpy.org/doc/stable/reference/arrays.scalars.html#arrays-scalars-built-in
+        # Calling `.type` retrieves the numpy scalar type, which is callable:
+        # - https://numpy.org/doc/stable/reference/arrays.scalars.html
+        # - https://numpy.org/doc/stable/reference/arrays.dtypes.html
         return {name: arr.dtype.type for name, arr in self._fields.items()}
 
     @cached_property

--- a/ribs/archives/_grid_archive.py
+++ b/ribs/archives/_grid_archive.py
@@ -3,8 +3,7 @@ import numpy as np
 from numpy_groupies import aggregate_nb as aggregate
 
 from ribs._utils import (check_batch_shape, check_finite, check_is_1d,
-                         check_shape, np_scalar, validate_batch,
-                         validate_single)
+                         check_shape, validate_batch, validate_single)
 from ribs.archives._archive_base import ArchiveBase
 from ribs.archives._archive_stats import ArchiveStats
 from ribs.archives._array_store import ArrayStore
@@ -143,11 +142,10 @@ class GridArchive(ArchiveBase):
         self._boundaries = self._compute_boundaries(self._dims,
                                                     self._lower_bounds,
                                                     self._upper_bounds)
-        self._epsilon = np_scalar(epsilon, dtype=self.dtypes["measures"])
+        self._epsilon = self.dtypes["measures"](epsilon)
         self._learning_rate, self._threshold_min = validate_cma_mae_settings(
             learning_rate, threshold_min, self.dtypes["threshold"])
-        self._qd_score_offset = np_scalar(qd_score_offset,
-                                          self.dtypes["objective"])
+        self._qd_score_offset = self.dtypes["objective"](qd_score_offset)
 
         # Set up statistics.
         self._stats = None
@@ -288,27 +286,25 @@ class GridArchive(ArchiveBase):
 
     def _stats_reset(self):
         """Resets the archive stats."""
-        zero = np_scalar(0.0, dtype=self.dtypes["objective"])
-
         self._stats = ArchiveStats(
             num_elites=0,
-            coverage=zero,
-            qd_score=zero,
-            norm_qd_score=zero,
+            coverage=self.dtypes["objective"](0.0),
+            qd_score=self.dtypes["objective"](0.0),
+            norm_qd_score=self.dtypes["objective"](0.0),
             obj_max=None,
             obj_mean=None,
         )
         self._best_elite = None
-        self._objective_sum = zero
+        self._objective_sum = self.dtypes["objective"](0.0)
 
     def _stats_update(self, new_objective_sum, new_best_index):
         """Updates statistics based on a new sum of objective values
         (new_objective_sum) and the index of a potential new best elite
         (new_best_index)."""
         self._objective_sum = new_objective_sum
-        new_qd_score = (self._objective_sum -
-                        np_scalar(len(self), dtype=self.dtypes["objective"]) *
-                        self._qd_score_offset)
+        new_qd_score = (
+            self._objective_sum -
+            self.dtypes["objective"](len(self)) * self._qd_score_offset)
 
         _, new_best_elite = self._store.retrieve([new_best_index])
 
@@ -324,14 +320,11 @@ class GridArchive(ArchiveBase):
 
         self._stats = ArchiveStats(
             num_elites=len(self),
-            coverage=np_scalar(len(self) / self.cells,
-                               dtype=self.dtypes["objective"]),
+            coverage=self.dtypes["objective"](len(self) / self.cells),
             qd_score=new_qd_score,
-            norm_qd_score=np_scalar(new_qd_score / self.cells,
-                                    dtype=self.dtypes["objective"]),
+            norm_qd_score=self.dtypes["objective"](new_qd_score / self.cells),
             obj_max=new_obj_max,
-            obj_mean=np_scalar(self._objective_sum / len(self),
-                               dtype=self.dtypes["objective"]),
+            obj_mean=self.dtypes["objective"](self._objective_sum / len(self)),
         )
 
     def index_of(self, measures):
@@ -482,7 +475,7 @@ class GridArchive(ArchiveBase):
         # -np.inf. This is because the case with threshold_min = -np.inf is
         # handled separately since we compute the new threshold based on the max
         # objective in each cell in that case.
-        ratio = np_scalar(1.0 - learning_rate, dtype=dtype)**objective_sizes
+        ratio = dtype(1.0 - learning_rate)**objective_sizes
         new_threshold = (ratio * cur_threshold +
                          (objective_sums / objective_sizes) * (1 - ratio))
 
@@ -621,7 +614,7 @@ class GridArchive(ArchiveBase):
         # If threshold_min is -inf, then we want CMA-ME behavior, which computes
         # the improvement value of new solutions w.r.t zero. Otherwise, we
         # compute improvement with respect to threshold_min.
-        cur_threshold[is_new] = (np_scalar(0.0, dtype=self.dtypes["threshold"])
+        cur_threshold[is_new] = (self.dtypes["threshold"](0.0)
                                  if self.threshold_min == -np.inf else
                                  self.threshold_min)
         add_info["value"] = data["objective"] - cur_threshold
@@ -756,9 +749,8 @@ class GridArchive(ArchiveBase):
             # If threshold_min is -inf, then we want CMA-ME behavior, which
             # computes the improvement value with a threshold of zero for new
             # solutions. Otherwise, we will set cur_threshold to threshold_min.
-            cur_threshold = (np_scalar(0.0, dtype=self.dtypes["threshold"])
-                             if self.threshold_min == -np.inf else
-                             self.threshold_min)
+            cur_threshold = (self.dtypes["threshold"](0.0) if self.threshold_min
+                             == -np.inf else self.threshold_min)
 
         # Retrieve candidate objective.
         objective = data["objective"]
@@ -804,8 +796,8 @@ class GridArchive(ArchiveBase):
             })
 
             # Update stats.
-            cur_objective = (cur_data["objective"] if cur_occupied else
-                             np_scalar(0.0, self.dtypes["objective"]))
+            cur_objective = (cur_data["objective"]
+                             if cur_occupied else self.dtypes["objective"](0.0))
             self._stats_update(self._objective_sum + objective - cur_objective,
                                index)
 

--- a/ribs/archives/_proximity_archive.py
+++ b/ribs/archives/_proximity_archive.py
@@ -4,8 +4,7 @@ from numpy_groupies import aggregate_nb as aggregate
 from scipy.spatial import cKDTree
 
 from ribs._utils import (check_batch_shape, check_finite, check_is_1d,
-                         check_shape, np_scalar, validate_batch,
-                         validate_single)
+                         check_shape, validate_batch, validate_single)
 from ribs.archives._archive_base import ArchiveBase
 from ribs.archives._archive_stats import ArchiveStats
 from ribs.archives._array_store import ArrayStore
@@ -164,13 +163,11 @@ class ProximityArchive(ArchiveBase):
 
         # Set up constant properties.
         self._k_neighbors = int(k_neighbors)
-        self._novelty_threshold = np_scalar(novelty_threshold,
-                                            dtype=self.dtypes["measures"])
+        self._novelty_threshold = self.dtypes["measures"](novelty_threshold)
         self._local_competition = local_competition
         self._ckdtree_kwargs = ({} if ckdtree_kwargs is None else
                                 ckdtree_kwargs.copy())
-        self._qd_score_offset = np_scalar(qd_score_offset,
-                                          self.dtypes["objective"])
+        self._qd_score_offset = self.dtypes["objective"](qd_score_offset)
 
         # Set up k-D tree with current measures in the archive. Updated on
         # add().
@@ -262,27 +259,25 @@ class ProximityArchive(ArchiveBase):
 
     def _stats_reset(self):
         """Resets the archive stats."""
-        zero = np_scalar(0.0, dtype=self.dtypes["objective"])
-
         self._stats = ArchiveStats(
             num_elites=0,
-            coverage=zero,
-            qd_score=zero,
-            norm_qd_score=zero,
+            coverage=self.dtypes["objective"](0.0),
+            qd_score=self.dtypes["objective"](0.0),
+            norm_qd_score=self.dtypes["objective"](0.0),
             obj_max=None,
             obj_mean=None,
         )
         self._best_elite = None
-        self._objective_sum = zero
+        self._objective_sum = self.dtypes["objective"](0.0)
 
     def _stats_update(self, new_objective_sum, new_best_index):
         """Updates statistics based on a new sum of objective values
         (new_objective_sum) and the index of a potential new best elite
         (new_best_index)."""
         self._objective_sum = new_objective_sum
-        new_qd_score = (self._objective_sum -
-                        np_scalar(len(self), dtype=self.dtypes["objective"]) *
-                        self._qd_score_offset)
+        new_qd_score = (
+            self._objective_sum -
+            self.dtypes["objective"](len(self)) * self._qd_score_offset)
 
         _, new_best_elite = self._store.retrieve([new_best_index])
 
@@ -298,14 +293,11 @@ class ProximityArchive(ArchiveBase):
 
         self._stats = ArchiveStats(
             num_elites=len(self),
-            coverage=np_scalar(len(self) / self.cells,
-                               dtype=self.dtypes["objective"]),
+            coverage=self.dtypes["objective"](len(self) / self.cells),
             qd_score=new_qd_score,
-            norm_qd_score=np_scalar(new_qd_score / self.cells,
-                                    dtype=self.dtypes["objective"]),
+            norm_qd_score=self.dtypes["objective"](new_qd_score / self.cells),
             obj_max=new_obj_max,
-            obj_mean=np_scalar(self._objective_sum / len(self),
-                               dtype=self.dtypes["objective"]),
+            obj_mean=self.dtypes["objective"](self._objective_sum / len(self)),
         )
 
     def index_of(self, measures) -> np.ndarray:

--- a/ribs/archives/_utils.py
+++ b/ribs/archives/_utils.py
@@ -16,6 +16,11 @@ def parse_dtype(dtype):
                              "'objective', and 'measures' keys.")
         dtype_dict = dtype
     else:
+        if dtype not in ["f", np.float32, "d", np.float64]:
+            raise ValueError(
+                'Unsupported dtype. Must be np.float32 or np.float64, or dict '
+                '{"solution": <dtype>, "objective": <dtype>, '
+                '"measures": <dtype>}')
         dtype_dict = {
             "solution": dtype,
             "objective": dtype,

--- a/ribs/archives/_utils.py
+++ b/ribs/archives/_utils.py
@@ -1,33 +1,32 @@
 """Utilities specific to archives."""
 import numpy as np
 
-from ribs._utils import np_scalar
-
 
 def parse_dtype(dtype):
-    """Parses dtypes for the archive."""
-    # Convert str dtypes to np.dtype.
-    if isinstance(dtype, str):
-        dtype = np.dtype(dtype)
+    """Parses dtypes for the archive.
 
-    # np.dtype is not np.float32 or np.float64, but it compares equal.
-    if dtype in [np.float32, np.float64]:
-        return {
-            "solution": dtype,
-            "objective": dtype,
-            "measures": dtype,
-        }
-    elif isinstance(dtype, dict):
+    At the end, all dtypes will be scalar types like np.float32 or np.float64 --
+    note that this is different from the numpy.dtype like np.dtype("f"). See
+    here: https://numpy.org/doc/stable/reference/arrays.dtypes.html
+    """
+    if isinstance(dtype, dict):
         if ("solution" not in dtype or "objective" not in dtype or
                 "measures" not in dtype):
             raise ValueError("If dtype is a dict, it must contain 'solution',"
                              "'objective', and 'measures' keys.")
-        return dtype
+        dtype_dict = dtype
     else:
-        raise ValueError(
-            'Unsupported dtype. Must be np.float32 or np.float64, '
-            'or dict of the form '
-            '{"solution": <dtype>, "objective": <dtype>, "measures": <dtype>}')
+        dtype_dict = {
+            "solution": dtype,
+            "objective": dtype,
+            "measures": dtype,
+        }
+
+    # Cast everything to scalar types, including string abbreviations like "f".
+    for key in dtype_dict:
+        dtype_dict[key] = np.dtype(dtype_dict[key]).type
+
+    return dtype_dict
 
 
 def validate_cma_mae_settings(learning_rate, threshold_min, dtype):
@@ -44,8 +43,8 @@ def validate_cma_mae_settings(learning_rate, threshold_min, dtype):
     if threshold_min == -np.inf and learning_rate != 1.0:
         raise ValueError("threshold_min can only be -np.inf if "
                          "learning_rate is 1.0")
-    learning_rate = np_scalar(learning_rate, dtype)
-    threshold_min = np_scalar(threshold_min, dtype)
+    learning_rate = dtype(learning_rate)
+    threshold_min = dtype(threshold_min)
     return learning_rate, threshold_min
 
 

--- a/ribs/emitters/_gradient_operator_emitter.py
+++ b/ribs/emitters/_gradient_operator_emitter.py
@@ -3,8 +3,7 @@ import numbers
 
 import numpy as np
 
-from ribs._utils import (check_batch_shape, check_shape, np_scalar,
-                         validate_batch)
+from ribs._utils import check_batch_shape, check_shape, validate_batch
 from ribs.emitters._emitter_base import EmitterBase
 
 
@@ -102,6 +101,7 @@ class GradientOperatorEmitter(EmitterBase):
 
     def __init__(self,
                  archive,
+                 *,
                  sigma,
                  sigma_g,
                  initial_solutions=None,
@@ -141,10 +141,9 @@ class GradientOperatorEmitter(EmitterBase):
                               archive.solution_dim, "archive.solution_dim")
 
         self._rng = np.random.default_rng(seed)
-        self._sigma = np_scalar(sigma,
-                                dtype=archive.dtypes["solution"]) if isinstance(
-                                    sigma, numbers.Real) else np.array(sigma)
-        self._sigma_g = np_scalar(sigma_g, dtype=archive.dtypes["solution"])
+        self._sigma = archive.dtypes["solution"](sigma) if isinstance(
+            sigma, numbers.Real) else np.array(sigma)
+        self._sigma_g = archive.dtypes["solution"](sigma_g)
         self._line_sigma = line_sigma
         self._use_isolinedd = operator_type != 'isotropic'
         self._measure_gradients = measure_gradients

--- a/ribs/emitters/_iso_line_emitter.py
+++ b/ribs/emitters/_iso_line_emitter.py
@@ -1,7 +1,7 @@
 """Provides the IsoLineEmitter."""
 import numpy as np
 
-from ribs._utils import check_batch_shape, check_shape, np_scalar
+from ribs._utils import check_batch_shape, check_shape
 from ribs.emitters._emitter_base import EmitterBase
 
 
@@ -70,8 +70,8 @@ class IsoLineEmitter(EmitterBase):
 
         self._rng = np.random.default_rng(seed)
         self._batch_size = batch_size
-        self._iso_sigma = np_scalar(iso_sigma, dtype=archive.dtypes["solution"])
-        self._line_sigma = np_scalar(line_sigma, archive.dtypes["solution"])
+        self._iso_sigma = archive.dtypes["solution"](iso_sigma)
+        self._line_sigma = archive.dtypes["solution"](line_sigma)
         self._x0 = None
         self._initial_solutions = None
 

--- a/tests/archives/archive_base_test.py
+++ b/tests/archives/archive_base_test.py
@@ -42,7 +42,7 @@ def test_dict_dtype():
         },
     )
 
-    assert archive.dtypes["solution"] == object
+    assert archive.dtypes["solution"] == np.dtype(object)
     assert archive.dtypes["objective"] == np.float32
     assert archive.dtypes["measures"] == np.float32
     assert archive.dtypes["threshold"] == np.float32


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the PR's purpose here. -->

Previously, we had a very roundabout way of creating numpy scalars with the `np_scalar` function. Instead, we can just make the archive dtypes always be scalar types -- see https://numpy.org/doc/stable/reference/arrays.dtypes.html and https://numpy.org/doc/stable/reference/arrays.scalars.html#arrays-scalars-built-in; note that scalar types differ from numpy dtypes. Since the archive dtypes are always scalar types, we can just call them on scalars to create new numpy scalars.

## TODO

<!-- Notable points that this PR has either accomplished or will accomplish. -->

- [x] Make ArrayStore dtypes always be scalar types so that we can call them on scalars
- [x] Remove `np_scalar`
- [x] Remove calls to `np_scalar`

## Status

- [x] I have read the guidelines in
      [CONTRIBUTING.md](https://github.com/icaros-usc/pyribs/blob/master/CONTRIBUTING.md)
- [x] I have formatted my code using `yapf`
- [x] I have tested my code by running `pytest`
- [x] I have linted my code with `pylint`
- [x] I have added a one-line description of my change to the changelog in
      `HISTORY.md`
- [x] This PR is ready to go
