### PR TITLE
Rearrange methods to be more consistent with ArchiveBase

### DIFF
--- a/ribs/archives/_archive_base.py
+++ b/ribs/archives/_archive_base.py
@@ -42,19 +42,6 @@ class ArchiveBase(ABC):
     ## Properties of the archive ##
 
     @property
-    def field_list(self):
-        """list: List of data fields in the archive."""
-        raise NotImplementedError(
-            "`field_list` has not been implemented in this archive")
-
-    @property
-    def dtypes(self):
-        """dict: Mapping from field name to dtype for all fields in the
-        archive."""
-        raise NotImplementedError(
-            "`dtypes` has not been implemented in this archive")
-
-    @property
     def solution_dim(self):
         """int: Dimensionality of the solution space."""
         return self._solution_dim
@@ -71,6 +58,19 @@ class ArchiveBase(ABC):
     def measure_dim(self):
         """int: Dimensionality of the measure space."""
         return self._measure_dim
+
+    @property
+    def field_list(self):
+        """list: List of data fields in the archive."""
+        raise NotImplementedError(
+            "`field_list` has not been implemented in this archive")
+
+    @property
+    def dtypes(self):
+        """dict: Mapping from field name to dtype for all fields in the
+        archive."""
+        raise NotImplementedError(
+            "`dtypes` has not been implemented in this archive")
 
     @property
     def stats(self):

--- a/ribs/archives/_cvt_archive.py
+++ b/ribs/archives/_cvt_archive.py
@@ -18,8 +18,7 @@ from ribs.archives._utils import (fill_sentinel_values, parse_dtype,
 
 class CVTArchive(ArchiveBase):
     # pylint: disable = too-many-public-methods
-    """An archive that divides the entire measure space into a fixed number of
-    cells.
+    """An archive that tessellates the measure space with centroids.
 
     This archive originates in `Vassiliades 2018
     <https://ieeexplore.ieee.org/document/8000667>`_. It uses Centroidal Voronoi
@@ -301,16 +300,16 @@ class CVTArchive(ArchiveBase):
         return self._store.field_list_with_index
 
     @property
+    def dtypes(self):
+        return self._store.dtypes_with_index
+
+    @property
     def stats(self):
         return self._stats
 
     @property
     def empty(self):
         return len(self._store) == 0
-
-    @property
-    def dtypes(self):
-        return self._store.dtypes_with_index
 
     ## Properties that are not in ArchiveBase ##
     ## Roughly ordered by the parameter list in the constructor. ##

--- a/ribs/archives/_grid_archive.py
+++ b/ribs/archives/_grid_archive.py
@@ -169,16 +169,16 @@ class GridArchive(ArchiveBase):
         return self._store.field_list_with_index
 
     @property
+    def dtypes(self):
+        return self._store.dtypes_with_index
+
+    @property
     def stats(self):
         return self._stats
 
     @property
     def empty(self):
         return len(self._store) == 0
-
-    @property
-    def dtypes(self):
-        return self._store.dtypes_with_index
 
     ## Properties that are not in ArchiveBase ##
     ## Roughly ordered by the parameter list in the constructor. ##

--- a/ribs/archives/_proximity_archive.py
+++ b/ribs/archives/_proximity_archive.py
@@ -187,16 +187,16 @@ class ProximityArchive(ArchiveBase):
         return self._store.field_list_with_index
 
     @property
+    def dtypes(self):
+        return self._store.dtypes_with_index
+
+    @property
     def stats(self):
         return self._stats
 
     @property
     def empty(self):
         return len(self._store) == 0
-
-    @property
-    def dtypes(self):
-        return self._store.dtypes_with_index
 
     ## Properties that are not in ArchiveBase ##
     ## Roughly ordered by the parameter list in the constructor. ##

--- a/ribs/archives/_sliding_boundaries_archive.py
+++ b/ribs/archives/_sliding_boundaries_archive.py
@@ -241,16 +241,16 @@ class SlidingBoundariesArchive(ArchiveBase):
         return self._store.field_list_with_index
 
     @property
+    def dtypes(self):
+        return self._store.dtypes_with_index
+
+    @property
     def stats(self):
         return self._stats
 
     @property
     def empty(self):
         return len(self._store) == 0
-
-    @property
-    def dtypes(self):
-        return self._store.dtypes_with_index
 
     ## Properties that are not in ArchiveBase ##
     ## Roughly ordered by the parameter list in the constructor. ##


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the PR's purpose here. -->

Shuffled around `field_list` and `dtype` to have same order as in ArchiveBase

## Status

- [x] I have read the guidelines in
      [CONTRIBUTING.md](https://github.com/icaros-usc/pyribs/blob/master/CONTRIBUTING.md)
- [x] I have formatted my code using `yapf`
- [x] I have tested my code by running `pytest`
- [x] I have linted my code with `pylint`
- [N/A] I have added a one-line description of my change to the changelog in
      `HISTORY.md`
- [x] This PR is ready to go
