### PR TITLE
Add pydocstyle and tidy up ribs.visualize docstrings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,6 +126,7 @@ select = [
   "I",  # isort
   "NPY",  # numpy
   "PD",  # pandas-vet
+  "D",  # pydocstyle
   "PL",  # pylint
   "PYI",  # flake8-pyi
   "PT",  # pytest
@@ -161,6 +162,9 @@ ignore = [
   "PLR0917",
   "PLR1702",
 ]
+
+[tool.ruff.lint.per-file-ignores]
+"tests/**/*" = ["D"]
 
 [tool.ruff.lint.pep8-naming]
 ignore-names = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,7 +126,7 @@ select = [
   "I",  # isort
   "NPY",  # numpy
   "PD",  # pandas-vet
-  "D",  # pydocstyle
+  # "D",  # pydocstyle
   "PL",  # pylint
   "PYI",  # flake8-pyi
   "PT",  # pytest

--- a/ribs/visualize/_cvt_archive_3d_plot.py
+++ b/ribs/visualize/_cvt_archive_3d_plot.py
@@ -46,7 +46,7 @@ def cvt_archive_3d_plot(
     plot_samples: bool = False,
     ms: float = 1,
 ) -> None:
-    """Plots a :class:`~ribs.archives.CVTArchive` with 3D measure space.
+    r"""Plots a :class:`~ribs.archives.CVTArchive` with 3D measure space.
 
     This function relies on Matplotlib's `mplot3d
     <https://matplotlib.org/stable/tutorials/toolkits/mplot3d.html>`_ toolkit. By
@@ -180,7 +180,7 @@ def cvt_archive_3d_plot(
             measure 1 on the y-axis, and measure 0 on the z-axis.
         cmap: The colormap to use when plotting intensity. Either the name of a
             :class:`~matplotlib.colors.Colormap`, a list of Matplotlib color
-            specifications (e.g., an :math:`N \\times 3` or :math:`N \\times 4` array --
+            specifications (e.g., an :math:`N \times 3` or :math:`N \times 4` array --
             see :class:`~matplotlib.colors.ListedColormap`), or a
             :class:`~matplotlib.colors.Colormap` object.
         lw: Line width when plotting the Voronoi diagram.

--- a/ribs/visualize/_cvt_archive_heatmap.py
+++ b/ribs/visualize/_cvt_archive_heatmap.py
@@ -47,8 +47,7 @@ def cvt_archive_heatmap(
     ms: float = 1,
     pcm_kwargs: dict | None = None,
 ) -> None:
-    """Plots heatmap of a :class:`~ribs.archives.CVTArchive` with 1D or 2D measure
-    space.
+    r"""Plots heatmap of a :class:`~ribs.archives.CVTArchive` with 1D or 2D measure space.
 
     In the 2D case, we create a Voronoi diagram and shade in each cell with a color
     corresponding to the objective value of that cell's elite. In the 1D case, we plot a
@@ -125,7 +124,7 @@ def cvt_archive_heatmap(
             for 1D archives.
         cmap: The colormap to use when plotting intensity. Either the name of a
             :class:`~matplotlib.colors.Colormap`, a list of Matplotlib color
-            specifications (e.g., an :math:`N \\times 3` or :math:`N \\times 4` array --
+            specifications (e.g., an :math:`N \times 3` or :math:`N \times 4` array --
             see :class:`~matplotlib.colors.ListedColormap`), or a
             :class:`~matplotlib.colors.Colormap` object.
         aspect: The aspect ratio of the heatmap (i.e. height/width). Defaults to

--- a/ribs/visualize/_grid_archive_heatmap.py
+++ b/ribs/visualize/_grid_archive_heatmap.py
@@ -37,8 +37,7 @@ def grid_archive_heatmap(
     rasterized: bool = False,
     pcm_kwargs: dict | None = None,
 ) -> None:
-    """Plots heatmap of a :class:`~ribs.archives.GridArchive` with 1D or 2D measure
-    space.
+    r"""Plots heatmap of a :class:`~ribs.archives.GridArchive` with 1D or 2D measure space.
 
     This function creates a grid of cells and shades each cell with a color
     corresponding to the objective value of that cell's elite. This function uses
@@ -113,7 +112,7 @@ def grid_archive_heatmap(
             for 1D archives.
         cmap: The colormap to use when plotting intensity. Either the name of a
             :class:`~matplotlib.colors.Colormap`, a list of Matplotlib color
-            specifications (e.g., an :math:`N \\times 3` or :math:`N \\times 4` array --
+            specifications (e.g., an :math:`N \times 3` or :math:`N \times 4` array --
             see :class:`~matplotlib.colors.ListedColormap`), or a
             :class:`~matplotlib.colors.Colormap` object.
         aspect: The aspect ratio of the heatmap (i.e. height/width). Defaults to

--- a/ribs/visualize/_parallel_axes_plot.py
+++ b/ribs/visualize/_parallel_axes_plot.py
@@ -37,7 +37,7 @@ def parallel_axes_plot(
     cbar: Literal["auto"] | None | Axes = "auto",
     cbar_kwargs: dict | None = None,
 ) -> None:
-    """Visualizes archive elites in measure space with a parallel axes plot.
+    r"""Visualizes archive elites in measure space with a parallel axes plot.
 
     This visualization is meant to show the coverage of the measure space at a glance.
     Each axis represents one measure dimension, and each line in the diagram represents
@@ -108,7 +108,7 @@ def parallel_axes_plot(
             ``[1, 3]`` or ``[1, 2, 3, 2]``.
         cmap: The colormap to use when plotting intensity. Either the name of a
             :class:`~matplotlib.colors.Colormap`, a list of Matplotlib color
-            specifications (e.g., an :math:`N \\times 3` or :math:`N \\times 4` array --
+            specifications (e.g., an :math:`N \times 3` or :math:`N \times 4` array --
             see :class:`~matplotlib.colors.ListedColormap`), or a
             :class:`~matplotlib.colors.Colormap` object.
         linewidth: Line width for each elite in the plot.

--- a/ribs/visualize/_proximity_archive_plot.py
+++ b/ribs/visualize/_proximity_archive_plot.py
@@ -38,8 +38,7 @@ def proximity_archive_plot(
     cbar_kwargs: dict | None = None,
     rasterized: bool = False,
 ) -> None:
-    """Plots scatterplot of a :class:`~ribs.archives.ProximityArchive` with 2D measure
-    space.
+    r"""Plots scatterplot of a :class:`~ribs.archives.ProximityArchive` with 2D measure space.
 
     Each marker in the scatterplot is an elite, and its color represents the objective
     value (objective values default to 0 in the ``ProximityArchive``).
@@ -118,7 +117,7 @@ def proximity_archive_plot(
             behavior (i.e. to transpose the axes), set this to ``True``.
         cmap: The colormap to use when plotting intensity. Either the name of a
             :class:`~matplotlib.colors.Colormap`, a list of Matplotlib color
-            specifications (e.g., an :math:`N \\times 3` or :math:`N \\times 4` array --
+            specifications (e.g., an :math:`N \times 3` or :math:`N \times 4` array --
             see :class:`~matplotlib.colors.ListedColormap`), or a
             :class:`~matplotlib.colors.Colormap` object.
         aspect: The aspect ratio of the heatmap (i.e. height/width). Defaults to
@@ -143,6 +142,7 @@ def proximity_archive_plot(
             raster graphic so that the archive cells will not have to be individually
             rendered. Meanwhile, the surrounding axes, particularly text labels, will
             remain in vector format.
+
     Raises:
         ValueError: The archive is not 2D.
     """

--- a/ribs/visualize/_sliding_boundaries_archive_heatmap.py
+++ b/ribs/visualize/_sliding_boundaries_archive_heatmap.py
@@ -37,8 +37,7 @@ def sliding_boundaries_archive_heatmap(
     cbar_kwargs: dict | None = None,
     rasterized: bool = False,
 ) -> None:
-    """Plots heatmap of a :class:`~ribs.archives.SlidingBoundariesArchive` with 2D
-    measure space.
+    r"""Plots heatmap of a :class:`~ribs.archives.SlidingBoundariesArchive` with 2D measure space.
 
     Since the boundaries of :class:`ribs.archives.SlidingBoundariesArchive` are dynamic,
     we plot the heatmap as a scatter plot, in which each marker is an elite and its
@@ -89,7 +88,7 @@ def sliding_boundaries_archive_heatmap(
             behavior (i.e. to transpose the axes), set this to ``True``.
         cmap: The colormap to use when plotting intensity. Either the name of a
             :class:`~matplotlib.colors.Colormap`, a list of Matplotlib color
-            specifications (e.g., an :math:`N \\times 3` or :math:`N \\times 4` array --
+            specifications (e.g., an :math:`N \times 3` or :math:`N \times 4` array --
             see :class:`~matplotlib.colors.ListedColormap`), or a
             :class:`~matplotlib.colors.Colormap` object.
         aspect: The aspect ratio of the heatmap (i.e. height/width). Defaults to
@@ -112,6 +111,7 @@ def sliding_boundaries_archive_heatmap(
             raster graphic so that the archive cells will not have to be individually
             rendered. Meanwhile, the surrounding axes, particularly text labels, will
             remain in vector format.
+
     Raises:
         ValueError: The archive is not 2D.
     """

--- a/ribs/visualize/_utils.py
+++ b/ribs/visualize/_utils.py
@@ -35,10 +35,12 @@ def validate_heatmap_visual_args(
     valid_dims: list[int],
     error_msg_measure_dim: str,
 ) -> None:
-    """Helper function to validate arguments passed to `*_archive_heatmap` plotting
-    functions.
+    """Helper function to validate arguments passed to `*_archive_heatmap` plotting functions.
 
     Args:
+        aspect: See a visualization function like grid_archive_heatmap.
+        cbar: See a visualization function like grid_archive_heatmap.
+        measure_dim: See a visualization function like grid_archive_heatmap.
         valid_dims: All specified valid archive dimensions that may be plotted into
             heatmaps.
         error_msg_measure_dim: Error message in ValueError if archive dimension plotting
@@ -63,7 +65,6 @@ def validate_heatmap_visual_args(
 
 def validate_df(df: DataFrame | ArchiveDataFrame | None) -> ArchiveDataFrame:
     """Helper to validate the df passed into visualization functions."""
-
     # Cast to an ArchiveDataFrame in case someone passed in a regular DataFrame
     # or other object.
     if not isinstance(df, ArchiveDataFrame):
@@ -126,6 +127,7 @@ def archive_heatmap_1d(
         cbar_kwargs: See heatmap methods, e.g., grid_archive_heatmap.
         rasterized: See heatmap methods, e.g., grid_archive_heatmap.
         pcm_kwargs: Additional kwargs to pass to :func:`~matplotlib.pyplot.pcolormesh`.
+
     Returns:
         The Axes where the heatmap was plotted. This may be used to further modify the
         plot.

--- a/ribs/visualize/_visualize_qdax.py
+++ b/ribs/visualize/_visualize_qdax.py
@@ -21,7 +21,6 @@ def _as_cvt_archive(
     ranges: Sequence[tuple[float, float]],
 ) -> CVTArchive:
     """Converts a QDax repertoire into a CVTArchive."""
-
     # Construct a CVTArchive. We set solution_dim to 0 since we are only plotting and do
     # not need to have the solutions available.
     cvt_archive = CVTArchive(
@@ -73,10 +72,10 @@ def qdax_repertoire_heatmap(
             does not store measure space bounds.
         *args: Positional arguments to pass to :meth:`cvt_archive_heatmap`.
         **kwargs: Keyword arguments to pass to :meth:`cvt_archive_heatmap`.
+
     Raises:
         ValueError: The repertoire passed in has more than one fitness.
     """
-
     cvt_archive_heatmap(_as_cvt_archive(repertoire, ranges), *args, **kwargs)
 
 
@@ -102,6 +101,7 @@ def qdax_repertoire_3d_plot(
             measure space bounds.
         *args: Positional arguments to pass to :meth:`cvt_archive_3d_plot`.
         **kwargs: Keyword arguments to pass to :meth:`cvt_archive_3d_plot`.
+
     Raises:
         ValueError: The repertoire passed in has more than one fitness.
     """


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the PR's purpose here. -->

Adds [pydocstyle](https://docs.astral.sh/ruff/rules/#pydocstyle-d) to the list of linting rules from Ruff. Since this triggers a lot of errors, I have commented out this rule for now and decided not to address all errors in this PR. Instead, I will handle them as I work on annotations (see #606).

## TODO

<!-- Notable points that this PR has either accomplished or will accomplish. -->

- [x] Add rule to pyproject.toml
- [x] Tidy up docstrings in ribs.visualize

## Status

- [x] I have read the guidelines in
      [CONTRIBUTING.md](https://github.com/icaros-usc/pyribs/blob/master/CONTRIBUTING.md)
- [x] I have linted and formatted my code with `ruff` and `ty`
- [x] I have tested my code by running `pytest`
- [x] I have added a description of my change to the changelog in `HISTORY.md`
- [x] This PR is ready to go
