### PR TITLE
Add alt text for discord link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # pyribs
 
-|                                                        Discord                                                        |                     Mailing List                     |                                                 X                                                  |
-| :-------------------------------------------------------------------------------------------------------------------: | :--------------------------------------------------: | :------------------------------------------------------------------------------------------------: |
-| [![](https://dcbadge.limes.pink/api/server/QxhcJSqZ8G?compact=true&style=flat-square)](https://discord.gg/QxhcJSqZ8G) | [Google Groups](https://groups.google.com/g/pyribs/) | [![X](https://img.shields.io/twitter/follow/pyribs?style=flat-square)](https://twitter.com/pyribs) |
+|                                                               Discord                                                               |                     Mailing List                     |                                                 X                                                  |
+| :---------------------------------------------------------------------------------------------------------------------------------: | :--------------------------------------------------: | :------------------------------------------------------------------------------------------------: |
+| [![Discord Invite](https://dcbadge.limes.pink/api/server/QxhcJSqZ8G?compact=true&style=flat-square)](https://discord.gg/QxhcJSqZ8G) | [Google Groups](https://groups.google.com/g/pyribs/) | [![X](https://img.shields.io/twitter/follow/pyribs?style=flat-square)](https://twitter.com/pyribs) |
 
 |             Website              |                     Source                     |                    Docs                    |                    Paper                     |
 | :------------------------------: | :--------------------------------------------: | :----------------------------------------: | :------------------------------------------: |


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the PR's purpose here. -->

The alt text for the badge was missing. Noticed it when building the documentation as a man page with sphinx.

## Status

- [x] I have read the guidelines in
      [CONTRIBUTING.md](https://github.com/icaros-usc/pyribs/blob/master/CONTRIBUTING.md)
- [x] I have formatted my code using `isort` and `ruff`
- [x] I have tested my code by running `pytest`
- [x] I have linted my code with `pylint`
- [N/A] I have added a one-line description of my change to the changelog in
      `HISTORY.md`
- [x] This PR is ready to go
