### PR TITLE
Specify args and kwargs for visualize_qdax

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ dependencies = [
   "scipy>=1.7.0",
   "sortedcontainers>=2.0.0",  # Primarily used in SlidingBoundariesArchive.
   "threadpoolctl>=3.0.0",
+  "typing-extensions>=4.12.0",
 ]
 
 [project.optional-dependencies]

--- a/ribs/visualize/_visualize_qdax.py
+++ b/ribs/visualize/_visualize_qdax.py
@@ -3,9 +3,10 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 import numpy as np
+from typing_extensions import ParamSpec
 
 from ribs.archives import CVTArchive
 from ribs.visualize._cvt_archive_3d_plot import cvt_archive_3d_plot
@@ -14,6 +15,8 @@ from ribs.visualize._cvt_archive_heatmap import cvt_archive_heatmap
 if TYPE_CHECKING:
     # Only import for type checking since QDax is not installed by default.
     from qdax.core.containers.mapelites_repertoire import MapElitesRepertoire
+
+P = ParamSpec("P")
 
 
 def _as_cvt_archive(
@@ -54,8 +57,8 @@ def _as_cvt_archive(
 def qdax_repertoire_heatmap(
     repertoire: MapElitesRepertoire,
     ranges: Sequence[tuple[float, float]],
-    *args: Any,
-    **kwargs: Any,
+    *args: P.args,
+    **kwargs: P.kwargs,
 ) -> None:
     """Plots a heatmap of a single-objective QDax MapElitesRepertoire.
 
@@ -82,8 +85,8 @@ def qdax_repertoire_heatmap(
 def qdax_repertoire_3d_plot(
     repertoire: MapElitesRepertoire,
     ranges: Sequence[tuple[float, float]],
-    *args: Any,
-    **kwargs: Any,
+    *args: P.args,
+    **kwargs: P.kwargs,
 ) -> None:
     """Plots a single-objective QDax MapElitesRepertoire with 3D measure space.
 


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the PR's purpose here. -->

Instead of  `typing.Any`, we can use ParamSpec. Since this is only available in Python 3.10+ and we support 3.9+, this PR also adds the typing_extensions dependency.

## Status

- [x] I have read the guidelines in
      [CONTRIBUTING.md](https://github.com/icaros-usc/pyribs/blob/master/CONTRIBUTING.md)
- [x] I have linted and formatted my code with `ruff` and `ty`
- [x] I have tested my code by running `pytest`
- [x] I have added a description of my change to the changelog in `HISTORY.md`
- [x] This PR is ready to go
