### PR TITLE
Remove old readonly util

### DIFF
--- a/ribs/_utils.py
+++ b/ribs/_utils.py
@@ -209,19 +209,15 @@ def validate_single(archive, data, none_objective_ok=False):
     return data
 
 
-# TODO (#576): Replace all calls to readonly with arr_readonly below.
-def readonly(arr):
-    """Sets an array to be readonly."""
-    arr.flags.writeable = False
-    return arr
-
-
 def arr_readonly(arr: ArrayVar, view: bool = False) -> ArrayVar:
     """Sets an array to be readonly if possible.
 
-    Intended to support arrays across libraries; currently only supports numpy.
+    Intended to support arrays across libraries; currently only supports numpy. Other
+    arrays are returned as is.
 
-    Pass `view` to call `arr.view` when the array is a numpy array.
+    Pass `view` to call `arr.view` when the array is a numpy array. This is useful if
+    you will still need to modify the array, as you can return a readonly view that does
+    not make the original array readonly.
     """
     if isinstance(arr, np.ndarray):
         readonly_arr = arr.view() if view else arr

--- a/ribs/_utils.py
+++ b/ribs/_utils.py
@@ -216,13 +216,15 @@ def readonly(arr):
     return arr
 
 
-def arr_readonly(arr: ArrayVar) -> ArrayVar:
+def arr_readonly(arr: ArrayVar, view: bool = False) -> ArrayVar:
     """Sets an array to be readonly if possible.
 
     Intended to support arrays across libraries; currently only supports numpy.
+
+    Pass `view` to call `arr.view` when the array is a numpy array.
     """
     if isinstance(arr, np.ndarray):
-        readonly_arr = arr.view()
+        readonly_arr = arr.view() if view else arr
         readonly_arr.flags.writeable = False
         return readonly_arr  # ty: ignore[invalid-return-type]
     else:

--- a/ribs/archives/_array_store.py
+++ b/ribs/archives/_array_store.py
@@ -194,7 +194,7 @@ class ArrayStore:
     @property
     def occupied(self) -> Array:
         """``(capacity,)`` Boolean array indicating whether each index has an entry."""
-        return arr_readonly(self._props["occupied"])
+        return arr_readonly(self._props["occupied"], view=True)
 
     @property
     def occupied_list(self) -> Array:

--- a/ribs/archives/_density_archive.py
+++ b/ribs/archives/_density_archive.py
@@ -4,7 +4,7 @@ import numpy as np
 from scipy.spatial.distance import cdist
 from sklearn.neighbors import KernelDensity
 
-from ribs._utils import check_batch_shape, check_finite, readonly
+from ribs._utils import arr_readonly, check_batch_shape, check_finite
 from ribs.archives._archive_base import ArchiveBase
 from ribs.archives._utils import parse_dtype
 
