### PR TITLE
Migrate from yapf to ruff for formatting

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -18,7 +18,7 @@
 
 - [ ] I have read the guidelines in
       [CONTRIBUTING.md](https://github.com/icaros-usc/pyribs/blob/master/CONTRIBUTING.md)
-- [ ] I have formatted my code using `yapf`
+- [ ] I have formatted my code using `isort` and `ruff`
 - [ ] I have tested my code by running `pytest`
 - [ ] I have linted my code with `pylint`
 - [ ] I have added a one-line description of my change to the changelog in

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -22,7 +22,8 @@ jobs:
     runs-on: ubuntu-latest
     env:
       # Skip pylint since not all of our code passes pylint.
-      SKIP: pylint
+      # TODO (btjanaka): Remove ruff-format and format the whole codebase.
+      SKIP: pylint, ruff-format
     steps:
       - uses: actions/checkout@v4
       - uses: conda-incubator/setup-miniconda@v3

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -22,8 +22,8 @@ jobs:
     runs-on: ubuntu-latest
     env:
       # Skip pylint since not all of our code passes pylint.
-      # TODO (btjanaka): Remove ruff-format and format the whole codebase.
-      SKIP: pylint, ruff-format
+      # TODO (btjanaka): Remove isort and ruff-format and format the whole codebase.
+      SKIP: pylint, isort, ruff-format
     steps:
       - uses: actions/checkout@v4
       - uses: conda-incubator/setup-miniconda@v3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,10 +16,10 @@ repos:
     hooks:
       - id: isort
         name: isort (python)
-  - repo: https://github.com/google/yapf
-    rev: v0.40.1
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.12.4
     hooks:
-      - id: yapf
+      - id: ruff-format
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: v3.0.2
     hooks:

--- a/.pylintrc
+++ b/.pylintrc
@@ -145,7 +145,7 @@ max-nested-blocks=5
 [FORMAT]
 
 # Maximum number of characters on a single line.
-max-line-length=80
+max-line-length=88
 
 # Regexp for a line that is allowed to be longer than the limit. The first group
 # (before the `|`) matches URLs, the second matches Sphinx links, the third

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,8 +41,8 @@ Ready to contribute? Here's how to set up pyribs for local development.
 
 1. We roughly follow the
    [Google Style Guide](https://google.github.io/styleguide/pyguide.html) in our
-   codebase by using yapf, isort, and pylint to enforce code format and style.
-   To automatically check for formatting and style every time you commit, we use
+   codebase and use isort, ruff, and pylint to enforce code format and style. To
+   automatically check for formatting and style every time you commit, we use
    [pre-commit](https://pre-commit.com). Pre-commit should have already been
    installed with `.[dev]` above. To set it up, run:
 
@@ -53,14 +53,15 @@ Ready to contribute? Here's how to set up pyribs for local development.
 1. Now make the appropriate changes locally. If relevant, make sure to write
    tests for your code in the `tests/` folder.
 
-1. Auto-format and lint your code using YAPF, isort, and pylint. Note that
-   pre-commit will automatically run these whenever you commit your code; you
-   can also run them with `pre-commit run`. You can also run these commands on
-   the command line:
+1. Auto-format and lint your code using [isort](https://pycqa.github.io/isort/),
+   [ruff](https://docs.astral.sh/ruff/formatter/), and
+   [pylint](https://www.pylint.org/). Note that pre-commit will automatically
+   run these whenever you commit your code; you can also run them with
+   `pre-commit run`. You can also run these commands on the command line:
 
    ```bash
-   yapf -i FILES
    isort FILES
+   ruff format FILES
    pylint FILES
    ```
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -25,6 +25,10 @@ This release makes some minor updates to 0.8.0.
 
 - Update Discord and X links in README ({pr}`566`)
 
+#### Improvements
+
+- Migrate from yapf to ruff for formatting ({pr}`581`)
+
 ## 0.8.0
 
 To learn about this release, see our page on What's New in v0.8.0:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,9 +55,10 @@ all = [
   "pymoo",
 ]
 dev = [
-  "pip>=20.3",
-  "pylint",
+  # Tools
+  "isort",
   "ruff",
+  "pylint",
   "pre-commit",
 
   # Testing

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ all = [
 dev = [
   "pip>=20.3",
   "pylint",
-  "yapf",
+  "ruff",
   "pre-commit",
 
   # Testing
@@ -109,12 +109,7 @@ readme = {file = ["README.md", "HISTORY.md"], content-type = "text/markdown"}
 
 [tool.isort]
 known_first_party = "ribs"
-line_length = 80
-
-[tool.yapf]
-based_on_style = "google"
-column_limit = 80
-indent_width = 4
+line_length = 88
 
 [tool.pytest.ini_options]
 python_files = "*_test.py"


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the PR's purpose here. -->

Ruff seems to be a highly popular tool for Python nowadays. I believe migrating to ruff would make pyribs just a bit more accessible for contributors.

A followup PR would run ruff to format the entire codebase.

In addition to formatting, ruff also supports linting. I believe it would also be great to migrate to ruff for linting since it is significantly faster than pylint, but this will require a separate PR.

Here is the info for setting up ruff in pre-commit: https://github.com/astral-sh/ruff-pre-commit

## TODO

<!-- Notable points that this PR has either accomplished or will accomplish. -->

- [x] Update pre-commit
- [x] Update instructions in CONTRIBUTING
- [x] Remove yapf config in pyproject.toml
- [x] Increase pylint and isort line length to 88

## Status

- [x] I have read the guidelines in
      [CONTRIBUTING.md](https://github.com/icaros-usc/pyribs/blob/master/CONTRIBUTING.md)
- [x] I have formatted my code using `yapf`
- [x] I have tested my code by running `pytest`
- [x] I have linted my code with `pylint`
- [x] I have added a one-line description of my change to the changelog in
      `HISTORY.md`
- [x] This PR is ready to go
