### PR TITLE
Annotate ArrayStore and add types for Array API

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -186,7 +186,7 @@ jobs:
         with:
           python-version: "3.10"
       - name: Install deps
-        run: pip install .[all,dev]
+        run: pip install .[all,dev,dev-array-api]
       - name: Build docs
         run: make docs
   deploy:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -19,6 +19,6 @@ python:
     - method: pip
       path: .
       extra_requirements:
-        - visualize
+        - all
         - dev
         - dev-array-api

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -21,3 +21,4 @@ python:
       extra_requirements:
         - visualize
         - dev
+        - dev-array-api

--- a/docs/api/ribs.typing.rst
+++ b/docs/api/ribs.typing.rst
@@ -11,6 +11,7 @@ ribs.typing
 .. autodata:: ribs.typing.Int
 .. autodata:: ribs.typing.Float
 .. autodata:: ribs.typing.Array
+.. autodata:: ribs.typing.ArrayVar
 .. autodata:: ribs.typing.Device
 .. autodata:: ribs.typing.BatchData
 .. autodata:: ribs.typing.SingleData

--- a/docs/api/ribs.typing.rst
+++ b/docs/api/ribs.typing.rst
@@ -8,9 +8,9 @@ ribs.typing
    :no-undoc-members:
 
 .. This list is updated manually when types are added to ribs/typing.py.
-.. autodata:: ribs.typing.BatchData
-.. autodata:: ribs.typing.SingleData
 .. autodata:: ribs.typing.Int
 .. autodata:: ribs.typing.Float
 .. autodata:: ribs.typing.Array
 .. autodata:: ribs.typing.Device
+.. autodata:: ribs.typing.BatchData
+.. autodata:: ribs.typing.SingleData

--- a/docs/api/ribs.typing.rst
+++ b/docs/api/ribs.typing.rst
@@ -11,7 +11,8 @@ ribs.typing
 .. autodata:: ribs.typing.Int
 .. autodata:: ribs.typing.Float
 .. autodata:: ribs.typing.Array
-.. autodata:: ribs.typing.ArrayVar
+.. autodata:: ribs.typing.DType
 .. autodata:: ribs.typing.Device
+.. autodata:: ribs.typing.ArrayVar
 .. autodata:: ribs.typing.BatchData
 .. autodata:: ribs.typing.SingleData

--- a/docs/api/ribs.typing.rst
+++ b/docs/api/ribs.typing.rst
@@ -12,3 +12,5 @@ ribs.typing
 .. autodata:: ribs.typing.SingleData
 .. autodata:: ribs.typing.Int
 .. autodata:: ribs.typing.Float
+.. autodata:: ribs.typing.Array
+.. autodata:: ribs.typing.Device

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -15,6 +15,17 @@ import sys
 
 import ribs
 
+try:
+    # These must be installed in order to make type annotations like ribs.typing.Device
+    # show up properly.
+    import cupy as cp  # noqa: F401
+    import numpy as np  # noqa: F401
+    import torch  # noqa: F401
+except ImportError as e:
+    raise ImportError(
+        "Array libraries must be installed to build the documentation."
+    ) from e
+
 # If extensions (or modules to document with autodoc) are in another directory, add
 # these directories to sys.path here. If the directory is relative to the documentation
 # root, use os.path.abspath to make it absolute, like shown here.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -319,4 +319,6 @@ intersphinx_mapping = {
     "qdax": ("https://qdax.readthedocs.io/en/latest/", None),
     "shapely": ("https://shapely.readthedocs.io/en/stable/", None),
     "cma": ("https://cma-es.github.io/apidocs-pycma/", None),
