### PR TITLE
Proof of concept for building Latex docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,6 +82,13 @@ servedocs: ## compile the docs watching for changes
 		docs/_build/html
 .PHONY: servedocs
 
+latexdocs: ## generate Sphinx Latex documentation, including API docs
+	$(MAKE) -C docs clean
+	$(MAKE) -C docs latex
+	cd docs/_build/latex && LATEXMKOPTS="-output-directory=../pdf" $(MAKE)
+	echo "PDF available in docs/_build/pdf"
+.PHONY: docs
+
 release-test: dist ## package and upload a release to TestPyPI
 	twine upload --repository testpypi dist/*
 .PHONY: release-test

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -106,6 +106,10 @@ extensions = [
     "colab_link",  # Colab links in notebooks.
 ]
 
+# -- Options for Latex output -------------------------------------------
+
+latex_engine = "xelatex"
+
 # -- Options for HTML output -------------------------------------------
 
 # Not used in sphinx-immaterial.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -97,6 +97,9 @@ extensions = [
     "myst_nb",  # Covers both Markdown files and Jupyter notebooks.
     "matplotlib.sphinxext.plot_directive",
     "sphinx_toolbox.more_autodoc.autonamedtuple",
+    # Converts SVG to PDF for Latex documentation; see:
+    # https://pypi.org/project/sphinxcontrib-svg2pdfconverter/
+    "sphinxcontrib.inkscapeconverter",
     # Custom extensions; see docs/_ext.
     "github_links",  # GitHub links.
     "minify_html_files",  # Minify HTML files.

--- a/docs/whats-new/v0.5.0.md
+++ b/docs/whats-new/v0.5.0.md
@@ -217,11 +217,13 @@ archives, columns in {class}`~ribs.archives.ArchiveDataFrame` (returned by
 
 | index | measure_0 | ... | objective | solution_0 | ... | metadata |
 | ----- | --------- | --- | --------- | ---------- | --- | -------- |
+|       |           |     |           |            |     |          |
 
 Before, they were:
 
 | index_0 | ... | behavior_0 | ... | objective | solution_0 | ... | metadata |
 | ------- | --- | ---------- | --- | --------- | ---------- | --- | -------- |
+|         |     |            |     |           |            |     |          |
 
 We have also renamed the `ArchiveDataFrame` methods as follows:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,6 +84,7 @@ dev = [
   "sphinxcontrib-jsmath==1.0.1",
   "sphinxcontrib-qthelp==2.0.0",
   "sphinxcontrib-serializinghtml==2.0.0",
+  "sphinxcontrib-svg2pdfconverter==1.3.0",
   "minify-html==0.15.0",
   "beautifulsoup4==4.13.4",
 

--- a/tutorials/ns_maze.ipynb
+++ b/tutorials/ns_maze.ipynb
@@ -77,7 +77,7 @@
     "\n",
     "We begin by setting up the maze environment in [Kheperax](https://github.com/adaptive-intelligent-robotics/Kheperax/tree/main). This environment contains a circular two-wheeled robot that navigates in a 2D maze for a single episode. The robot has three LiDAR sensors to estimate distance to walls, and two bumpers to detect contact with walls. Observations consist of the readings from the sensors and bumpers, and actions consist of the signals for the left and right wheels. The animation below (reproduced from the Kheperax repo) shows the robot navigating the maze with its sensors.\n",
     "\n",
-    "<!-- <img alt=\"Kheperax robot with sensors\" width=\"40%\" src=\"https://raw.githubusercontent.com/adaptive-intelligent-robotics/Kheperax/main/img/gif/target_policy_standard.gif\" /> -->"
+    "<img alt=\"Kheperax robot with sensors\" width=\"40%\" src=\"https://raw.githubusercontent.com/adaptive-intelligent-robotics/Kheperax/main/img/gif/target_policy_standard.gif\" />"
    ]
   },
   {

--- a/tutorials/ns_maze.ipynb
+++ b/tutorials/ns_maze.ipynb
@@ -77,7 +77,7 @@
     "\n",
     "We begin by setting up the maze environment in [Kheperax](https://github.com/adaptive-intelligent-robotics/Kheperax/tree/main). This environment contains a circular two-wheeled robot that navigates in a 2D maze for a single episode. The robot has three LiDAR sensors to estimate distance to walls, and two bumpers to detect contact with walls. Observations consist of the readings from the sensors and bumpers, and actions consist of the signals for the left and right wheels. The animation below (reproduced from the Kheperax repo) shows the robot navigating the maze with its sensors.\n",
     "\n",
-    "<img alt=\"Kheperax robot with sensors\" width=\"40%\" src=\"https://raw.githubusercontent.com/adaptive-intelligent-robotics/Kheperax/main/img/gif/target_policy_standard.gif\" />"
+    "<!-- <img alt=\"Kheperax robot with sensors\" width=\"40%\" src=\"https://raw.githubusercontent.com/adaptive-intelligent-robotics/Kheperax/main/img/gif/target_policy_standard.gif\" /> -->"
    ]
   },
   {


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the PR's purpose here. -->

I was experimenting with building the docs as a Latex file, since Sphinx provides the ability to build many different documentation formats. Most of the other formats like man pages, epub, dirhtml, singlehtml all work out of the box (although they need some tweaking to get the right appearance), while latex errors out due to a variety of issues. The TODO section below lists the steps I took to get it to mostly work. I think if we wanted this to work properly, it would be possible with a lot more polishing. I have decided to merge this PR since the steps here all seem to not affect the current code, with the exception of item 6 (commenting out the gif; I reverted this).

## TODO

<!-- Notable points that this PR has either accomplished or will accomplish. -->

1. **Make all tables have a table body.** It appears that there is a sphinx transform that will throw an error like:

    ```
    Exception occurred:
      File "/usr/local/lib/python3.11/site-packages/sphinx/builders/latex/transforms.py", line 441, in depart_table
        tbody = next(node.findall(nodes.tbody))
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    StopIteration
    ```
    This issue is shown here: https://github.com/sphinx-doc/sphinx/issues/11751. The solution listed in that issue appears to be to make all tables have a table body; as such, I added a table body to the tables in `docs/whats-new/v0.5.0.md`. I debugged this by modifying the `transforms.py` file to print out the node on line 441, so that I could try to determine where the table with the missing tbody was located.

2. **Latex does not support SVG images with `\includegraphics`.** As such, I had to install the `svg2pdfconverter` extension shown here: https://pypi.org/project/sphinxcontrib-svg2pdfconverter/ This extension converts the SVG files to PDFs with one of many possible commands; I chose to use Inkscape. Thus, the extension is added in `docs/conf.py` as `sphinxcontrib.inkscapeconverter`. This does not appear to affect the output when using the regular `html` output, i.e., the PDFs are _only_ generated for latex. Relevant StackOverflow question [here](https://stackoverflow.com/questions/49898798/using-sphinx-extension-to-convert-svg-to-pdf). Info on how it works is available in the source code [here](https://github.com/missinglinkelectronics/sphinxcontrib-svg2pdfconverter/blob/master/sphinxcontrib/inkscapeconverter.py) and in the reference image converter extension [here](https://www.sphinx-doc.org/en/master/usage/extensions/imgconverter.html), as well as the base class for image converters [here](https://www.sphinx-doc.org/en/master/_modules/sphinx/transforms/post_transforms/images.html).

3. **Bad file paths for images generated by svg2pdfconverter.** When `svg2pdfconverter` runs, one of the files it generates is called `pyribs.pdf` since one of the images in the README is called `pyribs.svg`. Thus, I created a custom build command (see `Makefile`) that builds the pdf from the compiled latex in `docs/_build/pdf/`.

4. **pdflatex does not support Unicode characters.** Due to showing progress bars from tqdm, the tutorials include Unicode characters, which are not supported in pdflatex. Thus, I set `latex_engine = "xelatex"` in `docs/conf.py`, since xelatex handles Unicode.

5. **List too deeply nested.** It turns out there is a docstring list in `ArrayStore` that is too deeply nested, so I modified that docstring to have a less deeply nested list.

6. **(UNRESOLVED) Latex raises an error due to the presence of a gif.** I commented out this gif in `ns_maze.ipynb`, but we would need some extension to convert this gif to make a Latex build work, or we would need a way to ignore the image for Latex.

7. **(UNRESOLVED) Various errors and broken references.** When I left off, there were still a ton of errors in the Latex build. While the PDF built, it seems many issues still need to be resolved.

The final instructions are as follows:

```
make latexdocs
```

In debugging this, it was helpful to run:

```
cd docs
make latex
cd _build
make
```

This way, I could repeatedly go through the Latex errors myself instead of having Sphinx regenerate the whole docs. I encountered errors like the ones shown [here](https://tex.stackexchange.com/questions/331296/error-pdf-file-is-damaged-attempting-to-reconstruct-xref-table), [here](https://tex.stackexchange.com/questions/507213/package-incompatibility-with-hyperxmp-and-silence), and [here](https://tex.stackexchange.com/questions/669494/latexmk-fls-file-lists-log-file-as-an-input-file-and-using-biber-omitting-te).

## Status

- [x] I have read the guidelines in
      [CONTRIBUTING.md](https://github.com/icaros-usc/pyribs/blob/master/CONTRIBUTING.md)
- [x] I have formatted my code using `isort` and `ruff`
- [x] I have tested my code by running `pytest`
- [x] I have linted my code with `pylint`
- [N/A] I have added a one-line description of my change to the changelog in
      `HISTORY.md`
- [x] This PR is ready to go