@@ -154,7 +154,7 @@ class DensityArchive(ArchiveBase):
 
         Shape (n, :attr:`measure_dim`).
         """
-        return readonly(self._buffer[: self._n_occupied])
+        return arr_readonly(self._buffer[: self._n_occupied])
 
     ## Utilities ##
 

--- a/ribs/emitters/opt/_cma_es.py
+++ b/ribs/emitters/opt/_cma_es.py
@@ -10,7 +10,7 @@ import numba as nb
 import numpy as np
 from threadpoolctl import threadpool_limits
 
-from ribs._utils import readonly
+from ribs._utils import arr_readonly
 from ribs.emitters.opt._evolution_strategy_base import (
     BOUNDS_SAMPLING_THRESHOLD,
     BOUNDS_WARNING,
@@ -232,7 +232,7 @@ class CMAEvolutionStrategy(EvolutionStrategyBase):
             if sampling_itrs > BOUNDS_SAMPLING_THRESHOLD:
                 warnings.warn(BOUNDS_WARNING, stacklevel=2)
 
-        return readonly(self._solutions)
+        return arr_readonly(self._solutions)
 
     def _calc_strat_params(self, num_parents):
         """Calculates weights, mueff, and learning rates for CMA-ES."""

--- a/ribs/emitters/opt/_lm_ma_es.py
+++ b/ribs/emitters/opt/_lm_ma_es.py
@@ -9,7 +9,7 @@ import warnings
 import numba as nb
 import numpy as np
 
-from ribs._utils import readonly
+from ribs._utils import arr_readonly
 from ribs.emitters.opt._evolution_strategy_base import (
     BOUNDS_SAMPLING_THRESHOLD,
     BOUNDS_WARNING,
@@ -187,7 +187,7 @@ class LMMAEvolutionStrategy(EvolutionStrategyBase):
             if sampling_itrs > BOUNDS_SAMPLING_THRESHOLD:
                 warnings.warn(BOUNDS_WARNING, stacklevel=2)
 
-        return readonly(self._solutions)
+        return arr_readonly(self._solutions)
 
     @staticmethod
     @nb.jit(nopython=True)

--- a/ribs/emitters/opt/_openai_es.py
+++ b/ribs/emitters/opt/_openai_es.py
@@ -7,7 +7,7 @@ import warnings
 
 import numpy as np
 
-from ribs._utils import readonly
+from ribs._utils import arr_readonly
 from ribs.emitters.opt._adam_opt import AdamOpt
 from ribs.emitters.opt._evolution_strategy_base import (
     BOUNDS_SAMPLING_THRESHOLD,
@@ -163,7 +163,7 @@ class OpenAIEvolutionStrategy(EvolutionStrategyBase):
             if sampling_itrs > BOUNDS_SAMPLING_THRESHOLD:
                 warnings.warn(BOUNDS_WARNING, stacklevel=2)
 
-        return readonly(self._solutions)
+        return arr_readonly(self._solutions)
 
     def tell(self, ranking_indices, ranking_values, num_parents):
         # Indices come in decreasing order, so we reverse to get them to

--- a/ribs/emitters/opt/_pycma_es.py
+++ b/ribs/emitters/opt/_pycma_es.py
@@ -3,7 +3,7 @@
 import numpy as np
 from threadpoolctl import threadpool_limits
 
-from ribs._utils import readonly
+from ribs._utils import arr_readonly
 from ribs.emitters.opt._evolution_strategy_base import EvolutionStrategyBase
 
 
@@ -146,7 +146,7 @@ class PyCMAEvolutionStrategy(EvolutionStrategyBase):
         """
         # batch_size defaults to popsize in CMA-ES.
         self._solutions = np.asarray(self._es.ask(batch_size))
-        return readonly(self._solutions.astype(self.dtype))
+        return arr_readonly(self._solutions.astype(self.dtype))
 
     # Limit OpenBLAS to single thread. This is typically faster than
     # multithreading because our data is too small.

--- a/ribs/emitters/opt/_sep_cma_es.py
+++ b/ribs/emitters/opt/_sep_cma_es.py
@@ -9,7 +9,7 @@ import warnings
 import numba as nb
 import numpy as np
 
-from ribs._utils import readonly
+from ribs._utils import arr_readonly
 from ribs.emitters.opt._evolution_strategy_base import (
     BOUNDS_SAMPLING_THRESHOLD,
     BOUNDS_WARNING,
@@ -185,7 +185,7 @@ class SeparableCMAEvolutionStrategy(EvolutionStrategyBase):
             if sampling_itrs > BOUNDS_SAMPLING_THRESHOLD:
                 warnings.warn(BOUNDS_WARNING, stacklevel=2)
 
-        return readonly(self._solutions)
+        return arr_readonly(self._solutions)
 
     @staticmethod
     def _conedf(df, mu, solution_dim):

--- a/ribs/schedulers/_bandit_scheduler.py
+++ b/ribs/schedulers/_bandit_scheduler.py
@@ -10,7 +10,7 @@ from typing import Literal
 import numpy as np
 from numpy.typing import ArrayLike
 
-from ribs._utils import readonly
+from ribs._utils import arr_readonly
 from ribs.archives import ArchiveBase
 from ribs.emitters import EmitterBase
 from ribs.schedulers._scheduler import Scheduler
@@ -182,7 +182,7 @@ class BanditScheduler:
     @property
     def active(self) -> np.ndarray:
         """Boolean array indicating which emitters in the :attr:`emitter_pool` are currently active."""
-        return readonly(self._active_arr.view())
+        return arr_readonly(self._active_arr, view=True)
 
     @property
     def result_archive(self) -> ArchiveBase:


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the PR's purpose here. -->

Resolves #576 by removing the old `readonly` function and replacing it with calls to `arr_readonly`, which is designed to support multiple array API backends.

## TODO

<!-- Notable points that this PR has either accomplished or will accomplish. -->

- [x] Remove old `readonly`
- [x] Update calls to use `arr_readonly`
- [x] Add `view` param to `arr_readonly`

## Status

- [x] I have read the guidelines in
      [CONTRIBUTING.md](https://github.com/icaros-usc/pyribs/blob/master/CONTRIBUTING.md)
- [x] I have linted and formatted my code with `ruff` and `ty`
- [x] I have tested my code by running `pytest`
- [x] I have added a description of my change to the changelog in `HISTORY.md`
- [x] This PR is ready to go