+    "cupy": ("https://docs.cupy.dev/en/stable/", None),
+    "torch": ("https://docs.pytorch.org/docs/stable/", None),
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ classifiers = [
 requires-python = ">=3.9.0"
 dependencies = [
   "array_api_compat",
+  "types-array-api",
   "numba>=0.51.0",
   "numpy>=1.22.0",  # numpy>=1.22.0 is when Array API gains support.
   "numpy_groupies>=0.9.16",  # Supports Python 3.7 and up.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,7 +97,7 @@ dev-array-api = [
   # Extras when working with the Array API. These can be pretty heavy, so they are
   # separate from `dev`.
   "torch",
-  "cupy",
+  "cupy-cuda12x",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,6 +93,12 @@ dev = [
   "check-wheel-contents",
   "twine",
 ]
+dev-array-api = [
+  # Extras when working with the Array API. These can be pretty heavy, so they are
+  # separate from `dev`.
+  "torch",
+  "cupy",
+]
 
 [project.urls]
 Homepage = "https://pyribs.org"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,6 @@ classifiers = [
 requires-python = ">=3.9.0"
 dependencies = [
   "array_api_compat",
-  "types-array-api",
   "numba>=0.51.0",
   "numpy>=1.22.0",  # numpy>=1.22.0 is when Array API gains support.
   "numpy_groupies>=0.9.16",  # Supports Python 3.7 and up.

--- a/ribs/_utils.py
+++ b/ribs/_utils.py
@@ -4,6 +4,7 @@ import numbers
 
 import array_api_compat.numpy as np_compat
 import numpy as np
+from array_api._2024_12 import ArrayNamespace
 from array_api_compat import array_namespace
 
 from ribs.typing import ArrayVar
@@ -226,7 +227,7 @@ def arr_readonly(arr: ArrayVar) -> ArrayVar:
         return arr
 
 
-def xp_namespace(xp):
+def xp_namespace(xp: ArrayNamespace) -> ArrayNamespace:
     """Utility for retrieving a namespace compatible with the array API.
 
     Expects to receive an argument like `torch` or `numpy`.

--- a/ribs/_utils.py
+++ b/ribs/_utils.py
@@ -3,10 +3,10 @@
 from __future__ import annotations
 
 import numbers
+from types import ModuleType
 
 import array_api_compat.numpy as np_compat
 import numpy as np
-from array_api._2024_12 import ArrayNamespace, ArrayNamespaceFull
 from array_api_compat import array_namespace
 
 from ribs.typing import ArrayVar
@@ -229,7 +229,7 @@ def arr_readonly(arr: ArrayVar) -> ArrayVar:
         return arr
 
 
-def xp_namespace(xp: ArrayNamespace | ArrayNamespaceFull | None) -> ArrayNamespaceFull:
+def xp_namespace(xp: ModuleType | None) -> ModuleType:
     """Utility for retrieving a namespace compatible with the array API.
 
     Expects to receive an argument like `torch` or `numpy`.
@@ -240,4 +240,4 @@ def xp_namespace(xp: ArrayNamespace | ArrayNamespaceFull | None) -> ArrayNamespa
     For more context, see:
     https://github.com/data-apis/array-api-compat/issues/342
     """
-    return np_compat if xp is None else array_namespace(xp.empty(0))  # ty: ignore[invalid-return-type]
+    return np_compat if xp is None else array_namespace(xp.empty(0))  # ty: ignore[unresolved-attribute]

--- a/ribs/_utils.py
+++ b/ribs/_utils.py
@@ -1,10 +1,12 @@
 """Miscellaneous internal utilities."""
 
+from __future__ import annotations
+
 import numbers
 
 import array_api_compat.numpy as np_compat
 import numpy as np
-from array_api._2024_12 import ArrayNamespace
+from array_api._2024_12 import ArrayNamespace, ArrayNamespaceFull
 from array_api_compat import array_namespace
 
 from ribs.typing import ArrayVar
@@ -219,7 +221,7 @@ def arr_readonly(arr: ArrayVar) -> ArrayVar:
 
     Intended to support arrays across libraries; currently only supports numpy.
     """
-    if isinstance(arr, np_compat.ndarray):
+    if isinstance(arr, np.ndarray):
         readonly_arr = arr.view()
         readonly_arr.flags.writeable = False
         return readonly_arr  # ty: ignore[invalid-return-type]
@@ -227,7 +229,7 @@ def arr_readonly(arr: ArrayVar) -> ArrayVar:
         return arr
 
 
-def xp_namespace(xp: ArrayNamespace) -> ArrayNamespace:
+def xp_namespace(xp: ArrayNamespace | ArrayNamespaceFull | None) -> ArrayNamespaceFull:
     """Utility for retrieving a namespace compatible with the array API.
 
     Expects to receive an argument like `torch` or `numpy`.
@@ -238,4 +240,4 @@ def xp_namespace(xp: ArrayNamespace) -> ArrayNamespace:
     For more context, see:
     https://github.com/data-apis/array-api-compat/issues/342
     """
-    return np_compat if xp is None else array_namespace(xp.empty(0))
+    return np_compat if xp is None else array_namespace(xp.empty(0))  # ty: ignore[invalid-return-type]

--- a/ribs/_utils.py
+++ b/ribs/_utils.py
@@ -3,7 +3,7 @@
 import numbers
 
 import array_api_compat.numpy as np_compat
-import numpy as np  # TODO (#576): Remove import of np
+import numpy as np
 from array_api_compat import array_namespace
 
 

--- a/ribs/_utils.py
+++ b/ribs/_utils.py
@@ -6,6 +6,8 @@ import array_api_compat.numpy as np_compat
 import numpy as np
 from array_api_compat import array_namespace
 
+from ribs.typing import ArrayVar
+
 
 def check_finite(x, name):
     """Checks that x is finite (i.e. not infinity or NaN).
@@ -211,7 +213,7 @@ def readonly(arr):
     return arr
 
 
-def arr_readonly(arr):
+def arr_readonly(arr: ArrayVar) -> ArrayVar:
     """Sets an array to be readonly if possible.
 
     Intended to support arrays across libraries; currently only supports numpy.
@@ -219,7 +221,7 @@ def arr_readonly(arr):
     if isinstance(arr, np_compat.ndarray):
         readonly_arr = arr.view()
         readonly_arr.flags.writeable = False
-        return readonly_arr
+        return readonly_arr  # ty: ignore[invalid-return-type]
     else:
         return arr
 

--- a/ribs/archives/_array_store.py
+++ b/ribs/archives/_array_store.py
@@ -1,18 +1,25 @@
 """Provides ArrayStore."""
 
+from __future__ import annotations
+
 import contextlib
 import itertools
 import numbers
+from collections.abc import Iterator, Sequence
 from enum import IntEnum
 from functools import cached_property
+from typing import Literal, overload
 
+import numpy as np
 from array_api_compat import is_cupy_array, is_numpy_array, is_torch_array
+from numpy.typing import ArrayLike, DTypeLike
 
 with contextlib.suppress(ImportError):
     from array_api_compat import cupy as cp
 
 from ribs._utils import arr_readonly, xp_namespace
 from ribs.archives._archive_data_frame import ArchiveDataFrame
+from ribs.typing import Array, BatchData, Device, DType, Int, SingleData
 
 
 class Update(IntEnum):
@@ -25,16 +32,16 @@ class Update(IntEnum):
 class ArrayStoreIterator:
     """An iterator for an ArrayStore's entries."""
 
-    def __init__(self, store):
+    def __init__(self, store: ArrayStore) -> None:
         self.store = store
         self.iter_idx = 0
         self.state = store._props["updates"].copy()
 
-    def __iter__(self):
+    def __iter__(self) -> Iterator[SingleData]:
         """This is the iterator, so it returns itself."""
         return self
 
-    def __next__(self):
+    def __next__(self) -> SingleData:
         """Returns dicts with each entry's data.
 
         Raises RuntimeError if the store was modified.
@@ -85,17 +92,17 @@ class ArrayStore:
     for ``xp`` and ``device``.
 
     Args:
-        field_desc (dict): Description of fields in the array store. The description is
-            a dict mapping from a str to a tuple of ``(shape, dtype)``. For instance,
+        field_desc: Description of fields in the array store. The description is a dict
+            mapping from a str to a tuple of ``(shape, dtype)``. For instance,
             ``{"objective": ((), np.float32), "measures": ((10,), np.float32)}`` will
             create an "objective" field with shape ``(capacity,)`` and a "measures"
             field with shape ``(capacity, 10)``. Note that field names must be valid
             Python identifiers.
-        capacity (int): Total possible entries in the store.
+        capacity: Total possible entries in the store.
         xp (array_namespace): Optional array namespace. Should be compatible with the
             array API standard, or supported by array-api-compat. Defaults to
             ``numpy``.
-        device (device): Device for arrays.
+        device: Device for arrays.
 
     Attributes:
         _props (dict): Properties that are common to every ArrayStore.
@@ -119,7 +126,13 @@ class ArrayStore:
             Python identifier.
     """
 
-    def __init__(self, field_desc, capacity, xp=None, device=None):
+    def __init__(
+        self,
+        field_desc: dict[str, tuple[Int | tuple[Int], DTypeLike]],
+        capacity: Int,
+        xp=None,
+        device: Device = None,
+    ) -> None:
         self._xp = xp_namespace(xp)
         self._device = device
 
@@ -148,14 +161,14 @@ class ArrayStore:
                 array_shape, dtype=dtype, device=self._device
             )
 
-    def __len__(self):
+    def __len__(self) -> int:
         """Number of occupied indices in the store.
 
         AKA, number of indices that have a corresponding data entry.
         """
         return self._props["n_occupied"]
 
-    def __iter__(self):
+    def __iter__(self) -> Iterator[SingleData]:
         """Iterates over entries in the store.
 
         When iterated over, this iterator yields dicts mapping from the fields to the
@@ -174,23 +187,23 @@ class ArrayStore:
         return ArrayStoreIterator(self)
 
     @property
-    def capacity(self):
-        """int: Maximum number of data entries in the store."""
+    def capacity(self) -> int:
+        """Maximum number of data entries in the store."""
         return self._props["capacity"]
 
     @property
-    def occupied(self):
-        """array: ``(capacity,)`` Boolean array indicating whether each index has a data entry."""
+    def occupied(self) -> Array:
+        """``(capacity,)`` Boolean array indicating whether each index has an entry."""
         return arr_readonly(self._props["occupied"])
 
     @property
-    def occupied_list(self):
-        """array: int32 array listing all occupied indices in the store."""
+    def occupied_list(self) -> Array:
+        """int32 array listing all occupied indices in the store."""
         return arr_readonly(self._props["occupied_list"][: self._props["n_occupied"]])
 
     @cached_property
-    def field_desc(self):
-        """dict: Description of fields in the store.
+    def field_desc(self) -> dict[str, tuple[tuple[int], DType]]:
+        """Description of fields in the store.
 
         Example:
             ::
@@ -209,8 +222,8 @@ class ArrayStore:
         return {name: (arr.shape[1:], arr.dtype) for name, arr in self._fields.items()}
 
     @cached_property
-    def dtypes(self):
-        """dict: Data types of fields in the store.
+    def dtypes(self) -> dict[str, DType]:
+        """Data types of fields in the store.
 
         Example:
             ::
@@ -223,8 +236,8 @@ class ArrayStore:
         return {name: arr.dtype for name, arr in self._fields.items()}
 
     @cached_property
-    def dtypes_with_index(self):
-        """dict: Data types of fields in the store, plus the index.
+    def dtypes_with_index(self) -> dict[str, DType]:
+        """Data types of fields in the store, plus the index.
 
         Example:
             ::
@@ -238,8 +251,8 @@ class ArrayStore:
         return self.dtypes | {"index": self._xp.int32}
 
     @cached_property
-    def field_list(self):
-        """list: List of fields in the store.
+    def field_list(self) -> list[str]:
+        """List of fields in the store.
 
         Example:
             ::
@@ -251,8 +264,8 @@ class ArrayStore:
         return list(self._fields)
 
     @cached_property
-    def field_list_with_index(self):
-        """list: List of fields in the store, plus the index.
+    def field_list_with_index(self) -> list[str]:
+        """List of fields in the store, plus the index.
 
         The index is always added at the end of the list.
 
@@ -265,7 +278,7 @@ class ArrayStore:
         return [*self._fields, "index"]
 
     @staticmethod
-    def _convert_to_numpy(arr):
+    def _convert_to_numpy(arr: Array) -> np.ndarray:
         """If needed, converts the given array to a numpy array.
 
         This is intended to be used in the pandas return type in `retrieve`.
@@ -528,11 +541,11 @@ class ArrayStore:
         self._props["n_occupied"] = 0  # Effectively clears occupied_list too.
         self._props["occupied"][:] = False
 
-    def resize(self, capacity):
+    def resize(self, capacity: Int) -> None:
         """Resizes the store to the given capacity.
 
         Args:
-            capacity (int): New capacity.
+            capacity: New capacity.
 
         Raises:
             ValueError: The new capacity is less than or equal to the current capacity.

--- a/ribs/archives/_array_store.py
+++ b/ribs/archives/_array_store.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import contextlib
 import itertools
 import numbers
-from collections.abc import Iterator, Sequence
+from collections.abc import Collection, Iterator
 from enum import IntEnum
 from functools import cached_property
 from typing import Literal, overload
@@ -445,14 +445,19 @@ class ArrayStore:
 
         return occupied, data
 
-    def data(self, fields=None, return_type="dict"):
+    def data(
+        self,
+        fields: None | Collection[str] | str = None,
+        return_type: Literal["dict", "tuple", "pandas"] = "dict",
+    ) -> np.ndarray | BatchData | tuple[np.ndarray] | ArchiveDataFrame:
         """Retrieves data for all entries in the store.
 
-        Equivalent to calling :meth:`retrieve` with :attr:`occupied_list`.
+        Equivalent to calling :meth:`retrieve` with ``indices`` set to
+        :attr:`occupied_list`.
 
         Args:
-            fields (str or array-like of str): See :meth:`retrieve`.
-            return_type (str): See :meth:`retrieve`.
+            fields: See :meth:`retrieve`.
+            return_type: See :meth:`retrieve`.
 
         Returns:
             See ``data`` in :meth:`retrieve`. ``occupied`` is not returned since

--- a/ribs/archives/_array_store.py
+++ b/ribs/archives/_array_store.py
@@ -460,7 +460,7 @@ class ArrayStore:
         """
         return self.retrieve(self.occupied_list, fields, return_type)[1]
 
-    def add(self, indices, data):
+    def add(self, indices: ArrayLike, data: dict[str, ArrayLike]) -> None:
         """Adds new data to the store at the given indices.
 
         Example:
@@ -475,9 +475,9 @@ class ArrayStore:
                 # `objective` of 2.0, and index 8 will have objective of 3.0.
 
         Args:
-            indices (array-like): List of indices for addition.
-            data (dict): Dict with data to add at each index. The dict maps from field
-                names to arrays of data for each field.
+            indices: List of indices for addition.
+            data: Dict with data to add at each index. The dict maps from field names to
+                arrays of data for each field.
 
         Raise:
             ValueError: ``data`` does not have the same keys as the fields of this
@@ -535,7 +535,7 @@ class ArrayStore:
                 data[name], dtype=arr.dtype, device=self._device
             )
 
-    def clear(self):
+    def clear(self) -> None:
         """Removes all entries from the store."""
         self._props["updates"][Update.CLEAR] += 1
         self._props["n_occupied"] = 0  # Effectively clears occupied_list too.

--- a/ribs/archives/_array_store.py
+++ b/ribs/archives/_array_store.py
@@ -11,6 +11,7 @@ from functools import cached_property
 from typing import Literal, overload
 
 import numpy as np
+from array_api._2024_12 import ArrayNamespace
 from array_api_compat import is_cupy_array, is_numpy_array, is_torch_array
 from numpy.typing import ArrayLike, DTypeLike
 
@@ -99,9 +100,8 @@ class ArrayStore:
             field with shape ``(capacity, 10)``. Note that field names must be valid
             Python identifiers.
         capacity: Total possible entries in the store.
-        xp (array_namespace): Optional array namespace. Should be compatible with the
-            array API standard, or supported by array-api-compat. Defaults to
-            ``numpy``.
+        xp: Optional array namespace. Should be compatible with the array API standard,
+            or supported by array-api-compat. Defaults to ``numpy``.
         device: Device for arrays.
 
     Attributes:
@@ -130,7 +130,7 @@ class ArrayStore:
         self,
         field_desc: dict[str, tuple[Int | tuple[Int], DTypeLike]],
         capacity: Int,
-        xp=None,
+        xp: ArrayNamespace | None = None,
         device: Device = None,
     ) -> None:
         self._xp = xp_namespace(xp)

--- a/ribs/archives/_array_store.py
+++ b/ribs/archives/_array_store.py
@@ -8,15 +8,11 @@ import numbers
 from collections.abc import Collection, Iterator
 from enum import IntEnum
 from functools import cached_property
+from types import ModuleType
 from typing import Literal, overload
 
 import numpy as np
-from array_api._2024_12 import ArrayNamespace
-from array_api_compat import (
-    is_cupy_array,  # ty: ignore[unresolved-import]
-    is_numpy_array,  # ty: ignore[unresolved-import]
-    is_torch_array,  # ty: ignore[unresolved-import]
-)
+from array_api_compat import is_cupy_array, is_numpy_array, is_torch_array
 from numpy.typing import ArrayLike, DTypeLike
 
 with contextlib.suppress(ImportError):
@@ -134,7 +130,7 @@ class ArrayStore:
         self,
         field_desc: dict[str, tuple[Int | tuple[Int], DTypeLike]],
         capacity: Int,
-        xp: ArrayNamespace | None = None,
+        xp: ModuleType | None = None,
         device: Device = None,
     ) -> None:
         self._xp = xp_namespace(xp)
