### PR TITLE
Add type annotations to `ribs.schedulers`

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -12,7 +12,7 @@
 
 #### Improvements
 
-- Add type annotations and use ty for type checking ({pr}`606`)
+- Add type annotations and use ty for type checking ({pr}`606`, {pr}`610`)
 - Migrate from pylint to ruff for linting ({pr}`605`, {pr}`607`)
 - Replace isort with ruff import check ({pr}`603`)
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -282,6 +282,12 @@ autodoc_member_order = "groupwise"  # Can be overridden by :member-order:
 autodoc_default_options = {
     "inherited-members": True,
 }
+autodoc_mock_imports = ["matplotlib.typing"]
+autodoc_type_aliases = {
+    # Aliases that we do not want to expand.
+    # https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html#confval-autodoc_type_aliases
+    "ColorType": "matplotlib.typing.ColorType",
+}
 autosummary_generate = True
 
 # -- Matplotlib plot directive.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -286,6 +286,7 @@ autodoc_mock_imports = ["matplotlib.typing"]
 autodoc_type_aliases = {
     # Aliases that we do not want to expand.
     # https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html#confval-autodoc_type_aliases
+    "ArrayLike": "numpy.typing.ArrayLike",
     "ColorType": "matplotlib.typing.ColorType",
 }
 autosummary_generate = True

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -282,7 +282,6 @@ autodoc_member_order = "groupwise"  # Can be overridden by :member-order:
 autodoc_default_options = {
     "inherited-members": True,
 }
