### PR TITLE
Treat archive dtypes as regular dtypes rather than scalar dtypes

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -10,6 +10,10 @@
 - **Backwards-incompatible:** Remove raw_dict methods from ArrayStore
   ({pr}`575`)
 
+#### Improvements
+
+- Migrate from yapf to ruff for formatting ({pr}`581`, {pr}`582`, {pr}`583`)
+
 ## 0.8.1
 
 This release makes some minor updates to 0.8.0.
@@ -24,10 +28,6 @@ This release makes some minor updates to 0.8.0.
 #### Documentation
 
 - Update Discord and X links in README ({pr}`566`)
-
-#### Improvements
-
-- Migrate from yapf to ruff for formatting ({pr}`581`, {pr}`582`, {pr}`583`)
 
 ## 0.8.0
 

--- a/examples/bop_elites.py
+++ b/examples/bop_elites.py
@@ -216,6 +216,15 @@ def main(
         plt.xlabel("Iteration")
         plt.savefig(str(logdir / f"{metric.lower().replace(' ', '_')}.png"))
         plt.clf()
+
+    # Convert metrics to Python scalars by calling .item(), since each stats value is a
+    # 0-D array by default, and JSON cannot serialize 0-D arrays.
+    for metric in metrics:
+        metrics[metric]["y"] = [
+            m if isinstance(m, (int, float)) else m.item() for m in metrics[metric]["y"]
+        ]
+
+    # Save metrics to JSON.
     with (logdir / "metrics.json").open("w") as file:
         json.dump(metrics, file, indent=2)
 

--- a/examples/lunar_lander.py
+++ b/examples/lunar_lander.py
@@ -286,8 +286,8 @@ def save_metrics(outdir, metrics):
         ax.set_xlabel("Iteration")
         fig.savefig(str(outdir / f"{metric.lower().replace(' ', '_')}.png"))
 
-    # Convert metrics to Python scalars by calling .item(), since each stats value
-    # is a 0-D array by default, and JSON cannot serialize 0-D arrays.
+    # Convert metrics to Python scalars by calling .item(), since each stats value is a
+    # 0-D array by default, and JSON cannot serialize 0-D arrays.
     for metric in metrics:
         metrics[metric]["y"] = [
             m if isinstance(m, (int, float)) else m.item() for m in metrics[metric]["y"]

--- a/examples/lunar_lander.py
+++ b/examples/lunar_lander.py
@@ -278,7 +278,7 @@ def save_metrics(outdir, metrics):
         outdir (Path): output directory for saving files.
         metrics (dict): Metrics as output by run_search.
     """
-    # Plots.
+    # Plot metrics.
     for metric in metrics:
         fig, ax = plt.subplots()
         ax.plot(metrics[metric]["x"], metrics[metric]["y"])
@@ -286,7 +286,14 @@ def save_metrics(outdir, metrics):
         ax.set_xlabel("Iteration")
         fig.savefig(str(outdir / f"{metric.lower().replace(' ', '_')}.png"))
 
-    # JSON file.
+    # Convert metrics to Python scalars by calling .item(), since each stats value
+    # is a 0-D array by default, and JSON cannot serialize 0-D arrays.
+    for metric in metrics:
+        metrics[metric]["y"] = [
+            m if isinstance(m, (int, float)) else m.item() for m in metrics[metric]["y"]
+        ]
+
+    # Save metrics to JSON.
     with (outdir / "metrics.json").open("w") as file:
         json.dump(metrics, file, indent=2)
 

--- a/examples/sphere.py
+++ b/examples/sphere.py
@@ -1120,8 +1120,8 @@ def sphere_main(
         plt.savefig(str(outdir / f"{name}_{metric.lower().replace(' ', '_')}.png"))
         plt.clf()
 
-    # Convert metrics to Python scalars by calling .item(), since each stats value
-    # is a 0-D array by default, and JSON cannot serialize 0-D arrays.
+    # Convert metrics to Python scalars by calling .item(), since each stats value is a
+    # 0-D array by default, and JSON cannot serialize 0-D arrays.
     for metric in metrics:
         metrics[metric]["y"] = [
             m if isinstance(m, (int, float)) else m.item() for m in metrics[metric]["y"]

--- a/examples/sphere.py
+++ b/examples/sphere.py
@@ -1119,6 +1119,15 @@ def sphere_main(
         plt.xlabel("Iteration")
         plt.savefig(str(outdir / f"{name}_{metric.lower().replace(' ', '_')}.png"))
         plt.clf()
+
+    # Convert metrics to Python scalars by calling .item(), since each stats value
+    # is a 0-D array by default, and JSON cannot serialize 0-D arrays.
+    for metric in metrics:
+        metrics[metric]["y"] = [
+            m if isinstance(m, (int, float)) else m.item() for m in metrics[metric]["y"]
+        ]
+
+    # Save metrics to JSON.
     with (outdir / f"{name}_metrics.json").open("w") as file:
         json.dump(metrics, file, indent=2)
 

--- a/ribs/_utils.py
+++ b/ribs/_utils.py
@@ -191,7 +191,9 @@ def validate_single(archive, data, none_objective_ok=False):
         if not none_objective_ok:
             raise ValueError("objective cannot be None")
     else:
-        data["objective"] = archive.dtypes["objective"](data["objective"])
+        data["objective"] = np.asarray(
+            data["objective"], dtype=archive.dtypes["objective"]
+        )
         check_finite(data["objective"], "objective")
 
     data["measures"] = np.asarray(data["measures"])

--- a/ribs/archives/_archive_stats.py
+++ b/ribs/archives/_archive_stats.py
@@ -10,7 +10,7 @@ class ArchiveStats:
     """Holds statistics about an archive."""
 
     #: Number of elites in the archive.
-    num_elites: int
+    num_elites: np.int32
 
     #: Proportion of cells in the archive that have an elite - always in the
     #: range :math:`[0,1]`.

--- a/ribs/archives/_archive_stats.py
+++ b/ribs/archives/_archive_stats.py
@@ -10,7 +10,7 @@ class ArchiveStats:
     """Holds statistics about an archive."""
 
     #: Number of elites in the archive.
-    num_elites: np.int32
+    num_elites: int
 
     #: Proportion of cells in the archive that have an elite - always in the
     #: range :math:`[0,1]`.

--- a/ribs/archives/_array_store.py
+++ b/ribs/archives/_array_store.py
@@ -5,12 +5,7 @@ import numbers
 from enum import IntEnum
 from functools import cached_property
 
-from array_api_compat import (
-    is_cupy_array,
-    is_numpy_array,
-    is_numpy_namespace,
-    is_torch_array,
-)
+from array_api_compat import is_cupy_array, is_numpy_array, is_torch_array
 
 try:
     from array_api_compat import cupy as cp
@@ -230,14 +225,7 @@ class ArrayStore:
                     "measures": np.float32,
                 }
         """
-        if is_numpy_namespace(self._xp):
-            # TODO (#577): In NumPy, we currently want the scalar type (i.e.,
-            # arr.dtype.type rather than arr.dtype), which is callable.
-            # Ultimately, this should be switched to just be the dtype to be
-            # compatible across array libraries.
-            return {name: arr.dtype.type for name, arr in self._fields.items()}
-        else:
-            return {name: arr.dtype for name, arr in self._fields.items()}
+        return {name: arr.dtype for name, arr in self._fields.items()}
 
     @cached_property
     def dtypes_with_index(self):

--- a/ribs/archives/_categorical_archive.py
+++ b/ribs/archives/_categorical_archive.py
@@ -267,7 +267,7 @@ class CategoricalArchive(ArchiveBase):
             * self._qd_score_offset
         )
         self._stats = ArchiveStats(
-            num_elites=len(self),
+            num_elites=np.asarray(len(self), dtype=np.int32),
             coverage=np.asarray(len(self) / self.cells, dtype=self.dtypes["objective"]),
             qd_score=new_qd_score,
             norm_qd_score=np.asarray(

--- a/ribs/archives/_categorical_archive.py
+++ b/ribs/archives/_categorical_archive.py
@@ -267,7 +267,7 @@ class CategoricalArchive(ArchiveBase):
             * self._qd_score_offset
         )
         self._stats = ArchiveStats(
-            num_elites=np.asarray(len(self), dtype=np.int32),
+            num_elites=len(self),
             coverage=np.asarray(len(self) / self.cells, dtype=self.dtypes["objective"]),
             qd_score=new_qd_score,
             norm_qd_score=np.asarray(

--- a/ribs/archives/_categorical_archive.py
+++ b/ribs/archives/_categorical_archive.py
@@ -136,7 +136,9 @@ class CategoricalArchive(ArchiveBase):
         self._learning_rate, self._threshold_min = validate_cma_mae_settings(
             learning_rate, threshold_min, self.dtypes["threshold"]
         )
-        self._qd_score_offset = self.dtypes["objective"](qd_score_offset)
+        self._qd_score_offset = np.asarray(
+            qd_score_offset, dtype=self.dtypes["objective"]
+        )
 
         # Set up statistics -- objective_sum is the sum of all objective values in the
         # archive; it is useful for computing qd_score and obj_mean.
@@ -233,12 +235,12 @@ class CategoricalArchive(ArchiveBase):
     def _stats_reset(self):
         """Resets the archive stats."""
         self._best_elite = None
-        self._objective_sum = self.dtypes["objective"](0.0)
+        self._objective_sum = np.asarray(0.0, dtype=self.dtypes["objective"])
         self._stats = ArchiveStats(
             num_elites=0,
-            coverage=self.dtypes["objective"](0.0),
-            qd_score=self.dtypes["objective"](0.0),
-            norm_qd_score=self.dtypes["objective"](0.0),
+            coverage=np.asarray(0.0, dtype=self.dtypes["objective"]),
+            qd_score=np.asarray(0.0, dtype=self.dtypes["objective"]),
+            norm_qd_score=np.asarray(0.0, dtype=self.dtypes["objective"]),
             obj_max=None,
             obj_mean=None,
         )
@@ -261,15 +263,20 @@ class CategoricalArchive(ArchiveBase):
         self._objective_sum = new_objective_sum
         new_qd_score = (
             self._objective_sum
-            - self.dtypes["objective"](len(self)) * self._qd_score_offset
+            - np.asarray(len(self), dtype=self.dtypes["objective"])
+            * self._qd_score_offset
         )
         self._stats = ArchiveStats(
             num_elites=len(self),
-            coverage=self.dtypes["objective"](len(self) / self.cells),
+            coverage=np.asarray(len(self) / self.cells, dtype=self.dtypes["objective"]),
             qd_score=new_qd_score,
-            norm_qd_score=self.dtypes["objective"](new_qd_score / self.cells),
+            norm_qd_score=np.asarray(
+                new_qd_score / self.cells, dtype=self.dtypes["objective"]
+            ),
             obj_max=new_obj_max,
-            obj_mean=self.dtypes["objective"](self._objective_sum / len(self)),
+            obj_mean=np.asarray(
+                self._objective_sum / len(self), dtype=self.dtypes["objective"]
+            ),
         )
 
     def index_of(self, measures):
@@ -330,7 +337,7 @@ class CategoricalArchive(ArchiveBase):
         If entries in `indices` are duplicated, they receive the same threshold.
         """
         if len(indices) == 0:
-            return np.array([], dtype=dtype)
+            return np.empty(0, dtype=dtype)
 
         # Compute the number of objectives inserted into each cell. Note that we index
         # with `indices` to place the counts at all relevant indices. For instance, if
@@ -355,7 +362,7 @@ class CategoricalArchive(ArchiveBase):
         # This is because the case with threshold_min = -np.inf is handled separately
         # since we compute the new threshold based on the max objective in each cell in
         # that case.
-        ratio = dtype(1.0 - learning_rate) ** objective_sizes
+        ratio = np.asarray(1.0 - learning_rate, dtype=dtype) ** objective_sizes
         new_threshold = ratio * cur_threshold + (objective_sums / objective_sizes) * (
             1 - ratio
         )
@@ -486,9 +493,7 @@ class CategoricalArchive(ArchiveBase):
         # improvement value of new solutions w.r.t zero. Otherwise, we compute
         # improvement with respect to threshold_min.
         cur_threshold[is_new] = (
-            self.dtypes["threshold"](0.0)
-            if self.threshold_min == -np.inf
-            else self.threshold_min
+            0.0 if self.threshold_min == -np.inf else self.threshold_min
         )
         add_info["value"] = data["objective"] - cur_threshold
 
@@ -622,7 +627,7 @@ class CategoricalArchive(ArchiveBase):
             # improvement value with a threshold of zero for new solutions. Otherwise,
             # we will set cur_threshold to threshold_min.
             cur_threshold = (
-                self.dtypes["threshold"](0.0)
+                np.asarray(0.0, self.dtypes["threshold"])
                 if self.threshold_min == -np.inf
                 else self.threshold_min
             )
@@ -676,7 +681,7 @@ class CategoricalArchive(ArchiveBase):
             cur_objective = (
                 cur_data["objective"][0]
                 if cur_occupied
-                else self.dtypes["objective"](0.0)
+                else np.asarray(0.0, dtype=self.dtypes["objective"])
             )
             self._stats_update(self._objective_sum + objective - cur_objective, index)
 

--- a/ribs/archives/_cvt_archive.py
+++ b/ribs/archives/_cvt_archive.py
@@ -444,7 +444,7 @@ class CVTArchive(ArchiveBase):
             * self._qd_score_offset
         )
         self._stats = ArchiveStats(
-            num_elites=np.asarray(len(self), dtype=np.int32),
+            num_elites=len(self),
             coverage=np.asarray(len(self) / self.cells, dtype=self.dtypes["objective"]),
             qd_score=new_qd_score,
             norm_qd_score=np.asarray(

--- a/ribs/archives/_cvt_archive.py
+++ b/ribs/archives/_cvt_archive.py
@@ -195,7 +195,9 @@ class CVTArchive(ArchiveBase):
         self._learning_rate, self._threshold_min = validate_cma_mae_settings(
             learning_rate, threshold_min, self.dtypes["threshold"]
         )
-        self._qd_score_offset = self.dtypes["objective"](qd_score_offset)
+        self._qd_score_offset = np.asarray(
+            qd_score_offset, dtype=self.dtypes["objective"]
+        )
 
         # Set up statistics -- objective_sum is the sum of all objective values in the
         # archive; it is useful for computing qd_score and obj_mean.
@@ -410,12 +412,12 @@ class CVTArchive(ArchiveBase):
     def _stats_reset(self):
         """Resets the archive stats."""
         self._best_elite = None
-        self._objective_sum = self.dtypes["objective"](0.0)
+        self._objective_sum = np.asarray(0.0, dtype=self.dtypes["objective"])
         self._stats = ArchiveStats(
             num_elites=0,
-            coverage=self.dtypes["objective"](0.0),
-            qd_score=self.dtypes["objective"](0.0),
-            norm_qd_score=self.dtypes["objective"](0.0),
+            coverage=np.asarray(0.0, dtype=self.dtypes["objective"]),
+            qd_score=np.asarray(0.0, dtype=self.dtypes["objective"]),
+            norm_qd_score=np.asarray(0.0, dtype=self.dtypes["objective"]),
             obj_max=None,
             obj_mean=None,
         )
@@ -438,15 +440,20 @@ class CVTArchive(ArchiveBase):
         self._objective_sum = new_objective_sum
         new_qd_score = (
             self._objective_sum
-            - self.dtypes["objective"](len(self)) * self._qd_score_offset
+            - np.asarray(len(self), dtype=self.dtypes["objective"])
+            * self._qd_score_offset
         )
         self._stats = ArchiveStats(
             num_elites=len(self),
-            coverage=self.dtypes["objective"](len(self) / self.cells),
+            coverage=np.asarray(len(self) / self.cells, dtype=self.dtypes["objective"]),
             qd_score=new_qd_score,
-            norm_qd_score=self.dtypes["objective"](new_qd_score / self.cells),
+            norm_qd_score=np.asarray(
+                new_qd_score / self.cells, dtype=self.dtypes["objective"]
+            ),
             obj_max=new_obj_max,
-            obj_mean=self.dtypes["objective"](self._objective_sum / len(self)),
+            obj_mean=np.asarray(
+                self._objective_sum / len(self), dtype=self.dtypes["objective"]
+            ),
         )
 
     def index_of(self, measures):
@@ -530,7 +537,7 @@ class CVTArchive(ArchiveBase):
         If entries in `indices` are duplicated, they receive the same threshold.
         """
         if len(indices) == 0:
-            return np.array([], dtype=dtype)
+            return np.empty(0, dtype=dtype)
 
         # Compute the number of objectives inserted into each cell. Note that we index
         # with `indices` to place the counts at all relevant indices. For instance, if
@@ -555,7 +562,7 @@ class CVTArchive(ArchiveBase):
         # This is because the case with threshold_min = -np.inf is handled separately
         # since we compute the new threshold based on the max objective in each cell in
         # that case.
-        ratio = dtype(1.0 - learning_rate) ** objective_sizes
+        ratio = np.asarray(1.0 - learning_rate, dtype=dtype) ** objective_sizes
         new_threshold = ratio * cur_threshold + (objective_sums / objective_sizes) * (
             1 - ratio
         )
@@ -686,9 +693,7 @@ class CVTArchive(ArchiveBase):
         # improvement value of new solutions w.r.t zero. Otherwise, we compute
         # improvement with respect to threshold_min.
         cur_threshold[is_new] = (
-            self.dtypes["threshold"](0.0)
-            if self.threshold_min == -np.inf
-            else self.threshold_min
+            0.0 if self.threshold_min == -np.inf else self.threshold_min
         )
         add_info["value"] = data["objective"] - cur_threshold
 
@@ -822,7 +827,7 @@ class CVTArchive(ArchiveBase):
             # improvement value with a threshold of zero for new solutions. Otherwise,
             # we will set cur_threshold to threshold_min.
             cur_threshold = (
-                self.dtypes["threshold"](0.0)
+                np.asarray(0.0, self.dtypes["threshold"])
                 if self.threshold_min == -np.inf
                 else self.threshold_min
             )
@@ -876,7 +881,7 @@ class CVTArchive(ArchiveBase):
             cur_objective = (
                 cur_data["objective"][0]
                 if cur_occupied
-                else self.dtypes["objective"](0.0)
+                else np.asarray(0.0, dtype=self.dtypes["objective"])
             )
             self._stats_update(self._objective_sum + objective - cur_objective, index)
 

--- a/ribs/archives/_cvt_archive.py
+++ b/ribs/archives/_cvt_archive.py
@@ -444,7 +444,7 @@ class CVTArchive(ArchiveBase):
             * self._qd_score_offset
         )
         self._stats = ArchiveStats(
-            num_elites=len(self),
+            num_elites=np.asarray(len(self), dtype=np.int32),
             coverage=np.asarray(len(self) / self.cells, dtype=self.dtypes["objective"]),
             qd_score=new_qd_score,
             norm_qd_score=np.asarray(

--- a/ribs/archives/_grid_archive.py
+++ b/ribs/archives/_grid_archive.py
@@ -324,7 +324,7 @@ class GridArchive(ArchiveBase):
             * self._qd_score_offset
         )
         self._stats = ArchiveStats(
-            num_elites=np.asarray(len(self), dtype=np.int32),
+            num_elites=len(self),
             coverage=np.asarray(len(self) / self.cells, dtype=self.dtypes["objective"]),
             qd_score=new_qd_score,
             norm_qd_score=np.asarray(

--- a/ribs/archives/_grid_archive.py
+++ b/ribs/archives/_grid_archive.py
@@ -147,11 +147,13 @@ class GridArchive(ArchiveBase):
         self._boundaries = self._compute_boundaries(
             self._dims, self._lower_bounds, self._upper_bounds
         )
-        self._epsilon = self.dtypes["measures"](epsilon)
+        self._epsilon = np.asarray(epsilon, dtype=self.dtypes["measures"])
         self._learning_rate, self._threshold_min = validate_cma_mae_settings(
             learning_rate, threshold_min, self.dtypes["threshold"]
         )
-        self._qd_score_offset = self.dtypes["objective"](qd_score_offset)
+        self._qd_score_offset = np.asarray(
+            qd_score_offset, dtype=self.dtypes["objective"]
+        )
 
         # Set up statistics -- objective_sum is the sum of all objective values in the
         # archive; it is useful for computing qd_score and obj_mean.
@@ -290,12 +292,12 @@ class GridArchive(ArchiveBase):
     def _stats_reset(self):
         """Resets the archive stats."""
         self._best_elite = None
-        self._objective_sum = self.dtypes["objective"](0.0)
+        self._objective_sum = np.asarray(0.0, dtype=self.dtypes["objective"])
         self._stats = ArchiveStats(
             num_elites=0,
-            coverage=self.dtypes["objective"](0.0),
-            qd_score=self.dtypes["objective"](0.0),
-            norm_qd_score=self.dtypes["objective"](0.0),
+            coverage=np.asarray(0.0, dtype=self.dtypes["objective"]),
+            qd_score=np.asarray(0.0, dtype=self.dtypes["objective"]),
+            norm_qd_score=np.asarray(0.0, dtype=self.dtypes["objective"]),
             obj_max=None,
             obj_mean=None,
         )
@@ -318,15 +320,20 @@ class GridArchive(ArchiveBase):
         self._objective_sum = new_objective_sum
         new_qd_score = (
             self._objective_sum
-            - self.dtypes["objective"](len(self)) * self._qd_score_offset
+            - np.asarray(len(self), dtype=self.dtypes["objective"])
+            * self._qd_score_offset
         )
         self._stats = ArchiveStats(
             num_elites=len(self),
-            coverage=self.dtypes["objective"](len(self) / self.cells),
+            coverage=np.asarray(len(self) / self.cells, dtype=self.dtypes["objective"]),
             qd_score=new_qd_score,
-            norm_qd_score=self.dtypes["objective"](new_qd_score / self.cells),
+            norm_qd_score=np.asarray(
+                new_qd_score / self.cells, dtype=self.dtypes["objective"]
+            ),
             obj_max=new_obj_max,
-            obj_mean=self.dtypes["objective"](self._objective_sum / len(self)),
+            obj_mean=np.asarray(
+                self._objective_sum / len(self), dtype=self.dtypes["objective"]
+            ),
         )
 
     def index_of(self, measures):
@@ -449,7 +456,7 @@ class GridArchive(ArchiveBase):
         If entries in `indices` are duplicated, they receive the same threshold.
         """
         if len(indices) == 0:
-            return np.array([], dtype=dtype)
+            return np.empty(0, dtype=dtype)
 
         # Compute the number of objectives inserted into each cell. Note that we index
         # with `indices` to place the counts at all relevant indices. For instance, if
@@ -474,7 +481,7 @@ class GridArchive(ArchiveBase):
         # This is because the case with threshold_min = -np.inf is handled separately
         # since we compute the new threshold based on the max objective in each cell in
         # that case.
-        ratio = dtype(1.0 - learning_rate) ** objective_sizes
+        ratio = np.asarray(1.0 - learning_rate, dtype=dtype) ** objective_sizes
         new_threshold = ratio * cur_threshold + (objective_sums / objective_sizes) * (
             1 - ratio
         )
@@ -605,9 +612,7 @@ class GridArchive(ArchiveBase):
         # improvement value of new solutions w.r.t zero. Otherwise, we compute
         # improvement with respect to threshold_min.
         cur_threshold[is_new] = (
-            self.dtypes["threshold"](0.0)
-            if self.threshold_min == -np.inf
-            else self.threshold_min
+            0.0 if self.threshold_min == -np.inf else self.threshold_min
         )
         add_info["value"] = data["objective"] - cur_threshold
 
@@ -741,7 +746,7 @@ class GridArchive(ArchiveBase):
             # improvement value with a threshold of zero for new solutions. Otherwise,
             # we will set cur_threshold to threshold_min.
             cur_threshold = (
-                self.dtypes["threshold"](0.0)
+                np.asarray(0.0, self.dtypes["threshold"])
                 if self.threshold_min == -np.inf
                 else self.threshold_min
             )
@@ -795,7 +800,7 @@ class GridArchive(ArchiveBase):
             cur_objective = (
                 cur_data["objective"][0]
                 if cur_occupied
-                else self.dtypes["objective"](0.0)
+                else np.asarray(0.0, dtype=self.dtypes["objective"])
             )
             self._stats_update(self._objective_sum + objective - cur_objective, index)
 

--- a/ribs/archives/_grid_archive.py
+++ b/ribs/archives/_grid_archive.py
@@ -324,7 +324,7 @@ class GridArchive(ArchiveBase):
             * self._qd_score_offset
         )
         self._stats = ArchiveStats(
-            num_elites=len(self),
+            num_elites=np.asarray(len(self), dtype=np.int32),
             coverage=np.asarray(len(self) / self.cells, dtype=self.dtypes["objective"]),
             qd_score=new_qd_score,
             norm_qd_score=np.asarray(

--- a/ribs/archives/_proximity_archive.py
+++ b/ribs/archives/_proximity_archive.py
@@ -296,7 +296,7 @@ class ProximityArchive(ArchiveBase):
             * self._qd_score_offset
         )
         self._stats = ArchiveStats(
-            num_elites=np.asarray(len(self), dtype=np.int32),
+            num_elites=len(self),
             coverage=np.asarray(len(self) / self.cells, dtype=self.dtypes["objective"]),
             qd_score=new_qd_score,
             norm_qd_score=np.asarray(

--- a/ribs/archives/_proximity_archive.py
+++ b/ribs/archives/_proximity_archive.py
@@ -165,10 +165,14 @@ class ProximityArchive(ArchiveBase):
 
         # Set up constant properties.
         self._k_neighbors = int(k_neighbors)
-        self._novelty_threshold = self.dtypes["measures"](novelty_threshold)
+        self._novelty_threshold = np.asarray(
+            novelty_threshold, dtype=self.dtypes["measures"]
+        )
         self._local_competition = local_competition
         self._ckdtree_kwargs = {} if ckdtree_kwargs is None else ckdtree_kwargs.copy()
-        self._qd_score_offset = self.dtypes["objective"](qd_score_offset)
+        self._qd_score_offset = np.asarray(
+            qd_score_offset, dtype=self.dtypes["objective"]
+        )
 
         # Set up k-D tree with current measures in the archive. Updated on add().
         self._cur_kd_tree = cKDTree(
@@ -260,20 +264,19 @@ class ProximityArchive(ArchiveBase):
     def _stats_reset(self):
         """Resets the archive stats."""
         self._best_elite = None
-        self._objective_sum = self.dtypes["objective"](0.0)
+        self._objective_sum = np.asarray(0.0, dtype=self.dtypes["objective"])
         self._stats = ArchiveStats(
             num_elites=0,
-            coverage=self.dtypes["objective"](0.0),
-            qd_score=self.dtypes["objective"](0.0),
-            norm_qd_score=self.dtypes["objective"](0.0),
+            coverage=np.asarray(0.0, dtype=self.dtypes["objective"]),
+            qd_score=np.asarray(0.0, dtype=self.dtypes["objective"]),
+            norm_qd_score=np.asarray(0.0, dtype=self.dtypes["objective"]),
             obj_max=None,
             obj_mean=None,
         )
 
     def _stats_update(self, new_objective_sum, new_best_index):
-        """Updates statistics based on a new sum of objective values
-        (new_objective_sum) and the index of a potential new best elite
-        (new_best_index)."""
+        """Updates statistics based on a new sum of objective values (new_objective_sum)
+        and the index of a potential new best elite (new_best_index)."""
         _, new_best_elite = self._store.retrieve([new_best_index])
         new_best_elite = {k: v[0] for k, v in new_best_elite.items()}
 
@@ -289,15 +292,20 @@ class ProximityArchive(ArchiveBase):
         self._objective_sum = new_objective_sum
         new_qd_score = (
             self._objective_sum
-            - self.dtypes["objective"](len(self)) * self._qd_score_offset
+            - np.asarray(len(self), dtype=self.dtypes["objective"])
+            * self._qd_score_offset
         )
         self._stats = ArchiveStats(
             num_elites=len(self),
-            coverage=self.dtypes["objective"](len(self) / self.cells),
+            coverage=np.asarray(len(self) / self.cells, dtype=self.dtypes["objective"]),
             qd_score=new_qd_score,
-            norm_qd_score=self.dtypes["objective"](new_qd_score / self.cells),
+            norm_qd_score=np.asarray(
+                new_qd_score / self.cells, dtype=self.dtypes["objective"]
+            ),
             obj_max=new_obj_max,
-            obj_mean=self.dtypes["objective"](self._objective_sum / len(self)),
+            obj_mean=np.asarray(
+                self._objective_sum / len(self), dtype=self.dtypes["objective"]
+            ),
         )
 
     def index_of(self, measures) -> np.ndarray:

--- a/ribs/archives/_proximity_archive.py
+++ b/ribs/archives/_proximity_archive.py
@@ -296,7 +296,7 @@ class ProximityArchive(ArchiveBase):
             * self._qd_score_offset
         )
         self._stats = ArchiveStats(
-            num_elites=len(self),
+            num_elites=np.asarray(len(self), dtype=np.int32),
             coverage=np.asarray(len(self) / self.cells, dtype=self.dtypes["objective"]),
             qd_score=new_qd_score,
             norm_qd_score=np.asarray(

--- a/ribs/archives/_sliding_boundaries_archive.py
+++ b/ribs/archives/_sliding_boundaries_archive.py
@@ -210,8 +210,10 @@ class SlidingBoundariesArchive(ArchiveBase):
         self._lower_bounds = np.array(ranges[0], dtype=self.dtypes["measures"])
         self._upper_bounds = np.array(ranges[1], dtype=self.dtypes["measures"])
         self._interval_size = self._upper_bounds - self._lower_bounds
-        self._epsilon = self.dtypes["measures"](epsilon)
-        self._qd_score_offset = self.dtypes["objective"](qd_score_offset)
+        self._epsilon = np.asarray(epsilon, dtype=self.dtypes["measures"])
+        self._qd_score_offset = np.asarray(
+            qd_score_offset, dtype=self.dtypes["objective"]
+        )
         self._remap_frequency = remap_frequency
 
         # Initialize the boundaries -- allocate an extra entry in each row so we can put
@@ -347,12 +349,12 @@ class SlidingBoundariesArchive(ArchiveBase):
     def _stats_reset(self):
         """Resets the archive stats."""
         self._best_elite = None
-        self._objective_sum = self.dtypes["objective"](0.0)
+        self._objective_sum = np.asarray(0.0, dtype=self.dtypes["objective"])
         self._stats = ArchiveStats(
             num_elites=0,
-            coverage=self.dtypes["objective"](0.0),
-            qd_score=self.dtypes["objective"](0.0),
-            norm_qd_score=self.dtypes["objective"](0.0),
+            coverage=np.asarray(0.0, dtype=self.dtypes["objective"]),
+            qd_score=np.asarray(0.0, dtype=self.dtypes["objective"]),
+            norm_qd_score=np.asarray(0.0, dtype=self.dtypes["objective"]),
             obj_max=None,
             obj_mean=None,
         )
@@ -375,15 +377,20 @@ class SlidingBoundariesArchive(ArchiveBase):
         self._objective_sum = new_objective_sum
         new_qd_score = (
             self._objective_sum
-            - self.dtypes["objective"](len(self)) * self._qd_score_offset
+            - np.asarray(len(self), dtype=self.dtypes["objective"])
+            * self._qd_score_offset
         )
         self._stats = ArchiveStats(
             num_elites=len(self),
-            coverage=self.dtypes["objective"](len(self) / self.cells),
+            coverage=np.asarray(len(self) / self.cells, dtype=self.dtypes["objective"]),
             qd_score=new_qd_score,
-            norm_qd_score=self.dtypes["objective"](new_qd_score / self.cells),
+            norm_qd_score=np.asarray(
+                new_qd_score / self.cells, dtype=self.dtypes["objective"]
+            ),
             obj_max=new_obj_max,
-            obj_mean=self.dtypes["objective"](self._objective_sum / len(self)),
+            obj_mean=np.asarray(
+                self._objective_sum / len(self), dtype=self.dtypes["objective"]
+            ),
         )
 
     def index_of(self, measures):
@@ -580,7 +587,9 @@ class SlidingBoundariesArchive(ArchiveBase):
         cur_occupied, cur_data = self._store.retrieve([index])
         cur_occupied = cur_occupied[0]
         cur_objective = (
-            cur_data["objective"][0] if cur_occupied else self.dtypes["objective"](0.0)
+            cur_data["objective"][0]
+            if cur_occupied
+            else np.asarray(0.0, dtype=self.dtypes["objective"])
         )
 
         # Retrieve candidate objective.

--- a/ribs/archives/_sliding_boundaries_archive.py
+++ b/ribs/archives/_sliding_boundaries_archive.py
@@ -381,7 +381,7 @@ class SlidingBoundariesArchive(ArchiveBase):
             * self._qd_score_offset
         )
         self._stats = ArchiveStats(
-            num_elites=len(self),
+            num_elites=np.asarray(len(self), dtype=np.int32),
             coverage=np.asarray(len(self) / self.cells, dtype=self.dtypes["objective"]),
             qd_score=new_qd_score,
             norm_qd_score=np.asarray(

--- a/ribs/archives/_sliding_boundaries_archive.py
+++ b/ribs/archives/_sliding_boundaries_archive.py
@@ -381,7 +381,7 @@ class SlidingBoundariesArchive(ArchiveBase):
             * self._qd_score_offset
         )
         self._stats = ArchiveStats(
-            num_elites=np.asarray(len(self), dtype=np.int32),
+            num_elites=len(self),
             coverage=np.asarray(len(self) / self.cells, dtype=self.dtypes["objective"]),
             qd_score=new_qd_score,
             norm_qd_score=np.asarray(

--- a/ribs/archives/_utils.py
+++ b/ribs/archives/_utils.py
@@ -54,8 +54,8 @@ def validate_cma_mae_settings(learning_rate, threshold_min, dtype):
         learning_rate = 1.0  # Default value.
     if threshold_min == -np.inf and learning_rate != 1.0:
         raise ValueError("threshold_min can only be -np.inf if learning_rate is 1.0")
-    learning_rate = dtype(learning_rate)
-    threshold_min = dtype(threshold_min)
+    learning_rate = np.asarray(learning_rate, dtype=dtype)
+    threshold_min = np.asarray(threshold_min, dtype=dtype)
     return learning_rate, threshold_min
 
 

--- a/ribs/emitters/_gaussian_emitter.py
+++ b/ribs/emitters/_gaussian_emitter.py
@@ -62,7 +62,7 @@ class GaussianEmitter(EmitterBase):
 
         self._rng = np.random.default_rng(seed)
         self._batch_size = batch_size
-        self._sigma = np.array(sigma, dtype=archive.dtypes["solution"])
+        self._sigma = np.asarray(sigma, dtype=archive.dtypes["solution"])
         self._x0 = None
         self._initial_solutions = None
 

--- a/ribs/emitters/_gradient_operator_emitter.py
+++ b/ribs/emitters/_gradient_operator_emitter.py
@@ -1,7 +1,5 @@
 """Provides the GradientOperatorEmitter."""
 
-import numbers
-
 import numpy as np
 
 from ribs._utils import check_batch_shape, check_shape, validate_batch
@@ -141,12 +139,9 @@ class GradientOperatorEmitter(EmitterBase):
             )
 
         self._rng = np.random.default_rng(seed)
-        self._sigma = (
-            archive.dtypes["solution"](sigma)
-            if isinstance(sigma, numbers.Real)
-            else np.array(sigma)
-        )
-        self._sigma_g = archive.dtypes["solution"](sigma_g)
+        # `sigma` can either be a scalar or a 1D array.
+        self._sigma = np.asarray(sigma, dtype=archive.dtypes["solution"])
+        self._sigma_g = np.asarray(sigma_g, archive.dtypes["solution"])
         self._line_sigma = line_sigma
         self._use_isolinedd = operator_type != "isotropic"
         self._measure_gradients = measure_gradients

--- a/ribs/emitters/_iso_line_emitter.py
+++ b/ribs/emitters/_iso_line_emitter.py
@@ -72,8 +72,8 @@ class IsoLineEmitter(EmitterBase):
 
         self._rng = np.random.default_rng(seed)
         self._batch_size = batch_size
-        self._iso_sigma = archive.dtypes["solution"](iso_sigma)
-        self._line_sigma = archive.dtypes["solution"](line_sigma)
+        self._iso_sigma = np.asarray(iso_sigma, dtype=archive.dtypes["solution"])
+        self._line_sigma = np.asarray(line_sigma, dtype=archive.dtypes["solution"])
         self._x0 = None
         self._initial_solutions = None
 

--- a/tests/archives/archive_base_test.py
+++ b/tests/archives/archive_base_test.py
@@ -149,11 +149,11 @@ def test_clear_and_add_during_iteration(add_mode):
 def test_stats_dtype(dtype):
     data = get_archive_data("GridArchive", dtype=dtype)
     assert isinstance(data.archive_with_elite.stats.num_elites, int)
-    assert isinstance(data.archive_with_elite.stats.coverage, dtype)
-    assert isinstance(data.archive_with_elite.stats.qd_score, dtype)
-    assert isinstance(data.archive_with_elite.stats.norm_qd_score, dtype)
-    assert isinstance(data.archive_with_elite.stats.obj_max, dtype)
-    assert isinstance(data.archive_with_elite.stats.obj_mean, dtype)
+    assert data.archive_with_elite.stats.coverage.dtype == dtype
+    assert data.archive_with_elite.stats.qd_score.dtype == dtype
+    assert data.archive_with_elite.stats.norm_qd_score.dtype == dtype
+    assert data.archive_with_elite.stats.obj_max.dtype == dtype
+    assert data.archive_with_elite.stats.obj_mean.dtype == dtype
 
 
 @pytest.mark.parametrize("qd_score_offset", [0.0, -1.0])

--- a/tests/archives/archive_base_test.py
+++ b/tests/archives/archive_base_test.py
@@ -148,7 +148,7 @@ def test_clear_and_add_during_iteration(add_mode):
 @pytest.mark.parametrize("dtype", [np.float64, np.float32], ids=["float64", "float32"])
 def test_stats_dtype(dtype):
     data = get_archive_data("GridArchive", dtype=dtype)
-    assert data.archive_with_elite.stats.num_elites.dtype == np.int32
+    assert isinstance(data.archive_with_elite.stats.num_elites, int)
     assert data.archive_with_elite.stats.coverage.dtype == dtype
     assert data.archive_with_elite.stats.qd_score.dtype == dtype
     assert data.archive_with_elite.stats.norm_qd_score.dtype == dtype

--- a/tests/archives/archive_base_test.py
+++ b/tests/archives/archive_base_test.py
@@ -148,7 +148,7 @@ def test_clear_and_add_during_iteration(add_mode):
 @pytest.mark.parametrize("dtype", [np.float64, np.float32], ids=["float64", "float32"])
 def test_stats_dtype(dtype):
     data = get_archive_data("GridArchive", dtype=dtype)
-    assert isinstance(data.archive_with_elite.stats.num_elites, int)
+    assert data.archive_with_elite.stats.num_elites.dtype == np.int32
     assert data.archive_with_elite.stats.coverage.dtype == dtype
     assert data.archive_with_elite.stats.qd_score.dtype == dtype
     assert data.archive_with_elite.stats.norm_qd_score.dtype == dtype


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the PR's purpose here. -->

Resolves #577. Previously, a lot of uses of the archives' `dtypes` assumed that `dtypes` were scalar types, rather than dtypes (see [here](https://numpy.org/doc/stable/reference/arrays.scalars.html) for more info). As such, calls like `archive.dtypes["objective"](qd_score_offset)` were used to convert scalar values into the relevant NumPy dtype. However, this call does not work with the regular NumPy dtypes because they are not callable. Instead, the call must be replaced with `np.asarray(qd_score_offset, archive.dtypes["objective"])` -- this creates a 0-D NumPy array that can be used just like any scalar.

This change helps prepare the library for Array API adoption in #570. Note that some other options were considered besides 0-D arrays, but it seems that 0-D arrays are the correct way to express scalars in the array API. See here for more info: https://github.com/data-apis/array-api-compat/issues/345

## TODO

- [x] Remove workaround in `ArrayStore.dtypes` from #571
- [x] Fix dtype calls in archives
- [x] Fix dtype calls in emitters
- [x] Fix archive tests
- [x] Fix issues with saving stats to JSON in examples -- I decided to convert the metrics to floats just before saving to JSON. I think this is better than converting as the stats are added to the metrics because the metrics themselves should have the same dtype, device, etc. as the archive where they originated. Converting to floats is only required for JSON.

## Status

- [x] I have read the guidelines in
      [CONTRIBUTING.md](https://github.com/icaros-usc/pyribs/blob/master/CONTRIBUTING.md)
- [x] I have formatted my code using `isort` and `ruff`
- [x] I have tested my code by running `pytest`
- [x] I have linted my code with `pylint`
- [x] I have added a one-line description of my change to the changelog in
      `HISTORY.md`
- [x] This PR is ready to go
