### PR TITLE
Tidy up stats calculations in archives

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -54,7 +54,7 @@
 - Remove `np_scalar` util by making archive dtypes be numpy scalar types
   ({pr}`534`)
 - Refactor archives into single-file implementations ({pr}`518`, {pr}`521`,
-  {pr}`526`, {pr}`528`, {pr}`529`, {pr}`530`, {pr}`533`)
+  {pr}`526`, {pr}`528`, {pr}`529`, {pr}`530`, {pr}`533`, {pr}`535`)
 - Make ArrayStore.data return ArchiveDataFrame instead of DataFrame ({pr}`522`)
 - Migrate to pyproject.toml ({pr}`514`)
 - Set vmin and vmax to None if archive is empty in ribs.visualize ({pr}`513`,

--- a/ribs/archives/_cvt_archive.py
+++ b/ribs/archives/_cvt_archive.py
@@ -874,7 +874,7 @@ class CVTArchive(ArchiveBase):
             })
 
             # Update stats.
-            cur_objective = (cur_data["objective"]
+            cur_objective = (cur_data["objective"][0]
                              if cur_occupied else self.dtypes["objective"](0.0))
             self._stats_update(self._objective_sum + objective - cur_objective,
                                index)

--- a/ribs/archives/_cvt_archive.py
+++ b/ribs/archives/_cvt_archive.py
@@ -199,12 +199,11 @@ class CVTArchive(ArchiveBase):
             learning_rate, threshold_min, self.dtypes["threshold"])
         self._qd_score_offset = self.dtypes["objective"](qd_score_offset)
 
-        # Set up statistics.
-        self._stats = None
+        # Set up statistics -- objective_sum is the sum of all objective values
+        # in the archive; it is useful for computing qd_score and obj_mean.
         self._best_elite = None
-        # Sum of all objective values in the archive; useful for computing
-        # qd_score and obj_mean.
         self._objective_sum = None
+        self._stats = None
         self._stats_reset()
 
         # Apply default args for k-means. Users can easily override these,
@@ -405,6 +404,8 @@ class CVTArchive(ArchiveBase):
 
     def _stats_reset(self):
         """Resets the archive stats."""
+        self._best_elite = None
+        self._objective_sum = self.dtypes["objective"](0.0)
         self._stats = ArchiveStats(
             num_elites=0,
             coverage=self.dtypes["objective"](0.0),
@@ -413,30 +414,25 @@ class CVTArchive(ArchiveBase):
             obj_max=None,
             obj_mean=None,
         )
-        self._best_elite = None
-        self._objective_sum = self.dtypes["objective"](0.0)
 
     def _stats_update(self, new_objective_sum, new_best_index):
         """Updates statistics based on a new sum of objective values
         (new_objective_sum) and the index of a potential new best elite
         (new_best_index)."""
+        _, new_best_elite = self._store.retrieve([new_best_index])
+        new_best_elite = {k: v[0] for k, v in new_best_elite.items()}
+
+        if (self._stats.obj_max is None or
+                new_best_elite["objective"] > self._stats.obj_max):
+            self._best_elite = new_best_elite
+            new_obj_max = new_best_elite["objective"]
+        else:
+            new_obj_max = self._stats.obj_max
+
         self._objective_sum = new_objective_sum
         new_qd_score = (
             self._objective_sum -
             self.dtypes["objective"](len(self)) * self._qd_score_offset)
-
-        _, new_best_elite = self._store.retrieve([new_best_index])
-
-        if (self._stats.obj_max is None or
-                new_best_elite["objective"] > self._stats.obj_max):
-            # Convert batched values to single values.
-            new_best_elite = {k: v[0] for k, v in new_best_elite.items()}
-
-            new_obj_max = new_best_elite["objective"]
-            self._best_elite = new_best_elite
-        else:
-            new_obj_max = self._stats.obj_max
-
         self._stats = ArchiveStats(
             num_elites=len(self),
             coverage=self.dtypes["objective"](len(self) / self.cells),

--- a/ribs/archives/_grid_archive.py
+++ b/ribs/archives/_grid_archive.py
@@ -792,7 +792,7 @@ class GridArchive(ArchiveBase):
             })
 
             # Update stats.
