### PR TITLE
Replace isort with ruff import check

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -18,7 +18,7 @@
 
 - [ ] I have read the guidelines in
       [CONTRIBUTING.md](https://github.com/icaros-usc/pyribs/blob/master/CONTRIBUTING.md)
-- [ ] I have formatted my code using `isort` and `ruff`
+- [ ] I have formatted my code using `ruff`
 - [ ] I have tested my code by running `pytest`
 - [ ] I have linted my code with `pylint`
 - [ ] I have added a one-line description of my change to the changelog in

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,14 +11,11 @@ repos:
       - id: end-of-file-fixer
       - id: mixed-line-ending
       - id: trailing-whitespace
-  - repo: https://github.com/pycqa/isort
-    rev: 5.11.5
-    hooks:
-      - id: isort
-        name: isort (python)
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.12.4
     hooks:
+      - id: ruff-check
+        args: [--select, I, --fix]
       - id: ruff-format
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: v3.0.2

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,7 +41,7 @@ Ready to contribute? Here's how to set up pyribs for local development.
 
 1. We roughly follow the
    [Google Style Guide](https://google.github.io/styleguide/pyguide.html) in our
-   codebase and use isort, ruff, and pylint to enforce code format and style. To
+   codebase. We use ruff and pylint to enforce code format and style. To
    automatically check for formatting and style every time you commit, we use
    [pre-commit](https://pre-commit.com). Pre-commit should have already been
    installed with `.[dev]` above. To set it up, run:
@@ -53,14 +53,14 @@ Ready to contribute? Here's how to set up pyribs for local development.
 1. Now make the appropriate changes locally. If relevant, make sure to write
    tests for your code in the `tests/` folder.
 
-1. Auto-format and lint your code using [isort](https://pycqa.github.io/isort/),
-   [ruff](https://docs.astral.sh/ruff/formatter/), and
+1. Auto-format and lint your code using
+   [ruff](https://docs.astral.sh/ruff/formatter/) and
    [pylint](https://www.pylint.org/). Note that pre-commit will automatically
    run these whenever you commit your code; you can also run them with
    `pre-commit run`. You can also run these commands on the command line:
 
    ```bash
-   isort FILES
+   ruff check --select I --fix FILES
    ruff format FILES
    pylint FILES
    ```

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -10,6 +10,10 @@
 - **Backwards-incompatible:** Remove raw_dict methods from ArrayStore
   ({pr}`575`)
 
+#### Improvements
+
+- Replace isort with ruff import check ({pr}`603`)
+
 ## 0.8.2
 
 This release focuses on improving documentation for pyribs, particularly by

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -11,7 +11,6 @@
 # the default.
 #
 # pylint: skip-file
-# isort: skip-file
 
 import datetime
 import os

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -11,8 +11,8 @@ Pyribs v0.8.0 introduces implementations of several new algorithms:
 - **Novelty Search**
   ([Lehman 2011](https://web.archive.org/web/20220707041732/https://eplex.cs.ucf.edu/papers/lehman_ecj11.pdf))
   via the {class}`~ribs.archives.ProximityArchive`. We illustrate how to run
-  Novelty Search in our new tutorial, {doc}`/tutorials/ns_maze`. Visualization is
-  available via {func}`~ribs.visualize.proximity_archive_plot`.
+  Novelty Search in our new tutorial, {doc}`/tutorials/ns_maze`. Visualization
+  is available via {func}`~ribs.visualize.proximity_archive_plot`.
   - Thanks to [@gresavage](https://github.com/gresavage) for helping with this
     implementation!
 - **Density Descent Search**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,6 @@ all = [
 ]
 dev = [
   # Tools
-  "isort",
   "ruff",
   "pylint",
   "pre-commit",
@@ -109,11 +108,8 @@ include = ["ribs", "ribs.*"]
 version = {attr = "ribs.__version__"}
 readme = {file = ["README.md", "HISTORY.md"], content-type = "text/markdown"}
 
-[tool.isort]
-known_first_party = "ribs"
-line_length = 88
-multi_line_output = 3  # Matches ruff.
-include_trailing_comma = true  # Matches ruff.
+[tool.ruff.lint.isort]
+known-first-party = ["ribs"]
 
 [tool.pytest.ini_options]
 python_files = "*_test.py"

--- a/tutorials/arm_repertoire.ipynb
+++ b/tutorials/arm_repertoire.ipynb
@@ -46,12 +46,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import time\n",
     "import sys\n",
+    "import time\n",
     "\n",
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",
-    "from tqdm import trange, tqdm"
+    "from tqdm import tqdm, trange"
    ]
   },
   {

--- a/tutorials/cma_mae.ipynb
+++ b/tutorials/cma_mae.ipynb
@@ -112,8 +112,8 @@
    "source": [
     "import sys\n",
     "\n",
-    "import numpy as np\n",
     "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
     "from tqdm import tqdm, trange"
    ]
   },

--- a/tutorials/fooling_mnist.ipynb
+++ b/tutorials/fooling_mnist.ipynb
@@ -46,8 +46,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import time\n",
     "import sys\n",
+    "import time\n",
     "\n",
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",
@@ -132,8 +132,8 @@
    ],
    "source": [
     "import os\n",
-    "from urllib.request import urlretrieve\n",
     "from pathlib import Path\n",
+    "from urllib.request import urlretrieve\n",
     "\n",
     "LOCAL_DIR = Path(\"fooling_mnist_weights\")\n",
     "LOCAL_DIR.mkdir(exist_ok=True)\n",

--- a/tutorials/lsi_mnist.ipynb
+++ b/tutorials/lsi_mnist.ipynb
@@ -176,8 +176,8 @@
    ],
    "source": [
     "import os\n",
-    "from urllib.request import urlretrieve\n",
     "from pathlib import Path\n",
+    "from urllib.request import urlretrieve\n",
     "\n",
     "LOCAL_DIR = Path(\"lsi_mnist_weights\")\n",
     "LOCAL_DIR.mkdir(exist_ok=True)\n",

--- a/tutorials/qdaif.ipynb
+++ b/tutorials/qdaif.ipynb
@@ -620,6 +620,7 @@
     "from pathlib import Path\n",
     "\n",
     "import matplotlib.pyplot as plt\n",
+    "\n",
     "from ribs.visualize import grid_archive_heatmap\n",
     "\n",
     "\n",

--- a/tutorials/qdhf.ipynb
+++ b/tutorials/qdhf.ipynb
@@ -115,6 +115,7 @@
    "outputs": [],
    "source": [
     "import time\n",
+    "\n",
     "import numpy as np\n",
     "from tqdm import tqdm, trange"
    ]
@@ -1011,8 +1012,8 @@
    "outputs": [],
    "source": [
     "from ribs.archives import GridArchive\n",
-    "from ribs.schedulers import Scheduler\n",
     "from ribs.emitters import GaussianEmitter\n",
+    "from ribs.schedulers import Scheduler\n",
     "\n",
     "GRID_SIZE = (20, 20)\n",
     "SEED = 123\n",
@@ -4103,6 +4104,7 @@
    ],
    "source": [
     "from matplotlib import pyplot as plt\n",
+    "\n",
     "from ribs.visualize import grid_archive_heatmap\n",
     "\n",
     "plt.figure(figsize=(6, 4.5))\n",

--- a/tutorials/scalable_cma_mae.ipynb
+++ b/tutorials/scalable_cma_mae.ipynb
@@ -52,8 +52,8 @@
    "source": [
     "import sys\n",
     "\n",
-    "import numpy as np\n",
     "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
     "from tqdm import tqdm, trange"
    ]
   },

--- a/tutorials/tom_cruise_dqd.ipynb
+++ b/tutorials/tom_cruise_dqd.ipynb
@@ -128,18 +128,18 @@
    },
    "outputs": [],
    "source": [
+    "import pickle\n",
+    "import time\n",
+    "from pathlib import Path\n",
+    "\n",
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",
     "import pandas as pd\n",
-    "import pickle\n",
-    "import time\n",
     "import torch\n",
     "import torch.nn.functional as F\n",
-    "\n",
+    "from einops import rearrange\n",
     "from IPython.display import display\n",
     "from PIL import Image\n",
-    "from einops import rearrange\n",
-    "from pathlib import Path\n",
     "from torchvision.utils import make_grid\n",
     "from tqdm import tqdm, trange"
    ]


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the PR's purpose here. -->

Previously, we used isort to sort the imports and ruff to handle the rest of the formatting. This PR migrates to using ruff for the import sorting as well, which reduces the number of tools we depend on.

## TODO

<!-- Notable points that this PR has either accomplished or will accomplish. -->

- [x] Update pyproject.toml -- the settings for ruff's import sorting are similar to isort and are placed under `tool.ruff.lint.isort`
- [x] Update CONTRIBUTING steps and PR template
- [x] Format codebase with the new import sorting -- imports in notebook tutorials were modified

## Status

- [x] I have read the guidelines in
      [CONTRIBUTING.md](https://github.com/icaros-usc/pyribs/blob/master/CONTRIBUTING.md)
- [x] I have formatted my code using `ruff`
- [x] I have tested my code by running `pytest`
- [x] I have linted my code with `pylint`
- [x] I have added a one-line description of my change to the changelog in
      `HISTORY.md`
- [x] This PR is ready to go