-autodoc_mock_imports = ["matplotlib.typing"]
 autodoc_type_aliases = {
     # Aliases that we do not want to expand.
     # https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html#confval-autodoc_type_aliases

--- a/ribs/schedulers/_bandit_scheduler.py
+++ b/ribs/schedulers/_bandit_scheduler.py
@@ -392,14 +392,14 @@ class BanditScheduler:
         # Warn the user if nothing was inserted into the archives -- these warnings use
         # stacklevel=2 so that it's clear the error comes from tell().
         if archive_empty_before and self.archive.empty:
-            warnings.warn(Scheduler.EMPTY_WARNING.format(name="archive"), stacklevel=2)
+            warnings.warn(Scheduler._EMPTY_WARNING.format(name="archive"), stacklevel=2)
         if (
             self._result_archive is not None
             and result_archive_empty_before
             and self.result_archive.empty
         ):
             warnings.warn(
-                Scheduler.EMPTY_WARNING.format(name="result_archive"), stacklevel=2
+                Scheduler._EMPTY_WARNING.format(name="result_archive"), stacklevel=2
             )
 
         # Keep track of pos because emitters may have different batch sizes.

--- a/ribs/schedulers/_bandit_scheduler.py
+++ b/ribs/schedulers/_bandit_scheduler.py
@@ -188,8 +188,8 @@ class BanditScheduler:
     def result_archive(self) -> ArchiveBase:
         """An additional archive for storing solutions found in this scheduler.
 
-        If `result_archive` was not passed to the constructor, this property is the same
-        as :attr:`archive`.
+        If ``result_archive`` was not passed to the constructor, this property is the
+        same as :attr:`archive`.
         """
         return self._archive if self._result_archive is None else self._result_archive
 
@@ -338,8 +338,8 @@ class BanditScheduler:
                 function evaluation of a solution. This can also be None to indicate
                 there is no objective, which would be the case in diversity optimization
                 problems.
-            measures: ``(batch_size, measure_dim)`` where each row contains a solution's
-                coordinates in measure space.
+            measures: ``(batch_size, measure_dim)`` array where each row contains a
+                solution's coordinates in measure space.
             fields: Additional data for each solution. Each argument should be an array
                 with ``batch_size`` as the first dimension.
         Raises:

--- a/ribs/schedulers/_bayesian_opt_scheduler.py
+++ b/ribs/schedulers/_bayesian_opt_scheduler.py
@@ -1,9 +1,15 @@
 """Provides the BayesianOptimizationScheduler."""
 
-import numpy as np
+from __future__ import annotations
 
-from ribs.archives._grid_archive import GridArchive
-from ribs.emitters._bayesian_opt_emitter import BayesianOptimizationEmitter
+from collections.abc import Sequence
+from typing import Literal
+
+import numpy as np
+from numpy.typing import ArrayLike
+
+from ribs.archives import ArchiveBase, GridArchive
+from ribs.emitters import BayesianOptimizationEmitter
 from ribs.schedulers._scheduler import Scheduler
 
 
@@ -15,28 +21,30 @@ class BayesianOptimizationScheduler(Scheduler):
     :class:`~ribs.archives.GridArchive`.
 
     Args:
-        archive (ribs.archives.GridArchive): An archive object.
-        emitters (list of ribs.emitters.BayesianOptimizationEmitter): A list of emitter
-            objects.
-        result_archive (ribs.archives.ArchiveBase): In some algorithms, such as CMA-MAE,
-            the archive does not store all the best-performing solutions. The
-            ``result_archive`` is a secondary archive where we can store all the
-            best-performing solutions.
-        add_mode (str): Indicates how solutions should be added to the archive. The
-            default is "batch", which adds all solutions with one call to
+        archive: An archive object.
+        emitters: A list of emitters.
+        result_archive: An additional archive where all solutions are added.
+        add_mode: Indicates how solutions should be added to the archive. The default is
+            "batch", which adds all solutions with one call to
             :meth:`~ribs.archives.ArchiveBase.add`. Alternatively, use "single" to add
             the solutions one at a time with
             :meth:`~ribs.archives.ArchiveBase.add_single`. "single" mode is included
-            for legacy reasons, as it was the only mode of operation in pyribs 0.4.0 and
-            before. We highly recommend using "batch" mode since it is significantly
-            faster.
+            since implementing batch addition on an archive is sometimes non-trivial.
+            We highly recommend "batch" mode since it is significantly faster.
 
     Raises:
         TypeError: Some emitters are not BayesianOptimizationEmitter.
         ValueError: Not all emitters have the same upscale schedule.
     """
 
-    def __init__(self, archive, emitters, result_archive=None, *, add_mode="batch"):
+    def __init__(
+        self,
+        archive: GridArchive,
+        emitters: Sequence[BayesianOptimizationEmitter],
+        result_archive: ArchiveBase | None = None,
+        *,
+        add_mode: Literal["batch", "single"] = "batch",
+    ) -> None:
         super().__init__(archive, emitters, result_archive, add_mode=add_mode)
 
         # Checks that all emitters are BayesianOptimizationEmitter and have the same
@@ -53,11 +61,17 @@ class BayesianOptimizationScheduler(Scheduler):
                 this_upscale_schedule = e.upscale_schedule
             else:
                 other_upscale_schedule = e.upscale_schedule
-                if (
-                    not isinstance(this_upscale_schedule, np.ndarray)
-                    or not isinstance(other_upscale_schedule, np.ndarray)
-                    or this_upscale_schedule.shape != other_upscale_schedule.shape
-                    or np.any(this_upscale_schedule != other_upscale_schedule)
+                if not (
+                    # Either both schedules are None...
+                    (this_upscale_schedule is None and other_upscale_schedule is None)
+                    or
+                    # ...or they are both numpy arrays with the same shape and values.
+                    (
+                        isinstance(this_upscale_schedule, np.ndarray)
+                        and isinstance(other_upscale_schedule, np.ndarray)
+                        and this_upscale_schedule.shape != other_upscale_schedule.shape
+                        and np.all(this_upscale_schedule == other_upscale_schedule)
+                    )
                 ):
                     raise ValueError(
                         "All emitters must have the same upscale schedule. "
@@ -79,22 +93,39 @@ class BayesianOptimizationScheduler(Scheduler):
             self._upscale_schedule = this_upscale_schedule.copy()
 
     @property
-    def upscale_schedule(self):
-        """The upscale schedules for all the Bayesian optimization emitters.  None if
-        emitters do not undergo archive upscaling."""
+    def upscale_schedule(self) -> np.ndarray | None:
+        """The upscale schedules for all the Bayesian optimization emitters.
+
+        None if emitters do not undergo archive upscaling.
+        """
         return self._upscale_schedule
 
     @Scheduler.archive.setter
-    def archive(self, new_archive):
+    def archive(self, new_archive: GridArchive) -> None:
         self._archive = new_archive
 
-    def ask_dqd(self):
-        raise NotImplementedError("BayesianOptimization currently does not support DQD")
+    def ask_dqd(self) -> None:
+        raise NotImplementedError(
+            "ask_dqd() is not supported by BayesianOptimizationScheduler."
+        )
 
-    def tell_dqd(self, objective, measures, jacobian, **fields):
-        raise NotImplementedError("BayesianOptimization currently does not support DQD")
+    def tell_dqd(
+        self,
+        objective: ArrayLike | None,
+        measures: ArrayLike,
+        jacobian: ArrayLike,
+        **fields: ArrayLike | None,
+    ) -> None:
+        raise NotImplementedError(
+            "tell_dqd() is not supported by BayesianOptimizationScheduler."
+        )
 
-    def tell(self, objective, measures, **fields):
+    def tell(
+        self,
+        objective: ArrayLike | None,
+        measures: ArrayLike,
+        **fields: ArrayLike | None,
+    ) -> None:
         """Updates :attr:`emitters` and the :attr:`archive` with new data.
 
         When **ALL** emitters are ready to upscale, calls

--- a/ribs/schedulers/_scheduler.py
+++ b/ribs/schedulers/_scheduler.py
@@ -135,8 +135,8 @@ class Scheduler:
     def result_archive(self) -> ArchiveBase:
         """An additional archive for storing solutions found in this scheduler.
 
-        If `result_archive` was not passed to the constructor, this property is the same
-        as :attr:`archive`.
+        If ``result_archive`` was not passed to the constructor, this property is the
+        same as :attr:`archive`.
         """
         return self._archive if self._result_archive is None else self._result_archive
 
@@ -314,8 +314,8 @@ class Scheduler:
                 function evaluation of a solution. This can also be None to indicate
                 there is no objective, which would be the case in diversity optimization
                 problems.
-            measures: ``(batch_size, measure_dim)`` where each row contains a solution's
-                coordinates in measure space.
+            measures: ``(batch_size, measure_dim)`` array where each row contains a
+                solution's coordinates in measure space.
             jacobian: ``(batch_size, 1 + measure_dim, solution_dim)`` array consisting
                 of Jacobian matrices of the solutions obtained from :meth:`ask_dqd`.
                 Each matrix should consist of the objective gradient of the solution
@@ -374,8 +374,8 @@ class Scheduler:
                 function evaluation of a solution. This can also be None to indicate
                 there is no objective, which would be the case in diversity optimization
                 problems.
-            measures: ``(batch_size, measure_dim)`` where each row contains a solution's
-                coordinates in measure space.
+            measures: ``(batch_size, measure_dim)`` array where each row contains a
+                solution's coordinates in measure space.
             fields: Additional data for each solution. Each argument should be an array
                 with ``batch_size`` as the first dimension.
         Raises:

--- a/ribs/schedulers/_scheduler.py
+++ b/ribs/schedulers/_scheduler.py
@@ -236,7 +236,7 @@ class Scheduler:
 
         return data
 
-    EMPTY_WARNING = (
+    _EMPTY_WARNING = (
         "`{name}` was empty before adding solutions, and it is still empty "
         "after adding solutions. "
         "One potential cause is that `threshold_min` is too high in this "
@@ -283,14 +283,14 @@ class Scheduler:
         # Warn the user if nothing was inserted into the archives -- these warnings use
         # stacklevel=3 so that it's clear the error comes from tell() or tell_dqd().
         if archive_empty_before and self.archive.empty:
-            warnings.warn(self.EMPTY_WARNING.format(name="archive"), stacklevel=3)
+            warnings.warn(self._EMPTY_WARNING.format(name="archive"), stacklevel=3)
         if (
             self._result_archive is not None
             and result_archive_empty_before
             and self.result_archive.empty
         ):
             warnings.warn(
-                self.EMPTY_WARNING.format(name="result_archive"), stacklevel=3
+                self._EMPTY_WARNING.format(name="result_archive"), stacklevel=3
             )
 
         return add_info

--- a/ribs/schedulers/_scheduler.py
+++ b/ribs/schedulers/_scheduler.py
@@ -1,9 +1,17 @@
 """Provides the Scheduler."""
 
+from __future__ import annotations
+
 import warnings
 from collections import defaultdict
+from collections.abc import Sequence
+from typing import Literal
 
 import numpy as np
+from numpy.typing import ArrayLike
+
+from ribs.archives import ArchiveBase
+from ribs.emitters import EmitterBase
 
 
 class Scheduler:
@@ -24,22 +32,19 @@ class Scheduler:
         range 5]``, which creates 5 unique instances of ``EmitterClass``.
 
     Args:
-        archive (ribs.archives.ArchiveBase): An archive object, e.g.,
-            :class:`~ribs.archives.GridArchive`.
-        emitters (list of ribs.emitters.EmitterBase): A list of emitter objects,
-            e.g., :class:`~ribs.emitters.EvolutionStrategyEmitter`.
-        result_archive (ribs.archives.ArchiveBase): An additional archive where all
-            solutions are added. For example, in CMA-MAE, this archive stores all the
-            best-performing solutions, since the main archive does not store all the
-            best-performing solutions.
-        add_mode (str): Indicates how solutions should be added to the archive. The
-            default is "batch", which adds all solutions with one call to
+        archive: An archive object, e.g., :class:`~ribs.archives.GridArchive`.
+        emitters: A list of emitter objects, e.g.,
+            :class:`~ribs.emitters.EvolutionStrategyEmitter`.
+        result_archive: An additional archive where all solutions are added. For
+            example, in CMA-MAE, this archive stores all the best-performing solutions,
+            since the main archive does not store all the best-performing solutions.
+        add_mode: Indicates how solutions should be added to the archive. The default is
+            "batch", which adds all solutions with one call to
             :meth:`~ribs.archives.ArchiveBase.add`. Alternatively, use "single" to add
             the solutions one at a time with
-            :meth:`~ribs.archives.ArchiveBase.add_single`. "single" mode is included for
-            legacy reasons, as it was the only mode of operation in pyribs 0.4.0 and
-            before. We highly recommend using "batch" mode since it is significantly
-            faster.
+            :meth:`~ribs.archives.ArchiveBase.add_single`. "single" mode is included
+            since implementing batch addition on an archive is sometimes non-trivial.
+            We highly recommend "batch" mode since it is significantly faster.
     Raises:
         TypeError: The ``emitters`` argument was not a list of emitters.
         ValueError: The emitters passed in do not have the same solution dimensions.
@@ -51,7 +56,14 @@ class Scheduler:
             (``result_archive`` should not be passed in this case).
     """
 
-    def __init__(self, archive, emitters, result_archive=None, *, add_mode="batch"):
+    def __init__(
+        self,
+        archive: ArchiveBase,
+        emitters: Sequence[EmitterBase],
+        result_archive: ArchiveBase | None = None,
+        *,
+        add_mode: Literal["batch", "single"] = "batch",
+    ) -> None:
         try:
             if len(emitters) == 0:
                 raise ValueError("Pass in at least one emitter to the scheduler.")
@@ -110,36 +122,33 @@ class Scheduler:
         self._num_emitted = [None for _ in self._emitters]
 
     @property
-    def archive(self):
-        """ribs.archives.ArchiveBase: Archive for storing solutions found in this
-        scheduler."""
+    def archive(self) -> ArchiveBase:
+        """Archive for storing solutions found in this scheduler."""
         return self._archive
 
     @property
-    def emitters(self):
-        """list of ribs.archives.EmitterBase: Emitters for generating solutions in this
-        scheduler."""
+    def emitters(self) -> Sequence[EmitterBase]:
+        """Emitters for generating solutions in this scheduler."""
         return self._emitters
 
     @property
-    def result_archive(self):
-        """ribs.archives.ArchiveBase: An additional archive for storing solutions found
-        in this scheduler.
+    def result_archive(self) -> ArchiveBase:
+        """An additional archive for storing solutions found in this scheduler.
 
-        If `result_archive` was not passed to the constructor, this property is
-        the same as :attr:`archive`.
+        If `result_archive` was not passed to the constructor, this property is the same
+        as :attr:`archive`.
         """
         return self._archive if self._result_archive is None else self._result_archive
 
-    def ask_dqd(self):
+    def ask_dqd(self) -> np.ndarray:
         """Generates a batch of solutions by calling ask_dqd() on all DQD emitters.
 
         .. note:: The order of the solutions returned from this method is important, so
             do not rearrange them.
 
         Returns:
-            (batch_size, dim) array: An array of n solutions to evaluate. Each row
-            contains a single solution.
+            A ``(batch_size, dim)`` array of solutions to evaluate. Each row contains a
+            single solution.
         Raises:
             RuntimeError: This method was called immediately after calling an ask
                 method.
@@ -165,15 +174,15 @@ class Scheduler:
         )
         return self._cur_solutions
 
-    def ask(self):
+    def ask(self) -> np.ndarray:
         """Generates a batch of solutions by calling ask() on all emitters.
 
         .. note:: The order of the solutions returned from this method is important, so
             do not rearrange them.
 
         Returns:
-            (batch_size, dim) array: An array of n solutions to evaluate. Each row
-            contains a single solution.
+            A ``(batch_size, dim)`` array of solutions to evaluate. Each row contains a
+            single solution.
         Raises:
             RuntimeError: This method was called immediately after calling an ask
                 method.
@@ -199,7 +208,7 @@ class Scheduler:
         )
         return self._cur_solutions
 
-    def _check_length(self, name, arr):
+    def _check_length(self, name: str, arr: ArrayLike) -> None:
         """Raises a ValueError if array does not have the same length as the
         solutions."""
         if len(arr) != len(self._cur_solutions):
@@ -209,7 +218,9 @@ class Scheduler:
                 f"has length {len(arr)}"
             )
 
