### PR TITLE
Add kde_sklearn option to DensityArchive

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -21,7 +21,7 @@
 - **Backwards-incompatible:** BanditScheduler: Add emitter_pool and active attr;
   remove emitters attr ({pr}`494`)
 - Add DensityArchive and DensityRanker for Density Descent Search ({pr}`483`,
-  {pr}`504`, {pr}`487`)
+  {pr}`504`, {pr}`487`, {pr}`543`)
 - Add NoveltyRanker for novelty search ({pr}`477`)
 - Add proximity_archive_plot for visualizing ProximityArchive ({pr}`476`,
   {pr}`480`, {pr}`523`)

--- a/ribs/archives/_density_archive.py
+++ b/ribs/archives/_density_archive.py
@@ -177,12 +177,11 @@ class DensityArchive(ArchiveBase):
         elif self._density_method == "kde_sklearn":
             if self.buffer.shape[0] == 0:
                 return np.zeros(measures.shape[0], dtype=measures.dtype)
+            # Note that this is log density with some normalization too.
             kde = KernelDensity(
                 bandwidth=self._bandwidth,
                 **self._sklearn_kwargs,
-            ).fit(
-                self.buffer
-            )  # Note that this is log density with some normalization added on.
+            ).fit(self.buffer)
             return kde.score_samples(measures).astype(self._measure_dtype)
         else:
             raise ValueError(f"Unknown density_method '{self._density_method}'")

--- a/ribs/archives/_density_archive.py
+++ b/ribs/archives/_density_archive.py
@@ -72,7 +72,9 @@ class DensityArchive(ArchiveBase):
         buffer_size (int): Size of the buffer of measures.
         density_method (str): Method for computing density. Currently supports
             ``"kde"`` (KDE -- kernel density estimator), ``"kde_sklearn"`` (KDE
-            using :class:`sklearn.neighbors.KernelDensity`).
+            using :class:`sklearn.neighbors.KernelDensity`). Note that when
+            ``"kde_sklearn"`` is used, this archive computes *log density*; see
+            :meth:`sklearn.neighbors.KernelDensity.score_samples` for more info.
         bandwidth (float): Bandwidth when using ``kde`` or ``kde_sklearn`` as
             the ``density_method``.
         sklearn_kwargs (dict): kwargs for
@@ -178,7 +180,9 @@ class DensityArchive(ArchiveBase):
             kde = KernelDensity(
                 bandwidth=self._bandwidth,
                 **self._sklearn_kwargs,
-            ).fit(self.buffer)
+            ).fit(
+                self.buffer
+            )  # Note that this is log density with some normalization added on.
             return kde.score_samples(measures).astype(self._measure_dtype)
         else:
             raise ValueError(f"Unknown density_method '{self._density_method}'")
@@ -221,7 +225,11 @@ class DensityArchive(ArchiveBase):
 
             - ``"density"`` (:class:`numpy.ndarray` of the dtype passed in at
               init): The density values of the measure passed in, before the
-              buffer or density estimator was updated.
+              buffer or density estimator was updated. Note that when
+              ``"kde_sklearn"`` is used as the ``density_method``, *log density*
+              is computed; see
+              :meth:`sklearn.neighbors.KernelDensity.score_samples` for more
+              info.
 
         Raises:
             ValueError: The array arguments do not match their specified shapes.

--- a/ribs/archives/_density_archive.py
+++ b/ribs/archives/_density_archive.py
@@ -1,6 +1,7 @@
 """Contains the DensityArchive."""
 import numpy as np
 from scipy.spatial.distance import cdist
+from sklearn.neighbors import KernelDensity
 
 from ribs._utils import check_batch_shape, check_finite, readonly
 from ribs.archives._archive_base import ArchiveBase
@@ -70,9 +71,14 @@ class DensityArchive(ArchiveBase):
         measure_dim (int): Dimension of the measure space.
         buffer_size (int): Size of the buffer of measures.
         density_method (str): Method for computing density. Currently supports
