### PR TITLE
Raise `KeyError` in `ArchiveDataFrame.get_field` when field not found

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,6 +6,8 @@
 
 #### API
 
+- Raise `KeyError` in `ArchiveDataFrame.get_field` when field not found
+  ({pr}`626`)
 - Support array backends via Python array API Standard ({issue}`570`)
 - **Backwards-incompatible:** Remove raw_dict methods from ArrayStore
   ({pr}`575`)

--- a/ribs/archives/_archive_data_frame.py
+++ b/ribs/archives/_archive_data_frame.py
@@ -1,8 +1,15 @@
 """Provides ArchiveDataFrame."""
 
-import re
+from __future__ import annotations
 
+import re
+from collections.abc import Iterable
+from typing import Any
+
+import numpy as np
 import pandas as pd
+
+from ribs.typing import SingleData
 
 # Developer Notes:
 # - The documentation for this class is hacked -- to add new methods, manually modify
@@ -71,14 +78,14 @@ class ArchiveDataFrame(pd.DataFrame):
         ``get_field("objective")[i]``, and ``get_field("solution")[i]``.
     """
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     @property
     def _constructor(self):
         return ArchiveDataFrame
 
-    def iterelites(self):
+    def iterelites(self) -> Iterable[SingleData]:
         """Iterator that outputs every elite in the ArchiveDataFrame as a dict."""
         # Identify fields in the data frame. There are some edge cases here, such as if
         # someone purposely names their field with an underscore and a number at the end
@@ -108,7 +115,7 @@ class ArchiveDataFrame(pd.DataFrame):
 
         return ({name: arr[i] for name, arr in fields.items()} for i in range(n_elites))
 
-    def get_field(self, field):
+    def get_field(self, field: str) -> np.ndarray | None:
         """Array holding the data for the given field.
 
         None if there is no data for the field.

--- a/ribs/archives/_archive_data_frame.py
+++ b/ribs/archives/_archive_data_frame.py
@@ -115,7 +115,6 @@ class ArchiveDataFrame(pd.DataFrame):
 
         return ({name: arr[i] for name, arr in fields.items()} for i in range(n_elites))
 
-    # TODO: get_field should throw KeyError if field is not found
     def get_field(self, field: str) -> np.ndarray:
         """Array holding the data for the given field.
 
@@ -132,4 +131,6 @@ class ArchiveDataFrame(pd.DataFrame):
             # and "measures_1".
             field_re = f"{field}_\\d+"
             cols = [c for c in self if re.fullmatch(field_re, c)]
-            return self[cols].to_numpy(copy=True) if cols else None
+            if cols:
+                return self[cols].to_numpy(copy=True)
+            raise KeyError(f"Field '{field}' was not found.")

--- a/ribs/archives/_archive_data_frame.py
+++ b/ribs/archives/_archive_data_frame.py
@@ -115,7 +115,8 @@ class ArchiveDataFrame(pd.DataFrame):
 
         return ({name: arr[i] for name, arr in fields.items()} for i in range(n_elites))
 
-    def get_field(self, field: str) -> np.ndarray | None:
+    # TODO: get_field should throw KeyError if field is not found
+    def get_field(self, field: str) -> np.ndarray:
         """Array holding the data for the given field.
 
         None if there is no data for the field.
@@ -124,11 +125,11 @@ class ArchiveDataFrame(pd.DataFrame):
         # might change in-place, e.g., when a column is deleted.
 
         if field in self:
-            # Scalar field -- e.g., "objective"
+            # Scalar field, e.g., "objective".
             return self[field].to_numpy(copy=True)
         else:
-            # Vector field -- e.g., field="measures" and we want columns like
-            # "measures_0" and "measures_1".
+            # Vector field, e.g., field="measures" and we want columns like "measures_0"
+            # and "measures_1".
             field_re = f"{field}_\\d+"
             cols = [c for c in self if re.fullmatch(field_re, c)]
             return self[cols].to_numpy(copy=True) if cols else None

--- a/tests/archives/archive_data_frame_test.py
+++ b/tests/archives/archive_data_frame_test.py
@@ -80,11 +80,12 @@ def test_get_field(data, df):
         "index",
     ],
 )
-def test_field_can_be_none(df, field_col):
-    """Removes a column so that get_field returns None."""
+def test_field_not_found(df, field_col):
+    """Removes a column so that get_field has KeyError."""
     field, col = field_col
     del df[col]
-    assert df.get_field(field) is None
+    with pytest.raises(KeyError, match=f"Field '{field}' was not found."):
+        df.get_field(field)
 
 
 def test_correct_constructor(df):


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the PR's purpose here. -->

Previously, when a field was not found in an ArchiveDataFrame, we would just return `None`. However, having a None value is not very useful and can lead to unexpected behavior. This PR instead raises a KeyError similar to what one would get if accessing an invalid column in a regular DataFrame.

This PR also adds some type annotations to ArchiveDataFrame.

## TODO

<!-- Notable points that this PR has either accomplished or will accomplish. -->

- [x] Raise KeyError in ArchiveDataFrame
- [x] Add test to check KeyError (replaced old test for checking if value is None)

## Status

- [x] I have read the guidelines in
      [CONTRIBUTING.md](https://github.com/icaros-usc/pyribs/blob/master/CONTRIBUTING.md)
- [x] I have linted and formatted my code with `ruff` and `ty`
- [x] I have tested my code by running `pytest`
- [x] I have added a description of my change to the changelog in `HISTORY.md`
- [x] This PR is ready to go
