### PR TITLE
Add custom types in ribs.typing

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -12,15 +12,14 @@
 
 #### Improvements
 
-- Add type annotations and use ty for type checking ({pr}`606`, {pr}`610`,
-  {pr}`620`)
+- Add type annotations and use ty for type checking ({issue}`624`)
 - Migrate from pylint to ruff for linting ({pr}`605`, {pr}`607`, {pr}`612`,
   {pr}`619`)
 - Replace isort with ruff import check ({pr}`603`)
 
 #### Bugs
 
-- Add best_elite back to SlidingBoundariesArchive ({pr}`622`)
+- Add best_elite back to SlidingBoundariesArchive ({pr}`623`)
 - Correct types of ArchiveStats obj_max and obj_mean ({pr}`617`)
 - Fix bug in ribs.visualize args tests ({pr}`615`)
 

--- a/docs/api/ribs.typing.rst
+++ b/docs/api/ribs.typing.rst
@@ -1,0 +1,14 @@
+ribs.typing
+===========
+
+.. automodule:: ribs.typing
+   :no-members:
+   :no-inherited-members:
+   :no-special-members:
+   :no-undoc-members:
+
+.. This list is updated manually when types are added to ribs/typing.py.
+.. autodata:: ribs.typing.BatchData
+.. autodata:: ribs.typing.SingleData
+.. autodata:: ribs.typing.Int
+.. autodata:: ribs.typing.Float

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -285,7 +285,9 @@ autodoc_type_aliases = {
     # Aliases that we do not want to expand.
     # https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html#confval-autodoc_type_aliases
     "ArrayLike": "numpy.typing.ArrayLike",
+    "DTypeLike": "numpy.typing.DTypeLike",
     "ColorType": "matplotlib.typing.ColorType",
+    # We are okay expanding most ribs.typing aliases because they are quite readable.
 }
 autosummary_generate = True
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,6 +24,7 @@ api/ribs.emitters.operators
 api/ribs.emitters.opt
 api/ribs.emitters.rankers
 api/ribs.schedulers
+api/ribs.typing
 api/ribs.visualize
 ```
 

--- a/ribs/typing.py
+++ b/ribs/typing.py
@@ -1,0 +1,23 @@
+"""Custom data types for pyribs."""
+
+# Developer Note: When adding new types, make sure to update the API listing in
+# `docs/api/ribs.typing.rst`.
+
+from __future__ import annotations
+
+from typing import Any, Union
+
+import numpy as np
+
+#: Represents data about a batch of solutions. The first dimension of each entry should
+#: be the batch dimension.
+BatchData = dict[str, np.ndarray]
+
+#: Represents data about a single solution.
+SingleData = dict[str, Any]
+
+#: General type for integers.
+Int = Union[int, np.integer]
+
+#: General type for floats.
+Float = Union[float, np.floating]


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the PR's purpose here. -->

This PR adds a small module called `ribs.typing` that holds convenient type aliases.

## TODO

<!-- Notable points that this PR has either accomplished or will accomplish. -->

- [x] Add ribs/typing.py
- [x] Add to listing in index.md
- [x] Add docs/api/ribs.typing.rst
- [x] Mention aliases in docs/conf.py

## Status

- [x] I have read the guidelines in
      [CONTRIBUTING.md](https://github.com/icaros-usc/pyribs/blob/master/CONTRIBUTING.md)
- [x] I have linted and formatted my code with `ruff` and `ty`
- [x] I have tested my code by running `pytest`
- [x] I have added a description of my change to the changelog in `HISTORY.md`
- [x] This PR is ready to go