-            cur_objective = (cur_data["objective"]
+            cur_objective = (cur_data["objective"][0]
                              if cur_occupied else self.dtypes["objective"](0.0))
             self._stats_update(self._objective_sum + objective - cur_objective,
                                index)

--- a/ribs/archives/_proximity_archive.py
+++ b/ribs/archives/_proximity_archive.py
@@ -174,12 +174,11 @@ class ProximityArchive(ArchiveBase):
         self._cur_kd_tree = cKDTree(self._store.data("measures"),
                                     **self._ckdtree_kwargs)
 
-        # Set up statistics.
-        self._stats = None
+        # Set up statistics -- objective_sum is the sum of all objective values
+        # in the archive; it is useful for computing qd_score and obj_mean.
         self._best_elite = None
-        # Sum of all objective values in the archive; useful for computing
-        # qd_score and obj_mean.
         self._objective_sum = None
+        self._stats = None
         self._stats_reset()
 
     ## Properties inherited from ArchiveBase ##
@@ -259,6 +258,8 @@ class ProximityArchive(ArchiveBase):
 
     def _stats_reset(self):
         """Resets the archive stats."""
+        self._best_elite = None
+        self._objective_sum = self.dtypes["objective"](0.0)
         self._stats = ArchiveStats(
             num_elites=0,
             coverage=self.dtypes["objective"](0.0),
@@ -267,30 +268,25 @@ class ProximityArchive(ArchiveBase):
             obj_max=None,
             obj_mean=None,
         )
-        self._best_elite = None
-        self._objective_sum = self.dtypes["objective"](0.0)
 
     def _stats_update(self, new_objective_sum, new_best_index):
         """Updates statistics based on a new sum of objective values
         (new_objective_sum) and the index of a potential new best elite
         (new_best_index)."""
+        _, new_best_elite = self._store.retrieve([new_best_index])
+        new_best_elite = {k: v[0] for k, v in new_best_elite.items()}
+
+        if (self._stats.obj_max is None or
+                new_best_elite["objective"] > self._stats.obj_max):
+            self._best_elite = new_best_elite
+            new_obj_max = new_best_elite["objective"]
+        else:
+            new_obj_max = self._stats.obj_max
+
         self._objective_sum = new_objective_sum
         new_qd_score = (
             self._objective_sum -
             self.dtypes["objective"](len(self)) * self._qd_score_offset)
-
-        _, new_best_elite = self._store.retrieve([new_best_index])
-
-        if (self._stats.obj_max is None or
-                new_best_elite["objective"] > self._stats.obj_max):
-            # Convert batched values to single values.
-            new_best_elite = {k: v[0] for k, v in new_best_elite.items()}
-
-            new_obj_max = new_best_elite["objective"]
-            self._best_elite = new_best_elite
-        else:
-            new_obj_max = self._stats.obj_max
-
         self._stats = ArchiveStats(
             num_elites=len(self),
             coverage=self.dtypes["objective"](len(self) / self.cells),

--- a/ribs/archives/_sliding_boundaries_archive.py
+++ b/ribs/archives/_sliding_boundaries_archive.py
@@ -228,12 +228,11 @@ class SlidingBoundariesArchive(ArchiveBase):
         # Total number of solutions encountered.
         self._total_num_sol = 0
 
-        # Set up statistics.
-        self._stats = None
+        # Set up statistics -- objective_sum is the sum of all objective values
+        # in the archive; it is useful for computing qd_score and obj_mean.
         self._best_elite = None
-        # Sum of all objective values in the archive; useful for computing
-        # qd_score and obj_mean.
         self._objective_sum = None
+        self._stats = None
         self._stats_reset()
 
     ## Properties inherited from ArchiveBase ##
@@ -342,6 +341,8 @@ class SlidingBoundariesArchive(ArchiveBase):
 
     def _stats_reset(self):
         """Resets the archive stats."""
+        self._best_elite = None
+        self._objective_sum = self.dtypes["objective"](0.0)
         self._stats = ArchiveStats(
             num_elites=0,
             coverage=self.dtypes["objective"](0.0),
@@ -350,30 +351,25 @@ class SlidingBoundariesArchive(ArchiveBase):
             obj_max=None,
             obj_mean=None,
         )
-        self._best_elite = None
-        self._objective_sum = self.dtypes["objective"](0.0)
 
     def _stats_update(self, new_objective_sum, new_best_index):
         """Updates statistics based on a new sum of objective values
         (new_objective_sum) and the index of a potential new best elite
         (new_best_index)."""
+        _, new_best_elite = self._store.retrieve([new_best_index])
+        new_best_elite = {k: v[0] for k, v in new_best_elite.items()}
+
+        if (self._stats.obj_max is None or
+                new_best_elite["objective"] > self._stats.obj_max):
+            self._best_elite = new_best_elite
+            new_obj_max = new_best_elite["objective"]
+        else:
+            new_obj_max = self._stats.obj_max
+
         self._objective_sum = new_objective_sum
         new_qd_score = (
             self._objective_sum -
             self.dtypes["objective"](len(self)) * self._qd_score_offset)
-
-        _, new_best_elite = self._store.retrieve([new_best_index])
-
-        if (self._stats.obj_max is None or
-                new_best_elite["objective"] > self._stats.obj_max):
-            # Convert batched values to single values.
-            new_best_elite = {k: v[0] for k, v in new_best_elite.items()}
-
-            new_obj_max = new_best_elite["objective"]
-            self._best_elite = new_best_elite
-        else:
-            new_obj_max = self._stats.obj_max
-
         self._stats = ArchiveStats(
             num_elites=len(self),
             coverage=self.dtypes["objective"](len(self) / self.cells),


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the PR's purpose here. -->

Just rearranged some things so that the stats calculations are always done in the same order: best_elite, objective_sum, stats.

## Status

- [x] I have read the guidelines in
      [CONTRIBUTING.md](https://github.com/icaros-usc/pyribs/blob/master/CONTRIBUTING.md)
- [x] I have formatted my code using `yapf`
- [x] I have tested my code by running `pytest`
- [x] I have linted my code with `pylint`
- [x] I have added a one-line description of my change to the changelog in
      `HISTORY.md`
- [x] This PR is ready to go
