### PR TITLE
Fix bug in ribs.visualize args tests

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -16,6 +16,10 @@
 - Migrate from pylint to ruff for linting ({pr}`605`, {pr}`607`)
 - Replace isort with ruff import check ({pr}`603`)
 
+#### Bugs
+
+- Fix bug in ribs.visualize args tests ({pr}`613`)
+
 ## 0.8.2
 
 This release focuses on improving documentation for pyribs, particularly by

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -18,7 +18,7 @@
 
 #### Bugs
 
-- Fix bug in ribs.visualize args tests ({pr}`613`)
+- Fix bug in ribs.visualize args tests ({pr}`615`)
 
 ## 0.8.2
 

--- a/tests/visualize/args_test.py
+++ b/tests/visualize/args_test.py
@@ -54,18 +54,18 @@ def test_fails_on_unsupported_dims(archive_type):
 def test_heatmap_fails_on_invalid_cbar_option(archive_type, invalid_arg_cbar):
     archive = {
         "grid": lambda: GridArchive(
-            solution_dim=2, dims=[20, 20, 20], ranges=[(-1, 1)] * 3
+            solution_dim=2, dims=[20, 20], ranges=[(-1, 1)] * 2
         ),
         "cvt": lambda: CVTArchive(
             solution_dim=2,
             cells=100,
-            ranges=[(-1, 1)] * 3,
+            ranges=[(-1, 1)] * 2,
             samples=100,
         ),
         "sliding": lambda: SlidingBoundariesArchive(
             solution_dim=2,
-            dims=[20, 20, 20],
-            ranges=[(-1, 1)] * 3,
+            dims=[20, 20],
+            ranges=[(-1, 1)] * 2,
         ),
         "cvt_3d": lambda: CVTArchive(
             solution_dim=2,
@@ -75,7 +75,7 @@ def test_heatmap_fails_on_invalid_cbar_option(archive_type, invalid_arg_cbar):
         ),
     }[archive_type]()
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=r"Invalid arg cbar=.*"):
         {
             "grid": grid_archive_heatmap,
             "cvt": cvt_archive_heatmap,
@@ -93,17 +93,17 @@ def test_heatmap_fails_on_invalid_cbar_option(archive_type, invalid_arg_cbar):
 def test_heatmap_fails_on_invalid_aspect_option(archive_type, invalid_arg_aspect):
     archive = {
         "grid": lambda: GridArchive(
-            solution_dim=2, dims=[20, 20, 20], ranges=[(-1, 1)] * 3
+            solution_dim=2, dims=[20, 20], ranges=[(-1, 1)] * 2
         ),
         "cvt": lambda: CVTArchive(
-            solution_dim=2, cells=100, ranges=[(-1, 1)] * 3, samples=100
+            solution_dim=2, cells=100, ranges=[(-1, 1)] * 2, samples=100
         ),
         "sliding": lambda: SlidingBoundariesArchive(
-            solution_dim=2, dims=[20, 20, 20], ranges=[(-1, 1)] * 3
+            solution_dim=2, dims=[20, 20], ranges=[(-1, 1)] * 2
         ),
     }[archive_type]()
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=r"Invalid arg aspect=.*"):
         {
             "grid": grid_archive_heatmap,
             "cvt": cvt_archive_heatmap,

--- a/tests/visualize/args_test.py
+++ b/tests/visualize/args_test.py
@@ -38,7 +38,7 @@ def test_fails_on_unsupported_dims(archive_type):
         ),
     }[archive_type]()
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=r".* can only be .* for .*"):
         {
             "grid": grid_archive_heatmap,
             "cvt": cvt_archive_heatmap,


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the PR's purpose here. -->

Found a bug in the tests where they did not catch the errors for invalid cbar and aspect args because the archives were incorrectly sized. I changed the tests to use `match` so that this does not slip through again.

## Status

- [x] I have read the guidelines in
      [CONTRIBUTING.md](https://github.com/icaros-usc/pyribs/blob/master/CONTRIBUTING.md)
- [x] I have linted and formatted my code with `ruff` and `ty`
- [x] I have tested my code by running `pytest`
- [x] I have added a description of my change to the changelog in `HISTORY.md`
- [x] This PR is ready to go