@@ -290,7 +286,7 @@ class ArrayStore:
         if is_numpy_array(arr):
             return arr
         elif is_torch_array(arr):
-            return arr.cpu().detach().numpy()
+            return arr.cpu().detach().numpy()  # ty: ignore[possibly-unbound-attribute]
         elif is_cupy_array(arr):
             return cp.asnumpy(arr)
         else:

--- a/ribs/typing.py
+++ b/ribs/typing.py
@@ -23,13 +23,6 @@ try:
 except ImportError:
     is_cp_availalbe = False
 
-#: Represents data about a batch of solutions. The first dimension of each entry should
-#: be the batch dimension.
-BatchData = dict[str, np.ndarray]
-
-#: Represents data about a single solution.
-SingleData = dict[str, Any]
-
 #: General type for integers.
 Int = Union[int, np.integer]
 
@@ -49,3 +42,10 @@ if is_torch_available:
     Device = Union[Device, torch.device]
 if is_cp_availalbe:
     Device = Union[Device, cp.cuda.Device]
+
+#: Represents data about a batch of solutions. The first dimension of each entry should
+#: be the batch dimension.
+BatchData = dict[str, Array]
+
+#: Represents data about a single solution.
+SingleData = dict[str, Any]

--- a/ribs/typing.py
+++ b/ribs/typing.py
@@ -35,19 +35,16 @@ Array = np.ndarray
 Device = Union[str, int]
 
 # Modify types based on which array backends are available.