-    def _validate_tell_data(self, data):
+    def _validate_tell_data(
+        self, data: dict[str, ArrayLike | None]
+    ) -> dict[str, np.ndarray | None]:
         """Preprocesses data passed into tell methods."""
         for name, arr in data.items():
             # Fields are allowed to be None to indicate they are not present, e.g.,
@@ -233,7 +244,9 @@ class Scheduler:
         "objective value does not exceed `threshold_min`."
     )
 
-    def _add_to_archives(self, data):
+    def _add_to_archives(
+        self, data: dict[str, np.ndarray | None]
+    ) -> dict[str, np.ndarray]:
         """Adds solutions to both the regular archive and the result archive."""
 
         archive_empty_before = self.archive.empty
@@ -282,7 +295,13 @@ class Scheduler:
 
         return add_info
 
-    def tell_dqd(self, objective, measures, jacobian, **fields):
+    def tell_dqd(
+        self,
+        objective: ArrayLike | None,
+        measures: ArrayLike,
+        jacobian: ArrayLike,
+        **fields: ArrayLike | None,
+    ) -> None:
         """Returns info for solutions from :meth:`ask_dqd`.
 
         .. note:: The objective, measures, and jacobian arrays must be in the same order
@@ -291,18 +310,18 @@ class Scheduler:
             jacobian for ``solution[i]``.
 
         Args:
-            objective ((batch_size,) array or None): Each entry of this array contains
-                the objective function evaluation of a solution. This can also be None
-                to indicate there is no objective -- this would be the case in diversity
-                optimization problems.
-            measures ((batch_size, measure_dim) array): Each row of this array contains
-                a solution's coordinates in measure space.
-            jacobian (numpy.ndarray): ``(batch_size, 1 + measure_dim, solution_dim)``
-                array consisting of Jacobian matrices of the solutions obtained from
-                :meth:`ask_dqd`. Each matrix should consist of the objective gradient of
-                the solution followed by the measure gradients.
-            fields (keyword arguments): Additional data for each solution. Each argument
-                should be an array with batch_size as the first dimension.
+            objective: ``(batch_size,)`` array where each entry contains the objective
+                function evaluation of a solution. This can also be None to indicate
+                there is no objective, which would be the case in diversity optimization
+                problems.
+            measures: ``(batch_size, measure_dim)`` where each row contains a solution's
+                coordinates in measure space.
+            jacobian: ``(batch_size, 1 + measure_dim, solution_dim)`` array consisting
+                of Jacobian matrices of the solutions obtained from :meth:`ask_dqd`.
+                Each matrix should consist of the objective gradient of the solution
+                followed by the measure gradients.
+            fields: Additional data for each solution. Each argument should be an array
+                with ``batch_size`` as the first dimension.
         Raises:
             RuntimeError: This method was called without first calling :meth:`ask_dqd`.
             ValueError: One of the inputs has the wrong shape.
@@ -338,22 +357,27 @@ class Scheduler:
             )
             pos = end
 
-    def tell(self, objective, measures, **fields):
+    def tell(
+        self,
+        objective: ArrayLike | None,
+        measures: ArrayLike,
+        **fields: ArrayLike | None,
+    ) -> None:
         """Returns info for solutions from :meth:`ask`.
 
         .. note:: The objective and measures arrays must be in the same order as the