-            ``"kde"`` (KDE -- kernel density estimator).
-        bandwidth (float): Bandwidth when using ``kde`` as the density
-            estimator.
+            ``"kde"`` (KDE -- kernel density estimator), ``"kde_sklearn"`` (KDE
+            using :class:`sklearn.neighbors.KernelDensity`).
+        bandwidth (float): Bandwidth when using ``kde`` or ``kde_sklearn`` as
+            the ``density_method``.
+        sklearn_kwargs (dict): kwargs for
+            :class:`sklearn.neighbors.KernelDensity` when using
+            ``"kde_sklearn"`` as the ``density_method``. Note that bandwidth is
+            already passed in via the ``bandwidth`` parameter above.
         seed (int): Value to seed the random number generator. Set to None to
             avoid a fixed seed.
         dtype (str or data-type or dict): Data type of the measures.
@@ -91,6 +97,7 @@ class DensityArchive(ArchiveBase):
         buffer_size=10000,
         density_method="kde",
         bandwidth=None,
+        sklearn_kwargs=None,
         seed=None,
         dtype=np.float64,
     ):
@@ -120,6 +127,10 @@ class DensityArchive(ArchiveBase):
         if self._density_method == "kde":
             # Kernel density estimation
             self._bandwidth = bandwidth
+        elif self._density_method == "kde_sklearn":
+            self._bandwidth = bandwidth
+            self._sklearn_kwargs = ({} if sklearn_kwargs is None else
+                                    sklearn_kwargs.copy())
         else:
             raise ValueError(f"Unknown density_method '{self._density_method}'")
 
@@ -161,6 +172,14 @@ class DensityArchive(ArchiveBase):
                 self.buffer,
                 self._bandwidth,
             ).astype(self._measure_dtype)
+        elif self._density_method == "kde_sklearn":
+            if self.buffer.shape[0] == 0:
+                return np.zeros(measures.shape[0], dtype=measures.dtype)
+            kde = KernelDensity(
+                bandwidth=self._bandwidth,
+                **self._sklearn_kwargs,
+            ).fit(self.buffer)
+            return kde.score_samples(measures).astype(self._measure_dtype)
         else:
             raise ValueError(f"Unknown density_method '{self._density_method}'")
 

--- a/tests/archives/density_archive_test.py
+++ b/tests/archives/density_archive_test.py
@@ -23,11 +23,12 @@ def test_add_to_buffer():
     assert np.all(archive.buffer == np.arange(10).reshape((5, 2)))
 
 
-def test_initial_density():
+@pytest.mark.parametrize("density_method", ["kde", "kde_sklearn"])
+def test_initial_density(density_method):
     archive = DensityArchive(
         measure_dim=2,
         buffer_size=10000,
-        density_method="kde",
+        density_method=density_method,
         bandwidth=2.0,
     )
 
@@ -39,13 +40,14 @@ def test_initial_density():
     assert_allclose(add_info["density"], np.zeros(5))
 
 
+@pytest.mark.parametrize("density_method", ["kde", "kde_sklearn"])
 @pytest.mark.parametrize("dtype", [np.float64, np.float32],
                          ids=["float64", "float32"])
-def test_density_dtype(dtype):
+def test_density_dtype(density_method, dtype):
     archive = DensityArchive(
         measure_dim=2,
         buffer_size=10000,
-        density_method="kde",
+        density_method=density_method,
         bandwidth=2.0,
         dtype=dtype,
     )
@@ -58,12 +60,15 @@ def test_density_dtype(dtype):
     assert density.dtype == dtype
 
 
-def test_density_after_add():
+# We only test actual density for `kde` since that is the one for which we know
+# the true value. `kde_sklearn` is a lot more complicated.
+@pytest.mark.parametrize("density_method", ["kde"])
+def test_density_after_add(density_method):
     bandwidth = 2.0
     archive = DensityArchive(
         measure_dim=2,
         buffer_size=10000,
-        density_method="kde",
+        density_method=density_method,
         bandwidth=bandwidth,
     )
 


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the PR's purpose here. -->

Support using sklearn's KernelDensity in DensityArchive to provide more flexible options for KDEs.

## TODO

<!-- Notable points that this PR has either accomplished or will accomplish. -->

- [x] Add `density_method=kde_sklearn` to DensityArchive
- [x] Add tests

## Status

- [x] I have read the guidelines in
      [CONTRIBUTING.md](https://github.com/icaros-usc/pyribs/blob/master/CONTRIBUTING.md)
- [x] I have formatted my code using `yapf`
- [x] I have tested my code by running `pytest`
- [x] I have linted my code with `pylint`
- [x] I have added a one-line description of my change to the changelog in
      `HISTORY.md`
- [x] This PR is ready to go