-_array_var_constraints = [np.ndarray]
 if is_torch_available:
     Array = Union[Array, torch.Tensor]
-    _array_var_constraints.append(torch.Tensor)
     Device = Union[Device, torch.device]
 if is_cp_availalbe:
     Array = Union[Array, cp.ndarray]
-    _array_var_constraints.append(cp.ndarray)
     Device = Union[Device, cp.cuda.Device]
 
 #: TypeVar for arrays; can be used, e.g., to indicate that input and output arrays are
 #: the same type.
-ArrayVar = TypeVar("ArrayVar", *_array_var_constraints)
+ArrayVar = TypeVar("ArrayVar")
 
 #: Represents data about a batch of solutions. The first dimension of each entry should
 #: be the batch dimension.

--- a/ribs/typing.py
+++ b/ribs/typing.py
@@ -31,15 +31,19 @@ Float = Union[float, np.floating]
 
 #: Represents an array compatible with pyribs.
 Array = np.ndarray
+#: Represents a dtype compatible with pyribs.
+DType = np.dtype
 #: Represents an array's device.
 Device = Union[str, int]
 
 # Modify types based on which array backends are available.
 if is_torch_available:
     Array = Union[Array, torch.Tensor]
+    DType = Union[DType, torch.dtype]
     Device = Union[Device, torch.device]
 if is_cp_availalbe:
     Array = Union[Array, cp.ndarray]
