### PR TITLE
Fix documentation warnings

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -14,8 +14,17 @@
 
 - Migrate from yapf to ruff for formatting ({pr}`581`, {pr}`582`, {pr}`583`)
 
+## 0.8.2
+
+This release focuses on improving documentation for pyribs, particularly by
+adding the
+[QDAIF tutorial](https://docs.pyribs.org/en/stable/tutorials/qdaif.html).
+
+### Changelog
+
 #### Documentation
 
+- Fix documentation warnings ({pr}`588`)
 - Add QDAIF tutorial ({pr}`587`)
 - Make all metrics start from values in archive stats ({pr}`586`)
 - Update dependencies for lunar lander ({pr}`585`)

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -11,7 +11,7 @@ Pyribs v0.8.0 introduces implementations of several new algorithms:
 - **Novelty Search**
   ([Lehman 2011](https://web.archive.org/web/20220707041732/https://eplex.cs.ucf.edu/papers/lehman_ecj11.pdf))
   via the {class}`~ribs.archives.ProximityArchive`. We illustrate how to run
-  Novelty Search in our new tutorial, {doc}`tutorials/ns_maze`. Visualization is
+  Novelty Search in our new tutorial, {doc}`/tutorials/ns_maze`. Visualization is
   available via {func}`~ribs.visualize.proximity_archive_plot`.
   - Thanks to [@gresavage](https://github.com/gresavage) for helping with this
     implementation!

--- a/docs/whats-new/v0.5.0.md
+++ b/docs/whats-new/v0.5.0.md
@@ -5,7 +5,7 @@ v0.4.0. Most of these changes can be categorized under two goals: (1) integrate
 new algorithms via new emitters and schedulers, and (2) improve archive
 performance via batched operations. We will review the changes related to these
 goals and several other changes made to pyribs. For the full list of changes,
-refer to our [History page](./history).
+refer to our [History page](../history).
 
 ```{note}
 To improve the pyribs API, many of these changes are backwards-incompatible and
@@ -20,12 +20,12 @@ We'll start with some important general changes.
 ### Tutorials
 
 We've added new tutorials and expanded our old ones! We recommend going over the
-updated version of our introductory tutorial, {doc}`tutorials/lunar_lander`, to
+updated version of our introductory tutorial, {doc}`/tutorials/lunar_lander`, to
 get a feel for the new API. Then, learn how we have integrated the
 [CMA-MAE](https://arxiv.org/abs/2205.10752) algorithm in
-{doc}`tutorials/cma_mae`, and implement
+{doc}`/tutorials/cma_mae`, and implement
 [Differentiable Quality Diversity (DQD) algorithms](https://arxiv.org/abs/2106.03894)
-in the tutorial {doc}`tutorials/tom_cruise_dqd`.
+in the tutorial {doc}`/tutorials/tom_cruise_dqd`.
 
 ### Terminology
 
@@ -101,7 +101,7 @@ EvolutionStrategyEmitter(archive, ..., es="sep_cma_es")  # sep-CMA-ES instead of
 
 We have added a {class}`~ribs.emitters.GradientArborescenceEmitter` which
 supports [DQD algorithms](https://arxiv.org/abs/2106.03894). For usage examples,
-see the tutorial {doc}`tutorials/tom_cruise_dqd`.
+see the tutorial {doc}`/tutorials/tom_cruise_dqd`.
 
 ### Custom Initial Solutions in Emitters
 
@@ -306,7 +306,10 @@ To illustrate, the signature for
 {class}`~ribs.emitters.EvolutionStrategyEmitter` is:
 
 ```python
-EvolutionStrategyEmitter(archive, *, x0, sigma0, ranker='2imp', es='cma_es', es_kwargs=None, selection_rule='filter', restart_rule='no_improvement', bounds=None, batch_size=None, seed=None)
+class EvolutionStrategyEmitter(...):
+
+    def __init__(archive, *, x0, sigma0, ranker='2imp', es='cma_es', es_kwargs=None, selection_rule='filter', restart_rule='no_improvement', bounds=None, batch_size=None, seed=None):
+        ...
 ```
 
 All parameters after the `*` are keyword-only. The following will result in an

--- a/docs/whats-new/v0.7.0.md
+++ b/docs/whats-new/v0.7.0.md
@@ -2,7 +2,7 @@
 
 The updates in v0.7.0 centered around making the archives more flexible and
 adding new algorithmic features. Below we describe some of the key changes. For
-the full list of changes, please refer to our [History page](./history).
+the full list of changes, please refer to our [History page](../history).
 
 ## More Flexible Archives
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,7 @@ dev = [
   "Sphinx==4.5.0",
   "sphinx-autobuild==2021.3.14",
   "sphinx-autodoc-typehints==1.18.2",
-  "sphinx-codeautolink==0.12.1",
+  "sphinx-codeautolink==0.17.5",
   "sphinx-copybutton==0.3.1",
   "sphinx-jinja2-compat==0.2.0",
   "sphinx-material==0.0.32",

--- a/ribs/archives/_proximity_archive.py
+++ b/ribs/archives/_proximity_archive.py
@@ -528,7 +528,7 @@ class ProximityArchive(ArchiveBase):
             ValueError: The array arguments do not match their specified shapes.
             ValueError: ``objective`` or ``measures`` has non-finite values (inf or
                 NaN).
-            ValueError: ``local_competition` is turned on but objective was not passed
+            ValueError: ``local_competition`` is turned on but objective was not passed
                 in.
         """
         if objective is None:
@@ -720,7 +720,7 @@ class ProximityArchive(ArchiveBase):
             ValueError: The array arguments do not match their specified shapes.
             ValueError: ``objective`` is non-finite (inf or NaN) or ``measures`` has
                 non-finite values.
-            ValueError: ``local_competition` is turned on but objective was not passed
+            ValueError: ``local_competition`` is turned on but objective was not passed
                 in.
         """
         if objective is None:

--- a/ribs/emitters/_bayesian_opt_emitter.py
+++ b/ribs/emitters/_bayesian_opt_emitter.py
@@ -520,7 +520,7 @@ class BayesianOptimizationEmitter(EmitterBase):
            been found. If not, increments :attr:`_overspec` and repeats the
            process until at least :attr:`batch_size` solutions with positive
            EJIE values have been found.
-        4. Returns the top :attr:`batch_size` solutions with the largest
+        5. Returns the top :attr:`batch_size` solutions with the largest
            EJIE values.
 
         NOTE: This process has been simplified from the original implementation. The


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the PR's purpose here. -->

We are seeing various warnings related to typos and other mistakes in the documentation. `sphinx-codeautolink` was also throwing many warnings; I upgraded it and the warnings seem to be gone now.

## Status

- [x] I have read the guidelines in
      [CONTRIBUTING.md](https://github.com/icaros-usc/pyribs/blob/master/CONTRIBUTING.md)
- [x] I have formatted my code using `isort` and `ruff`
- [x] I have tested my code by running `pytest`
- [x] I have linted my code with `pylint`
- [x] I have added a one-line description of my change to the changelog in
      `HISTORY.md`
- [x] This PR is ready to go
