### PR TITLE
Allow result_archive to be positional arg in schedulers

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -7,6 +7,8 @@
 #### API
 
 - Allow result_archive to be positional arg in schedulers ({pr}`557`)
+- **Backwards-incompatible:** Make `num_active` a keyword-only arg in
+  BanditScheduler ({pr}`557`)
 - Add CategoricalArchive ({pr}`549`)
 - Support solutions with non-1D shapes ({pr}`550`)
 - **Backwards-incompatible:** Move cqd_score into a separate function

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,7 +6,7 @@
 
 #### API
 
-- Allow result_archive to be positional arg in Scheduler ({pr}`557`)
+- Allow result_archive to be positional arg in schedulers ({pr}`557`)
 - Add CategoricalArchive ({pr}`549`)
 - Support solutions with non-1D shapes ({pr}`550`)
 - **Backwards-incompatible:** Move cqd_score into a separate function

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,6 +6,7 @@
 
 #### API
 
+- Allow result_archive to be positional arg in Scheduler ({pr}`557`)
 - Add CategoricalArchive ({pr}`549`)
 - Support solutions with non-1D shapes ({pr}`550`)
 - **Backwards-incompatible:** Move cqd_score into a separate function

--- a/examples/sphere.py
+++ b/examples/sphere.py
@@ -926,7 +926,7 @@ def create_scheduler(config, algorithm, seed=None):
     scheduler = config["scheduler"]["class"](
         archive,
         emitters,
-        result_archive=result_archive,
+        result_archive,
         **config["scheduler"]["kwargs"],
     )
 

--- a/ribs/schedulers/_bandit_scheduler.py
+++ b/ribs/schedulers/_bandit_scheduler.py
@@ -38,6 +38,10 @@ class BanditScheduler:
             select from, e.g. :class:`ribs.emitters.GaussianEmitter`. On the
             first iteration, the first `num_active` emitters from the
             emitter_pool will be activated.
+        result_archive (ribs.archives.ArchiveBase): In some algorithms, such as
+            CMA-MAE, the archive does not store all the best-performing
+            solutions. The ``result_archive`` is a secondary archive where we
+            can store all the best-performing solutions.
         num_active (int): The number of active emitters at a time. Active
             emitters are used when calling ask-tell.
         zeta (float): Hyperparamter of UCB1 that balances the trade-off between
@@ -57,10 +61,6 @@ class BanditScheduler:
             included for legacy reasons, as it was the only mode of operation
             in pyribs 0.4.0 and before. We highly recommend using "batch" mode
             since it is significantly faster.
-        result_archive (ribs.archives.ArchiveBase): In some algorithms, such as
-            CMA-MAE, the archive does not store all the best-performing
-            solutions. The ``result_archive`` is a secondary archive where we
-            can store all the best-performing solutions.
     Raises:
         TypeError: The ``emitter_pool`` argument was not a list of emitters.
         ValueError: Number of active emitters is less than one.
@@ -78,11 +78,11 @@ class BanditScheduler:
     def __init__(self,
                  archive,
                  emitter_pool,
-                 num_active,
+                 result_archive=None,
                  *,
+                 num_active,
                  reselect="terminated",
                  zeta=0.05,
-                 result_archive=None,
                  add_mode="batch"):
         if num_active < 1:
             raise ValueError("num_active cannot be less than 1.")

--- a/ribs/schedulers/_bayesian_opt_scheduler.py
+++ b/ribs/schedulers/_bayesian_opt_scheduler.py
@@ -17,6 +17,10 @@ class BayesianOptimizationScheduler(Scheduler):
         archive (ribs.archives.GridArchive): An archive object.
         emitters (list of ribs.emitters.BayesianOptimizationEmitter): A list of
             emitter objects.
+        result_archive (ribs.archives.ArchiveBase): In some algorithms, such as
+            CMA-MAE, the archive does not store all the best-performing
+            solutions. The ``result_archive`` is a secondary archive where we
+            can store all the best-performing solutions.
         add_mode (str): Indicates how solutions should be added to the archive.
             The default is "batch", which adds all solutions with one call to
             :meth:`~ribs.archives.ArchiveBase.add`. Alternatively, use "single"
@@ -25,10 +29,6 @@ class BayesianOptimizationScheduler(Scheduler):
             included for legacy reasons, as it was the only mode of operation in
             pyribs 0.4.0 and before. We highly recommend using "batch" mode
             since it is significantly faster.
-        result_archive (ribs.archives.ArchiveBase): In some algorithms, such as
-            CMA-MAE, the archive does not store all the best-performing
-            solutions. The ``result_archive`` is a secondary archive where we
-            can store all the best-performing solutions.
 
     Raises:
         TypeError: Some emitters are not BayesianOptimizationEmitter.