+    DType = Union[DType, cp.dtype]
     Device = Union[Device, cp.cuda.Device]
 
 #: TypeVar for arrays; can be used, e.g., to indicate that input and output arrays are

--- a/ribs/typing.py
+++ b/ribs/typing.py
@@ -9,6 +9,20 @@ from typing import Any, Union
 
 import numpy as np
 
+try:
+    import torch
+
+    is_torch_available = True
+except ImportError:
+    is_torch_available = False
+
+try:
+    import cupy as cp
+
+    is_cp_availalbe = True
+except ImportError:
+    is_cp_availalbe = False
+
 #: Represents data about a batch of solutions. The first dimension of each entry should
 #: be the batch dimension.
 BatchData = dict[str, np.ndarray]
@@ -21,3 +35,17 @@ Int = Union[int, np.integer]
 
 #: General type for floats.
 Float = Union[float, np.floating]
+
+#: Represents an array compatible with pyribs.
+Array = np.ndarray
+if is_torch_available:
+    Array = Union[Array, torch.Tensor]
+if is_cp_availalbe:
+    Array = Union[Array, cp.ndarray]
+
+#: Represents an array's device.
+Device = Union[str, int]
+if is_torch_available:
+    Device = Union[Device, torch.device]
+if is_cp_availalbe:
+    Device = Union[Device, cp.cuda.Device]