-            solutions created by :meth:`ask_dqd`; i.e. ``objective[i]`` and
-            ``measures[i]`` should be the objective and measures for ``solution[i]``.
+            solutions created by :meth:`ask`; i.e. ``objective[i]`` and ``measures[i]``
+            should be the objective and measures for ``solution[i]``.
 
         Args:
-            objective ((batch_size,) array or None): Each entry of this array contains
-                the objective function evaluation of a solution. This can also be None
-                to indicate there is no objective -- this would be the case in diversity
-                optimization problems.
-            measures ((batch_size, measures_dm) array): Each row of this array contains
-                a solution's coordinates in measure space.
-            fields (keyword arguments): Additional data for each solution. Each argument
-                should be an array with batch_size as the first dimension.
+            objective: ``(batch_size,)`` array where each entry contains the objective
+                function evaluation of a solution. This can also be None to indicate
+                there is no objective, which would be the case in diversity optimization
+                problems.
+            measures: ``(batch_size, measure_dim)`` where each row contains a solution's
+                coordinates in measure space.
+            fields: Additional data for each solution. Each argument should be an array
+                with ``batch_size`` as the first dimension.
         Raises:
             RuntimeError: This method was called without first calling :meth:`ask`.
             ValueError: One of the inputs has the wrong shape.

