### PR TITLE
Remove convenience extras ribs[pymoo] and ribs[pycma]

### DIFF
--- a/examples/bop_elites.py
+++ b/examples/bop_elites.py
@@ -3,9 +3,8 @@
 BOP-Elites was introduced in Kent 2024:
 https://ieeexplore.ieee.org/abstract/document/10472301
 
-Before running this example, please install pymoo with:
-
-    pip install ribs[pymoo]
+Install the following dependencies before running this example:
+    pip install ribs[visualize] pymoo tqdm fire
 """
 
 import json


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the PR's purpose here. -->

It was suggested [here](https://github.com/conda-forge/admin-requests/pull/1575) that "convenience" extras like `ribs[pymoo]` and `ribs[pycma]` are not that helpful. I am inclined to agree, as these extras only install one dependency. I think it would be helpful to instead place these extras in the `all` extra. Particularly heavy dependencies like pytorch can be left out of `all`. Thus, this PR removes the current "convenience" extras and all mentions of them in the codebase.

## TODO

<!-- Notable points that this PR has either accomplished or will accomplish. -->

- [ ] Remove `pycma` and `pymoo` from `pyproject.toml`
- [ ] Fix dependencies in BOP-Elites example
- [ ] Fix mentions of pymoo in codebase
- [ ] Fix mentions of pycma in codebase

## Status

- [x] I have read the guidelines in
      [CONTRIBUTING.md](https://github.com/icaros-usc/pyribs/blob/master/CONTRIBUTING.md)
- [x] I have formatted my code using `yapf`
- [x] I have tested my code by running `pytest`
- [x] I have linted my code with `pylint`
- [x] I have added a one-line description of my change to the changelog in
      `HISTORY.md`
- [ ] This PR is ready to go