@@ -38,13 +38,10 @@ class BayesianOptimizationScheduler(Scheduler):
     def __init__(self,
                  archive,
                  emitters,
-                 *,
                  result_archive=None,
+                 *,
                  add_mode="batch"):
-        super().__init__(archive,
-                         emitters,
-                         result_archive=result_archive,
-                         add_mode=add_mode)
+        super().__init__(archive, emitters, result_archive, add_mode=add_mode)
 
         # Checks that all emitters are BayesianOptimizationEmitter and have the
         # same upscale schedule

--- a/ribs/schedulers/_scheduler.py
+++ b/ribs/schedulers/_scheduler.py
@@ -29,6 +29,10 @@ class Scheduler:
             selected from :mod:`ribs.archives`.
         emitters (list of ribs.archives.EmitterBase): A list of emitter objects,
             e.g. :class:`ribs.emitters.GaussianEmitter`.
+        result_archive (ribs.archives.ArchiveBase): In some algorithms, such as
+            CMA-MAE, the archive does not store all the best-performing
+            solutions. The ``result_archive`` is a secondary archive where we
+            can store all the best-performing solutions.
         add_mode (str): Indicates how solutions should be added to the archive.
             The default is "batch", which adds all solutions with one call to
             :meth:`~ribs.archives.ArchiveBase.add`. Alternatively, use "single"
@@ -37,10 +41,6 @@ class Scheduler:
             included for legacy reasons, as it was the only mode of operation in
             pyribs 0.4.0 and before. We highly recommend using "batch" mode
             since it is significantly faster.
-        result_archive (ribs.archives.ArchiveBase): In some algorithms, such as
-            CMA-MAE, the archive does not store all the best-performing
-            solutions. The ``result_archive`` is a secondary archive where we
-            can store all the best-performing solutions.
     Raises:
         TypeError: The ``emitters`` argument was not a list of emitters.
         ValueError: The emitters passed in do not have the same solution
@@ -56,8 +56,8 @@ class Scheduler:
     def __init__(self,
                  archive,
                  emitters,
-                 *,
                  result_archive=None,
+                 *,
                  add_mode="batch"):
         try:
             if len(emitters) == 0:

--- a/tests/schedulers/scheduler_test.py
+++ b/tests/schedulers/scheduler_test.py
@@ -49,7 +49,7 @@ def test_attributes(scheduler_type):
         assert scheduler.archive == archive
         assert scheduler.emitters == emitters
     else:
-        scheduler = BanditScheduler(archive, emitters, 1)
+        scheduler = BanditScheduler(archive, emitters, num_active=1)
 
         assert scheduler.archive == archive
         assert scheduler.emitter_pool == emitters
@@ -117,7 +117,7 @@ def test_warn_nothing_added_to_archive(scheduler_type):
     if scheduler_type == "Scheduler":
         scheduler = Scheduler(archive, emitters)
     else:
-        scheduler = BanditScheduler(archive, emitters, 1)
+        scheduler = BanditScheduler(archive, emitters, num_active=1)
 
     _ = scheduler.ask()
     with pytest.warns(UserWarning):
@@ -145,12 +145,10 @@ def test_warn_nothing_added_to_result_archive(scheduler_type):
     if scheduler_type == "Scheduler":
         scheduler = Scheduler(archive, emitters, result_archive)
     else:
-        scheduler = BanditScheduler(
-            archive,
-            emitters,
-            1,
-            result_archive=result_archive,
-        )
+        scheduler = BanditScheduler(archive,
+                                    emitters,
+                                    result_archive,
+                                    num_active=1)
 
     _ = scheduler.ask()
     with pytest.warns(UserWarning):
@@ -181,12 +179,10 @@ def test_result_archive_mismatch_fields(scheduler_type):
     if scheduler_type == "Scheduler":
         scheduler = Scheduler(archive, emitters, result_archive)
     else:
-        scheduler = BanditScheduler(
-            archive,
-            emitters,
-            1,
-            result_archive=result_archive,
-        )
+        scheduler = BanditScheduler(archive,
+                                    emitters,
+                                    result_archive,
+                                    num_active=1)
 
     scheduler.ask()
 
@@ -225,8 +221,8 @@ def test_result_archive_same_fields_with_threshold(scheduler_type):
         scheduler = BanditScheduler(
             archive,
             emitters,
-            1,
-            result_archive=result_archive,
+            result_archive,
+            num_active=1,
         )
 
     scheduler.ask()
@@ -329,7 +325,10 @@ def test_tell_with_none_objective(scheduler_type, add_mode):
     if scheduler_type == "Scheduler":
         scheduler = Scheduler(archive, emitters, add_mode=add_mode)
     else:
-        scheduler = BanditScheduler(archive, emitters, 1, add_mode=add_mode)
+        scheduler = BanditScheduler(archive,
+                                    emitters,
+                                    num_active=1,
+                                    add_mode=add_mode)
 
     solutions = scheduler.ask()
 

--- a/tests/schedulers/scheduler_test.py
+++ b/tests/schedulers/scheduler_test.py
@@ -143,11 +143,7 @@ def test_warn_nothing_added_to_result_archive(scheduler_type):
                                  learning_rate=1.0)
     emitters = [GaussianEmitter(archive, sigma=1, x0=[0.0, 0.0], batch_size=4)]
     if scheduler_type == "Scheduler":
-        scheduler = Scheduler(
-            archive,
-            emitters,
-            result_archive=result_archive,
-        )
+        scheduler = Scheduler(archive, emitters, result_archive)
     else:
         scheduler = BanditScheduler(
             archive,
@@ -183,11 +179,7 @@ def test_result_archive_mismatch_fields(scheduler_type):
     emitters = [GaussianEmitter(archive, sigma=1, x0=[0.0, 0.0], batch_size=4)]
 
     if scheduler_type == "Scheduler":
-        scheduler = Scheduler(
-            archive,
-            emitters,
-            result_archive=result_archive,
-        )
+        scheduler = Scheduler(archive, emitters, result_archive)
     else:
         scheduler = BanditScheduler(
             archive,
@@ -228,11 +220,7 @@ def test_result_archive_same_fields_with_threshold(scheduler_type):
     emitters = [GaussianEmitter(archive, sigma=1, x0=[0.0, 0.0], batch_size=4)]
 
     if scheduler_type == "Scheduler":
-        scheduler = Scheduler(
-            archive,
-            emitters,
-            result_archive=result_archive,
-        )
+        scheduler = Scheduler(archive, emitters, result_archive)
     else:
         scheduler = BanditScheduler(
             archive,

--- a/tutorials/cma_mae.ipynb
+++ b/tutorials/cma_mae.ipynb
@@ -344,7 +344,7 @@
    "source": [
     "from ribs.schedulers import Scheduler\n",
     "\n",
-    "scheduler = Scheduler(archive, emitters, result_archive=result_archive)"
+    "scheduler = Scheduler(archive, emitters, result_archive)"
    ]
   },
   {
@@ -540,7 +540,7 @@
     "      ) for _ in range(15)\n",
     "    ]\n",
     "\n",
-    "    return Scheduler(archive, emitters, result_archive=result_archive)"
+    "    return Scheduler(archive, emitters, result_archive)"
    ]
   },
   {

--- a/tutorials/scalable_cma_mae.ipynb
+++ b/tutorials/scalable_cma_mae.ipynb
@@ -295,7 +295,7 @@
    "source": [
     "from ribs.schedulers import Scheduler\n",
     "\n",
-    "scheduler = Scheduler(archive, emitters, result_archive=result_archive)"
+    "scheduler = Scheduler(archive, emitters, result_archive)"
    ]
   },
   {

--- a/tutorials/tom_cruise_dqd.ipynb
+++ b/tutorials/tom_cruise_dqd.ipynb
@@ -670,7 +670,7 @@
    "source": [
     "from ribs.schedulers import Scheduler\n",
     "\n",
-    "scheduler = Scheduler(archive, emitters, result_archive=result_archive)"
+    "scheduler = Scheduler(archive, emitters, result_archive)"
    ]
   },
   {


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the PR's purpose here. -->

Previously, `result_archive` could only be passed in to schedulers as a kwarg. However, it is such a common argument that I think it makes sense to allow passing it in as a positional argument. Thus, a Scheduler can be constructed as `Scheduler(archive, emitter, result_archive)` rather than `Scheduler(archive, emitter, result_archive=result_archive)`.'

## TODO

<!-- Notable points that this PR has either accomplished or will accomplish. -->

- [x] Update parameter list in Scheduler
- [x] Update parameter list in BayesianOptimizationScheduler
- [x] Update parameter list in BanditScheduler -- note that this is a **backwards-incompatible** change that moves `num_active` to be a keyword-only arg. I believe this is appropriate because all schedulers now have a common API where they take in the `archive, emitters, result_archive` and any further parameters are specified via kwargs.
- [x] Update current calls to Scheduler in tutorials, tests, examples, etc.

## Status

- [x] I have read the guidelines in
      [CONTRIBUTING.md](https://github.com/icaros-usc/pyribs/blob/master/CONTRIBUTING.md)
- [x] I have formatted my code using `yapf`
- [x] I have tested my code by running `pytest`
- [x] I have linted my code with `pylint`
- [x] I have added a one-line description of my change to the changelog in
      `HISTORY.md`
- [x] This PR is ready to go
