### PR TITLE
Update dependencies for lunar lander

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -14,6 +14,10 @@
 
 - Migrate from yapf to ruff for formatting ({pr}`581`, {pr}`582`, {pr}`583`)
 
+#### Documentation
+
+- Update dependencies for lunar lander ({pr}`585`)
+
 ## 0.8.1
 
 This release makes some minor updates to 0.8.0.

--- a/examples/lunar_lander.py
+++ b/examples/lunar_lander.py
@@ -3,7 +3,7 @@
 Install the following dependencies before running this example -- swig must be installed
 before box2d can be installed, hence it is a separate command:
     pip install swig
-    pip install ribs[visualize] tqdm fire "gymnasium[box2d]>=1.0.0" "moviepy>=1.0.0" dask distributed bokeh
+    pip install ribs[visualize] tqdm "gymnasium[box2d]>=1.0.0" "moviepy>=1.0.0" dask distributed bokeh fire
 
 This script uses the same setup as the tutorial, but it also uses Dask instead of
 Python's multiprocessing to parallelize evaluations on a single machine and adds in a

--- a/examples/lunar_lander.py
+++ b/examples/lunar_lander.py
@@ -3,7 +3,7 @@
 Install the following dependencies before running this example -- swig must be installed
 before box2d can be installed, hence it is a separate command:
     pip install swig
-    pip install ribs[visualize] tqdm fire gymnasium[box2d]==1.0.0 moviepy>=1.0.0 dask>=2.0.0 distributed>=2.0.0 bokeh>=2.0.0
+    pip install ribs[visualize] tqdm fire "gymnasium[box2d]>=1.0.0" "moviepy>=1.0.0" dask distributed bokeh
 
 This script uses the same setup as the tutorial, but it also uses Dask instead of
 Python's multiprocessing to parallelize evaluations on a single machine and adds in a

--- a/tests/examples.sh
+++ b/tests/examples.sh
@@ -18,7 +18,7 @@ function install_deps() {
   # Loop through all instances of `pip install` in the script and run the
   # installation commands.
   grep '^\s*pip install' "$1" | while read -r install_cmd ; do
-      $install_cmd
+      bash -c "$install_cmd"
   done
 }
 

--- a/tutorials/lunar_lander.ipynb
+++ b/tutorials/lunar_lander.ipynb
@@ -157,15 +157,7 @@
    "outputs": [],
    "source": [
     "%pip install swig  # Must be installed before box2d.\n",
-    "%pip install ribs[visualize] gymnasium[box2d]==1.0.0 \"moviepy>=1.0.0\" dask distributed\n",
-    "\n",
-    "# An uninstalled version of decorator is occasionally loaded. This loads the\n",
-    "# newly installed version of decorator so that moviepy works properly -- see\n",
-    "# https://github.com/Zulko/moviepy/issues/1625\n",
-    "import importlib\n",
-    "import decorator\n",
-    "\n",
-    "importlib.reload(decorator)"
+    "%pip install ribs[visualize] gymnasium[box2d]>=1.0.0 \"moviepy>=1.0.0\" dask distributed"
    ]
   },
   {

--- a/tutorials/lunar_lander.ipynb
+++ b/tutorials/lunar_lander.ipynb
@@ -157,7 +157,7 @@
    "outputs": [],
    "source": [
     "%pip install swig  # Must be installed before box2d.\n",
-    "%pip install ribs[visualize] gymnasium[box2d]>=1.0.0 \"moviepy>=1.0.0\" dask distributed"
+    "%pip install ribs[visualize] tqdm \"gymnasium[box2d]>=1.0.0\" \"moviepy>=1.0.0\" dask distributed"
    ]
   },
   {


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the PR's purpose here. -->

Update the dependencies for the lunar lander tutorial and example. Specifically, I loosened the gymnasium dependency to be `>=1.0.0` since lunar lander seems fairly stable. I also removed the old `importlib.reload` statement in the notebook as that no longer seems necessary. Finally, I updated the installation command in `examples.sh`.

Tested in local Conda environments with Python 3.10/3.11, and on Colab.

## Status

- [x] I have read the guidelines in
      [CONTRIBUTING.md](https://github.com/icaros-usc/pyribs/blob/master/CONTRIBUTING.md)
- [x] I have formatted my code using `isort` and `ruff`
- [x] I have tested my code by running `pytest`
- [x] I have linted my code with `pylint`
- [x] I have added a one-line description of my change to the changelog in
      `HISTORY.md`
- [x] This PR is ready to go