--- a/tests/schedulers/scheduler_test.py
+++ b/tests/schedulers/scheduler_test.py
@@ -62,7 +62,7 @@ def test_init_fails_with_non_list():
     emitters = GaussianEmitter(archive, sigma=1, x0=[0.0, 0.0], batch_size=1)
 
     with pytest.raises(TypeError):
-        Scheduler(archive, emitters)
+        Scheduler(archive, emitters)  # ty: ignore[invalid-argument-type]
 
 
 def test_init_fails_with_no_emitters():


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the PR's purpose here. -->

Continuing #606.

## TODO

<!-- Notable points that this PR has either accomplished or will accomplish. -->

- [x] Add annotations to ribs.schedulers
- [x] Make `EMPTY_WARNING` private on `Scheduler`
- [x] Avoid expanding ArrayLike and ColorType alias in the docs -- unfortunately, I could not figure out how to get the links to these types to work, so they just show up as `ArrayLike` and `matplotlib.typing.ColorType` in the docs and you can't click on a link to see what they mean. This seems to be a persistent issue; see: https://github.com/sphinx-doc/sphinx/issues/10794, https://github.com/sphinx-doc/sphinx/issues/10746, https://github.com/jbms/sphinx-immaterial/issues/270

## Status

- [x] I have read the guidelines in
      [CONTRIBUTING.md](https://github.com/icaros-usc/pyribs/blob/master/CONTRIBUTING.md)
- [x] I have linted and formatted my code with `ruff` and `ty`
- [x] I have tested my code by running `pytest`
- [x] I have added a description of my change to the changelog in `HISTORY.md`
- [x] This PR is ready to go