--- a/ribs/typing.py
+++ b/ribs/typing.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Union
+from typing import Any, TypeVar, Union
 
 import numpy as np
 
@@ -31,17 +31,23 @@ Float = Union[float, np.floating]
 
 #: Represents an array compatible with pyribs.
 Array = np.ndarray
-if is_torch_available:
-    Array = Union[Array, torch.Tensor]
-if is_cp_availalbe:
-    Array = Union[Array, cp.ndarray]
-
 #: Represents an array's device.
 Device = Union[str, int]
+
+# Modify types based on which array backends are available.
+_array_var_constraints = [np.ndarray]
 if is_torch_available:
+    Array = Union[Array, torch.Tensor]
+    _array_var_constraints.append(torch.Tensor)
     Device = Union[Device, torch.device]
 if is_cp_availalbe:
+    Array = Union[Array, cp.ndarray]
+    _array_var_constraints.append(cp.ndarray)
     Device = Union[Device, cp.cuda.Device]
+
+#: TypeVar for arrays; can be used, e.g., to indicate that input and output arrays are
+#: the same type.
+ArrayVar = TypeVar("ArrayVar", *_array_var_constraints)
 
 #: Represents data about a batch of solutions. The first dimension of each entry should
 #: be the batch dimension.


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the PR's purpose here. -->

