### PR TITLE
Add `import_aggregate` utility to correctly import from numpy groupies

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -12,6 +12,8 @@
 
 #### Improvements
 
+- Add `import_aggregate` utility to correctly import from numpy groupies
+  ({pr}`621`)
 - Add type annotations and use ty for type checking ({pr}`606`, {pr}`610`,
   {pr}`620`)
 - Migrate from pylint to ruff for linting ({pr}`605`, {pr}`607`, {pr}`612`,

--- a/ribs/_utils.py
+++ b/ribs/_utils.py
@@ -1,6 +1,7 @@
 """Miscellaneous internal utilities."""
 
 import numbers
+import warnings
 
 import array_api_compat.numpy as np_compat
 import numpy as np  # TODO (#576): Remove import of np
@@ -236,3 +237,23 @@ def xp_namespace(xp):
     https://github.com/data-apis/array-api-compat/issues/342
     """
     return np_compat if xp is None else array_namespace(xp.empty(0))
+
+
+def import_aggregate():
+    """Imports the aggregate function from numpy groupies.
+
+    If we are unable to get the numba version (aggregate_nb), we import the regular
+    aggregate (which may be slow) and warn the user accordingly.
+    """
+    from numpy_groupies import aggregate_nb
+
+    if aggregate_nb is not None:
+        return aggregate_nb
+    else:
+        from numpy_groupies import aggregate
+
+        warnings.warn(
+            "Unable to import aggregate_nb from numpy_groupies. For best performance, please make sure numba is installed.",
+            stacklevel=2,
+        )
+        return aggregate

--- a/ribs/archives/_categorical_archive.py
+++ b/ribs/archives/_categorical_archive.py
@@ -1,9 +1,14 @@
 """Contains the CategoricalArchive."""
 
 import numpy as np
-from numpy_groupies import aggregate_nb as aggregate
 
-from ribs._utils import check_batch_shape, check_shape, validate_batch, validate_single
+from ribs._utils import (
+    check_batch_shape,
+    check_shape,
+    import_aggregate,
+    validate_batch,
+    validate_single,
+)
 from ribs.archives._archive_base import ArchiveBase
 from ribs.archives._archive_stats import ArchiveStats
 from ribs.archives._array_store import ArrayStore
@@ -13,6 +18,8 @@ from ribs.archives._utils import (
     parse_dtype,
     validate_cma_mae_settings,
 )
+
+aggregate = import_aggregate()
 
 
 class CategoricalArchive(ArchiveBase):
@@ -351,11 +358,11 @@ class CategoricalArchive(ArchiveBase):
         #
         # All objective_sizes should be > 0 since we only retrieve counts for indices in
         # `indices`.
-        objective_sizes = aggregate(indices, 1, func="len", fill_value=0)[indices]  # ty: ignore[call-non-callable]
+        objective_sizes = aggregate(indices, 1, func="len", fill_value=0)[indices]
 
         # Compute the sum of the objectives inserted into each cell -- again, we index
         # with `indices`.
-        objective_sums = aggregate(indices, objective, func="sum", fill_value=np.nan)[  # ty: ignore[call-non-callable]
+        objective_sums = aggregate(indices, objective, func="sum", fill_value=np.nan)[
             indices
         ]
 
@@ -544,7 +551,7 @@ class CategoricalArchive(ArchiveBase):
         # elite will be inserted if there is a tie. See their default numpy
         # implementation for more info:
         # https://github.com/ml31415/numpy-groupies/blob/master/numpy_groupies/aggregate_numpy.py#L107
-        archive_argmax = aggregate(  # ty: ignore[call-non-callable]
+        archive_argmax = aggregate(
             indices, data["objective"], func="argmax", fill_value=-1
         )
         should_insert = archive_argmax[archive_argmax != -1]

--- a/ribs/archives/_cvt_archive.py
+++ b/ribs/archives/_cvt_archive.py
@@ -3,7 +3,6 @@
 import numbers
 
 import numpy as np
-from numpy_groupies import aggregate_nb as aggregate
 from scipy.spatial import cKDTree  # ty: ignore[unresolved-import]
 from scipy.stats.qmc import Halton, Sobol
 from sklearn.cluster import k_means
@@ -12,6 +11,7 @@ from ribs._utils import (
     check_batch_shape,
     check_finite,
     check_shape,
+    import_aggregate,
     validate_batch,
     validate_single,
 )
@@ -23,6 +23,8 @@ from ribs.archives._utils import (
     parse_dtype,
     validate_cma_mae_settings,
 )
+
+aggregate = import_aggregate()
 
 
 class CVTArchive(ArchiveBase):
@@ -547,11 +549,11 @@ class CVTArchive(ArchiveBase):
         #
         # All objective_sizes should be > 0 since we only retrieve counts for indices in
         # `indices`.
-        objective_sizes = aggregate(indices, 1, func="len", fill_value=0)[indices]  # ty: ignore[call-non-callable]
+        objective_sizes = aggregate(indices, 1, func="len", fill_value=0)[indices]
 
         # Compute the sum of the objectives inserted into each cell -- again, we index
         # with `indices`.
-        objective_sums = aggregate(indices, objective, func="sum", fill_value=np.nan)[  # ty: ignore[call-non-callable]
+        objective_sums = aggregate(indices, objective, func="sum", fill_value=np.nan)[
             indices
         ]
 
@@ -740,7 +742,7 @@ class CVTArchive(ArchiveBase):
         # elite will be inserted if there is a tie. See their default numpy
         # implementation for more info:
         # https://github.com/ml31415/numpy-groupies/blob/master/numpy_groupies/aggregate_numpy.py#L107
-        archive_argmax = aggregate(  # ty: ignore[call-non-callable]
+        archive_argmax = aggregate(
             indices, data["objective"], func="argmax", fill_value=-1
         )
         should_insert = archive_argmax[archive_argmax != -1]

--- a/ribs/archives/_grid_archive.py
+++ b/ribs/archives/_grid_archive.py
@@ -1,13 +1,13 @@
 """Contains the GridArchive."""
 
 import numpy as np
-from numpy_groupies import aggregate_nb as aggregate
 
 from ribs._utils import (
     check_batch_shape,
     check_finite,
     check_is_1d,
     check_shape,
+    import_aggregate,
     validate_batch,
     validate_single,
 )
@@ -19,6 +19,8 @@ from ribs.archives._utils import (
     parse_dtype,
     validate_cma_mae_settings,
 )
+
+aggregate = import_aggregate()
 
 
 class GridArchive(ArchiveBase):
@@ -476,11 +478,11 @@ class GridArchive(ArchiveBase):
         #
         # All objective_sizes should be > 0 since we only retrieve counts for indices in
         # `indices`.
-        objective_sizes = aggregate(indices, 1, func="len", fill_value=0)[indices]  # ty: ignore[call-non-callable]
+        objective_sizes = aggregate(indices, 1, func="len", fill_value=0)[indices]
 
         # Compute the sum of the objectives inserted into each cell -- again, we index
         # with `indices`.
-        objective_sums = aggregate(indices, objective, func="sum", fill_value=np.nan)[  # ty: ignore[call-non-callable]
+        objective_sums = aggregate(indices, objective, func="sum", fill_value=np.nan)[
             indices
         ]
 
@@ -669,7 +671,7 @@ class GridArchive(ArchiveBase):
         # elite will be inserted if there is a tie. See their default numpy
         # implementation for more info:
         # https://github.com/ml31415/numpy-groupies/blob/master/numpy_groupies/aggregate_numpy.py#L107
-        archive_argmax = aggregate(  # ty: ignore[call-non-callable]
+        archive_argmax = aggregate(
             indices, data["objective"], func="argmax", fill_value=-1
         )
         should_insert = archive_argmax[archive_argmax != -1]

--- a/ribs/archives/_proximity_archive.py
+++ b/ribs/archives/_proximity_archive.py
@@ -1,13 +1,13 @@
 """Contains the ProximityArchive."""
 
 import numpy as np
-from numpy_groupies import aggregate_nb as aggregate
 from scipy.spatial import cKDTree  # ty: ignore[unresolved-import]
 
 from ribs._utils import (
     check_batch_shape,
     check_finite,
     check_shape,
+    import_aggregate,
     validate_batch,
     validate_single,
 )
@@ -15,6 +15,8 @@ from ribs.archives._archive_base import ArchiveBase
 from ribs.archives._archive_stats import ArchiveStats
 from ribs.archives._array_store import ArrayStore
 from ribs.archives._utils import fill_sentinel_values, parse_dtype
+
+aggregate = import_aggregate()
 
 
 class ProximityArchive(ArchiveBase):
@@ -673,7 +675,7 @@ class ProximityArchive(ArchiveBase):
                 # first elite will be inserted if there is a tie. See their default
                 # numpy implementation for more info:
                 # https://github.com/ml31415/numpy-groupies/blob/master/numpy_groupies/aggregate_numpy.py#L107
-                archive_argmax = aggregate(  # ty: ignore[call-non-callable]
+                archive_argmax = aggregate(
                     indices, data["objective"], func="argmax", fill_value=-1
                 )
                 should_insert = archive_argmax[archive_argmax != -1]


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the PR's purpose here. -->

Previously, we always imported `aggregate_nb` from numpy-groupies. However, it is possible that `aggregate_nb` is None due to Numba not being installed, which was shown in the type checker in #620. This PR thus adds an `import_aggregate` utility so that we always try to import `aggregate_nb`, and if that is not possible, we fall back to importing `aggregate` and warn the user to install Numba. Numba should be present as part of the normal installation process, so this is more of a "just in case."

## TODO

<!-- Notable points that this PR has either accomplished or will accomplish. -->

- [x] Add `import_aggregate` utility
- [x] Use `import_aggregate` in all archives that need it

## Status

- [x] I have read the guidelines in
      [CONTRIBUTING.md](https://github.com/icaros-usc/pyribs/blob/master/CONTRIBUTING.md)
- [x] I have linted and formatted my code with `ruff` and `ty`
- [x] I have tested my code by running `pytest`
- [x] I have added a description of my change to the changelog in `HISTORY.md`
- [x] This PR is ready to go
