### PR TITLE
Add DDS with kde_sklearn to sphere example

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -21,7 +21,7 @@
 - **Backwards-incompatible:** BanditScheduler: Add emitter_pool and active attr;
   remove emitters attr ({pr}`494`)
 - Add DensityArchive and DensityRanker for Density Descent Search ({pr}`483`,
-  {pr}`504`, {pr}`487`, {pr}`543`)
+  {pr}`504`, {pr}`487`, {pr}`543`, {pr}`546`)
 - Add NoveltyRanker for novelty search ({pr}`477`)
 - Add proximity_archive_plot for visualizing ProximityArchive ({pr}`476`,
   {pr}`480`, {pr}`523`)

--- a/examples/sphere.py
+++ b/examples/sphere.py
@@ -712,9 +712,51 @@ CONFIG = {
         "archive": {
             "class": DensityArchive,
             "kwargs": {
+                "buffer_size": 10000,
                 "density_method": "kde",
                 "bandwidth": 25.6,
+            }
+        },
+        "result_archive": {
+            "class": GridArchive,
+            "kwargs": {
+                "dims": (100, 100),
+            }
+        },
+        "emitters": [{
+            "class": EvolutionStrategyEmitter,
+            "kwargs": {
+                "sigma0": 1.5,
+                "ranker": "density",
+                "selection_rule": "mu",
+                "restart_rule": "basic",
+                "batch_size": 36
+            },
+            "num_emitters": 15
+        }],
+        "scheduler": {
+            "class": Scheduler,
+            "kwargs": {}
+        }
+    },
+    "dds_kde_sklearn": {
+        # Hyperparameters from DDS paper: https://arxiv.org/abs/2312.11331
+        "is_dqd": False,
+        # In DDS, the DensityArchive does not store any solutions, so emitters
+        # must use the result archive instead.
+        "pass_result_archive_to_emitters": True,
+        "archive": {
+            "class": DensityArchive,
+            "kwargs": {
+                # `density_method` and `sklearn_kwargs` are the only differences
+                # from the `dds` config above. `kde_sklearn` tends to be slower
+                # but it has more options available.
                 "buffer_size": 10000,
+                "density_method": "kde_sklearn",
+                "bandwidth": 25.6,
+                "sklearn_kwargs": {
+                    "kernel": "gaussian",
+                }
             }
         },
         "result_archive": {


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the PR's purpose here. -->

Add the version of DDS with `density_method="kde_sklearn"` to the sphere example.

## Status

- [x] I have read the guidelines in
      [CONTRIBUTING.md](https://github.com/icaros-usc/pyribs/blob/master/CONTRIBUTING.md)
- [x] I have formatted my code using `yapf`
- [x] I have tested my code by running `pytest`
- [x] I have linted my code with `pylint`
- [x] I have added a one-line description of my change to the changelog in
      `HISTORY.md`
- [x] This PR is ready to go