Annotations for the ArrayStore. Since we support the Array API in the ArrayStore, this PR also creates types to make it easier to work with the Array API.

Regarding typing of `xp`, official types for Array API are coming soon: https://github.com/data-apis/array-api-typing It also seems there is an unofficial package here that gets the job done: https://github.com/34j/types-array-api We should install the official package once it is available and update the files in this PR accordingly. I added a note to the tracking issue #624.

## TODO

<!-- Notable points that this PR has either accomplished or will accomplish. -->

- [x] Add annotations to ArrayStore
- [x] Add new types in `ribs.typing`: `Array`, `DType`, `Device`, `ArrayVar`
- [x] Modify documentation to require importing torch and cupy so that the above type annotations will work
  - [x] Check if it is possible to avoid those imports, perhaps by using `if TYPE_CHECKING` -> Yes, is it possible by doing something like below. However, now Sphinx doesn't see the types correctly in the documentation, so it's easier to just add an extra that installs these dependencies. I added the `dev-array-api` extra.
```
if TYPE_CHECKING:
    import torch
    import cupy as cp

Array = np.ndarray
if TYPE_CHECKING:
    Array = Union[np.ndarray, torch.Tensor, cp.ndarray]
```
- [x] Add types to `arr_readonly` in utils

## Status

- [x] I have read the guidelines in
      [CONTRIBUTING.md](https://github.com/icaros-usc/pyribs/blob/master/CONTRIBUTING.md)
- [x] I have linted and formatted my code with `ruff` and `ty`
- [x] I have tested my code by running `pytest`
- [x] I have added a description of my change to the changelog in `HISTORY.md`
- [x] This PR is ready to go
