### PR TITLE
Annotate archives

### DIFF
--- a/docs/api/ribs.typing.rst
+++ b/docs/api/ribs.typing.rst
@@ -17,3 +17,4 @@ ribs.typing
 .. autodata:: ribs.typing.BatchData
 .. autodata:: ribs.typing.SingleData
 .. autodata:: ribs.typing.FieldDesc
+.. autodata:: ribs.typing.ArchiveDType

--- a/docs/api/ribs.typing.rst
+++ b/docs/api/ribs.typing.rst
@@ -16,3 +16,4 @@ ribs.typing
 .. autodata:: ribs.typing.ArrayVar
 .. autodata:: ribs.typing.BatchData
 .. autodata:: ribs.typing.SingleData
+.. autodata:: ribs.typing.FieldDesc

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -322,3 +322,22 @@ intersphinx_mapping = {
     "cupy": ("https://docs.cupy.dev/en/stable/", None),
     "torch": ("https://docs.pytorch.org/docs/stable/", None),
 }
+
+# -- Small custom extensions -------------------------------------------------
+
+
+def process_signature(app, what, name, obj, options, signature, return_annotation):  # noqa: ARG001
+    """Cleans up numpy dtypes in signatures.
+
+    According to ChatGPT, the problem seems to be that if you set the default value to
+    np.float64, autodoc will expand the value with repr() which gives a messy `class`
+    tag like the one shown below. So it is better to just replace it with text.
+    """
+    if signature:
+        signature = signature.replace("<class 'numpy.float64'>", "numpy.float64")
+    return (signature, return_annotation)
+
+
+def setup(app):
+    """Installs extensions."""
+    app.connect("autodoc-process-signature", process_signature)

--- a/ribs/_utils.py
+++ b/ribs/_utils.py
@@ -8,11 +8,13 @@ from types import ModuleType
 import array_api_compat.numpy as np_compat
 import numpy as np
 from array_api_compat import array_namespace
+from numpy.typing import ArrayLike
 
-from ribs.typing import ArrayVar
+from ribs.archives._archive_base import ArchiveBase
+from ribs.typing import ArrayVar, BatchData, Int, SingleData
 
 
-def check_finite(x, name):
+def check_finite(x: ArrayLike, name: str) -> None:
     """Checks that x is finite (i.e. not infinity or NaN).
 
     `x` must be either a scalar or NumPy array.
@@ -28,7 +30,13 @@ def check_finite(x, name):
         )
 
 
-def check_batch_shape(array, array_name, dim, dim_name, extra_msg=""):
+def check_batch_shape(
+    array: np.ndarray,
+    array_name: str,
+    dim: Int | tuple[Int, ...],
+    dim_name: str,
+    extra_msg: str = "",
+) -> None:
     """Checks that the array has shape (batch_size, dim) or (batch_size, *dim).
 
     `batch_size` can be any value.
@@ -47,7 +55,13 @@ def check_batch_shape(array, array_name, dim, dim_name, extra_msg=""):
         )
 
 
-def check_shape(array, array_name, dim, dim_name, extra_msg=""):
+def check_shape(
+    array: np.ndarray,
+    array_name: str,
+    dim: Int | tuple[Int, ...],
+    dim_name: str,
+    extra_msg: str = "",
+) -> None:
     """Checks that the array has shape dim.
 
     `array` must be a numpy array, and `dim` must be an int or tuple of int.
@@ -63,7 +77,7 @@ def check_shape(array, array_name, dim, dim_name, extra_msg=""):
         )
 
 
-def check_is_1d(array, array_name, extra_msg=""):
+def check_is_1d(array: np.ndarray, array_name: str, extra_msg: str = "") -> None:
     """Checks that an array is 1D."""
     if array.ndim != 1:
         raise ValueError(
@@ -72,7 +86,13 @@ def check_is_1d(array, array_name, extra_msg=""):
         )
 
 
-def check_solution_batch_dim(array, array_name, batch_size, is_1d=False, extra_msg=""):
+def check_solution_batch_dim(
+    array: np.ndarray,
+    array_name: str,
+    batch_size: int,
+    is_1d: bool = False,
+    extra_msg: str = "",
+) -> None:
     """Checks the batch dimension of an array with respect to the solutions."""
     if array.shape[0] != batch_size:
         raise ValueError(
@@ -85,8 +105,12 @@ def check_solution_batch_dim(array, array_name, batch_size, is_1d=False, extra_m
 
 
 def validate_batch(
-    archive, data, add_info=None, jacobian=None, none_objective_ok=False
-):
+    archive: ArchiveBase,
+    data: BatchData,
+    add_info: BatchData | None = None,
+    jacobian: ArrayLike = None,
+    none_objective_ok: bool = False,
+):  # No return annotation because it's quite complicated.
     """Preprocesses and validates batch arguments.
 
     ``data`` is a dict containing arrays with the data of each solution, e.g., objective
@@ -187,7 +211,9 @@ def validate_batch(
         return data
 
 
-def validate_single(archive, data, none_objective_ok=False):
+def validate_single(
+    archive: ArchiveBase, data: SingleData, none_objective_ok: bool = False
+) -> SingleData:
     """Performs preprocessing and checks for arguments to add_single()."""
     data["solution"] = np.asarray(data["solution"])
     check_shape(data["solution"], "solution", archive.solution_dim, "solution_dim")

--- a/ribs/archives/_archive_base.py
+++ b/ribs/archives/_archive_base.py
@@ -48,7 +48,7 @@ class ArchiveBase(ABC):
     def __init__(
         self,
         *,
-        solution_dim: Int | tuple[Int],
+        solution_dim: Int | tuple[Int, ...],
         objective_dim: tuple[()] | Int,
         measure_dim: Int,
     ) -> None:
@@ -59,7 +59,7 @@ class ArchiveBase(ABC):
     ## Properties of the archive ##
 
     @property
-    def solution_dim(self) -> Int | tuple[Int]:
+    def solution_dim(self) -> Int | tuple[Int, ...]:
         """Dimensionality of the solution space."""
         return self._solution_dim
 

--- a/ribs/archives/_archive_base.py
+++ b/ribs/archives/_archive_base.py
@@ -226,7 +226,7 @@ class ArchiveBase(ABC):
         """
         raise NotImplementedError("`retrieve` has not been implemented in this archive")
 
-    def retrieve_single(self, measures: ArrayLike) -> SingleData:
+    def retrieve_single(self, measures: ArrayLike) -> tuple[bool, SingleData]:
         """Queries the archive for an elite with the given measures.
 
         While :meth:`retrieve` takes in a *batch* of measures, this method takes in the

--- a/ribs/archives/_array_store.py
+++ b/ribs/archives/_array_store.py
@@ -13,14 +13,14 @@ from typing import Literal, overload
 
 import numpy as np
 from array_api_compat import is_cupy_array, is_numpy_array, is_torch_array
-from numpy.typing import ArrayLike, DTypeLike
+from numpy.typing import ArrayLike
 
 with contextlib.suppress(ImportError):
     from array_api_compat import cupy as cp
 
 from ribs._utils import arr_readonly, xp_namespace
 from ribs.archives._archive_data_frame import ArchiveDataFrame
-from ribs.typing import Array, BatchData, Device, DType, Int, SingleData
+from ribs.typing import Array, BatchData, Device, DType, FieldDesc, Int, SingleData
 
 
 class Update(IntEnum):
@@ -128,7 +128,7 @@ class ArrayStore:
 
     def __init__(
         self,
-        field_desc: dict[str, tuple[Int | tuple[Int], DTypeLike]],
+        field_desc: FieldDesc,
         capacity: Int,
         xp: ModuleType | None = None,
         device: Device = None,

--- a/ribs/archives/_array_store.py
+++ b/ribs/archives/_array_store.py
@@ -341,7 +341,7 @@ class ArrayStore:
                 with an additional "index" as the last field. The "index" field can also
                 be added anywhere in this list of fields. This argument can also be a
                 single str indicating a field name.
-            return_type (str): Type of data to return. See the ``data`` returned below.
+            return_type: Type of data to return. See the ``data`` returned below.
                 Ignored if ``fields`` is a str.
 
         Returns:

--- a/ribs/archives/_array_store.py
+++ b/ribs/archives/_array_store.py
@@ -202,7 +202,7 @@ class ArrayStore:
         return arr_readonly(self._props["occupied_list"][: self._props["n_occupied"]])
 
     @cached_property
-    def field_desc(self) -> dict[str, tuple[tuple[int], DType]]:
+    def field_desc(self) -> FieldDesc:
         """Description of fields in the store.
 
         Example:

--- a/ribs/archives/_categorical_archive.py
+++ b/ribs/archives/_categorical_archive.py
@@ -1,10 +1,17 @@
 """Contains the CategoricalArchive."""
 
+from __future__ import annotations
+
+from collections.abc import Collection, Hashable, Iterator
+from typing import Literal, overload
+
 import numpy as np
+from numpy.typing import ArrayLike
 from numpy_groupies import aggregate_nb as aggregate
 
 from ribs._utils import check_batch_shape, check_shape, validate_batch, validate_single
 from ribs.archives._archive_base import ArchiveBase
+from ribs.archives._archive_data_frame import ArchiveDataFrame
 from ribs.archives._archive_stats import ArchiveStats
 from ribs.archives._array_store import ArrayStore
 from ribs.archives._grid_archive import GridArchive
@@ -12,6 +19,15 @@ from ribs.archives._utils import (
     fill_sentinel_values,
     parse_dtype,
     validate_cma_mae_settings,
+)
+from ribs.typing import (
+    ArchiveDType,
+    Array,
+    BatchData,
+    FieldDesc,
+    Float,
+    Int,
+    SingleData,
 )
 
 
@@ -35,38 +51,36 @@ class CategoricalArchive(ArchiveBase):
         solution_dim: Dimensionality of the solution space. Scalar or multi-dimensional
             solution shapes are allowed by passing an empty tuple or tuple of integers,
             respectively.
-        categories (list of list of any): The name of each category for each dimension
-            of the measure space. The length of this list is the dimensionality of the
-            measure space. An example is ``[["A", "B", "C"], ["One", "Two", "Three",
-            "Four"]]``, which defines a 2D measure space where the first dimension has
-            categories ``["A", "B", "C"]`` and the second has categories ``["One",
-            "Two", "Three", "Four"]``. While any object can be used for the category
-            name, strings are expected to be the typical use case.
-        learning_rate (float): The learning rate for threshold updates. Defaults to 1.0.
-        threshold_min (float): The initial threshold value for all the cells.
-        qd_score_offset (float): Archives often contain negative objective values, and
-            if the QD score were to be computed with these negative objectives, the
-            algorithm would be penalized for adding new cells with negative objectives.
-            Thus, a standard practice is to normalize all the objectives so that they
-            are non-negative by introducing an offset. This QD score offset will be
+        categories: The name of each category for each dimension of the measure space.
+            The length of this list is the dimensionality of the measure space. An
+            example is ``[["A", "B", "C"], ["One", "Two", "Three", "Four"]]``, which
+            defines a 2D measure space where the first dimension has categories ``["A",
+            "B", "C"]`` and the second has categories ``["One", "Two", "Three",
+            "Four"]``. While any object can be used for the category name, strings are
+            expected to be the typical use case.
+        learning_rate: The learning rate for threshold updates. Defaults to 1.0.
+        threshold_min: The initial threshold value for all the cells.
+        qd_score_offset: Archives often contain negative objective values, and if the QD
+            score were to be computed with these negative objectives, the algorithm
+            would be penalized for adding new cells with negative objectives. Thus, a
+            standard practice is to normalize all the objectives so that they are
+            non-negative by introducing an offset. This QD score offset will be
             *subtracted* from all objectives in the archive, e.g., if your objectives go
             as low as -300, pass in -300 so that each objective will be transformed as
             ``objective - (-300)``.
-        seed (int): Value to seed the random number generator. Set to None to avoid a
-            fixed seed.
-        dtype (str or data-type or dict): There are two options for this parameter.
-            First, it can be just the data type of the solutions and objectives, with
-            the measures defaulting to a dtype of ``object``. In this case, ``dtype``
-            can be ``"f"`` / ``np.float32`` or ``"d"`` / ``np.float64``. Second,
-            ``dtype`` can be a dict specifying separate dtypes, of the form
-            ``{"solution": <dtype>, "objective": <dtype>, "measures": <dtype>}``.
-        extra_fields (dict): Description of extra fields of data that is stored next to
-            elite data like solutions and objectives. The description is a dict mapping
-            from a field name (str) to a tuple of ``(shape, dtype)``. For instance,
-            ``{"foo": ((), np.float32), "bar": ((10,), np.float32)}`` will create a
-            "foo" field that contains scalar values and a "bar" field that contains 10D
-            values. Note that field names must be valid Python identifiers, and names
-            already used in the archive are not allowed.
+        seed: Value to seed the random number generator. Set to None to avoid a fixed
+            seed.
+        dtype: Data type of the solutions, objectives, and measures. This can be ``"f"``
+            / ``np.float32``, ``"d"`` / ``np.float64``, or a dict specifying separate
+            dtypes, of the form ``{"solution": <dtype>, "objective": <dtype>,
+            "measures": <dtype>}``.
+        extra_fields: Description of extra fields of data that are stored next to elite
+            data like solutions and objectives. The description is a dict mapping from a
+            field name (str) to a tuple of ``(shape, dtype)``. For instance, ``{"foo":
+            ((), np.float32), "bar": ((10,), np.float32)}`` will create a "foo" field
+            that contains scalar values and a "bar" field that contains 10D values. Note
+            that field names must be valid Python identifiers, and names already used in
+            the archive are not allowed.
 
     Raises:
         ValueError: Invalid values for learning_rate and threshold_min.
@@ -76,15 +90,15 @@ class CategoricalArchive(ArchiveBase):
     def __init__(
         self,
         *,
-        solution_dim,
-        categories,
-        learning_rate=None,
-        threshold_min=-np.inf,
-        qd_score_offset=0.0,
-        seed=None,
-        dtype=np.float64,
-        extra_fields=None,
-    ):
+        solution_dim: Int | tuple[Int, ...],
+        categories: Collection[Collection[Hashable]],
+        learning_rate: Float | None = None,
+        threshold_min: Float = -np.inf,
+        qd_score_offset: Float = 0.0,
+        seed: Int | None = None,
+        dtype: ArchiveDType = np.float64,
+        extra_fields: FieldDesc | None = None,
+    ) -> None:
         self._rng = np.random.default_rng(seed)
         self._categories = [list(measure_dim) for measure_dim in categories]
         self._dims = np.array(
@@ -150,27 +164,27 @@ class CategoricalArchive(ArchiveBase):
     ## Properties inherited from ArchiveBase ##
 
     @property
-    def field_list(self):
+    def field_list(self) -> list[str]:
         return self._store.field_list_with_index
 
     @property
-    def dtypes(self):
+    def dtypes(self) -> dict[str, np.dtype]:
         return self._store.dtypes_with_index
 
     @property
-    def stats(self):
+    def stats(self) -> ArchiveStats:
         return self._stats
 
     @property
-    def empty(self):
+    def empty(self) -> bool:
         return len(self._store) == 0
 
     ## Properties that are not in ArchiveBase ##
     ## Roughly ordered by the parameter list in the constructor. ##
 
     @property
-    def best_elite(self):
-        """dict: The elite with the highest objective in the archive.
+    def best_elite(self) -> SingleData:
+        """The elite with the highest objective in the archive.
 
         None if there are no elites in the archive.
 
@@ -191,46 +205,46 @@ class CategoricalArchive(ArchiveBase):
         return self._best_elite
 
     @property
-    def categories(self):
-        """list of list: The categories in each dimension of the measure space."""  # noqa: D403
+    def categories(self) -> list[list[Hashable]]:
+        """The categories in each dimension of the measure space."""
         return self._categories
 
     @property
-    def dims(self):
-        """(measure_dim,) numpy.ndarray: Number of cells in each dimension."""
+    def dims(self) -> np.ndarray:
+        """(:attr:`measure_dim`,) array listing the number of cells in each dimension."""
         return self._dims
 
     @property
-    def cells(self):
-        """int: Total number of cells in the archive."""
+    def cells(self) -> Int:
+        """Total number of cells in the archive."""
         return self._store.capacity
 
     @property
-    def learning_rate(self):
-        """float: The learning rate for threshold updates."""
+    def learning_rate(self) -> float:
+        """The learning rate for threshold updates."""
         return self._learning_rate
 
     @property
-    def threshold_min(self):
-        """float: The initial threshold value for all the cells."""
+    def threshold_min(self) -> float:
+        """The initial threshold value for all the cells."""
         return self._threshold_min
 
     @property
-    def qd_score_offset(self):
-        """float: Subtracted from objective values when computing the QD score."""
+    def qd_score_offset(self) -> float:
+        """Subtracted from objective values when computing the QD score."""
         return self._qd_score_offset
 
     ## dunder methods ##
 
-    def __len__(self):
+    def __len__(self) -> int:
         return len(self._store)
 
-    def __iter__(self):
+    def __iter__(self) -> Iterator[SingleData]:
         return iter(self._store)
 
     ## Utilities ##
 
-    def _stats_reset(self):
+    def _stats_reset(self) -> None:
         """Resets the archive stats."""
         self._best_elite = None
         self._objective_sum = np.asarray(0.0, dtype=self.dtypes["objective"])
@@ -243,8 +257,8 @@ class CategoricalArchive(ArchiveBase):
             obj_mean=None,
         )
 
-    def _stats_update(self, new_objective_sum, new_best_index):
-        """Updates archive statistics.
+    def _stats_update(self, new_objective_sum: Float, new_best_index: Float) -> None:
+        """Updates statistics.
 
         Update is based on a new sum of objective values (new_objective_sum) and the
         index of a potential new best elite (new_best_index).
@@ -280,19 +294,19 @@ class CategoricalArchive(ArchiveBase):
             ),
         )
 
-    def index_of(self, measures):
+    def index_of(self, measures: ArrayLike) -> np.ndarray:
         """Returns archive indices for the given batch of measures.
 
         This is by done by mapping from the category name to the cell indices, and then
         converting to integer indices with :meth:`grid_to_int_index`.
 
         Args:
-            measures (array-like): (batch_size, :attr:`measure_dim`) array of
-                coordinates in measure space.
+            measures: (batch_size, :attr:`measure_dim`) array of coordinates/categories
+                in measure space.
 
         Returns:
-            numpy.ndarray: (batch_size,) array of integer indices representing the
-            flattened grid coordinates.
+            (batch_size,) array of integer indices representing the flattened grid
+            coordinates.
 
         Raises:
             ValueError: ``measures`` is not of shape (batch_size, :attr:`measure_dim`).
@@ -308,18 +322,16 @@ class CategoricalArchive(ArchiveBase):
 
         return self.grid_to_int_index(grid_indices)
 
-    def index_of_single(self, measures):
+    def index_of_single(self, measures: ArrayLike) -> Int:
         """Returns the index of the measures for one solution.
 
         See :meth:`index_of`.
 
         Args:
-            measures (array-like): (:attr:`measure_dim`,) array of measures for a single
-                solution.
+            measures: (:attr:`measure_dim`,) array of measures for a single solution.
 
         Returns:
-            int or numpy.integer: Integer index of the measures in the archive's storage
-            arrays.
+            Integer index of the measures in the archive's storage arrays.
 
         Raises:
             ValueError: ``measures`` is not of shape (:attr:`measure_dim`,).
@@ -336,7 +348,13 @@ class CategoricalArchive(ArchiveBase):
     ## Methods for writing to the archive ##
 
     @staticmethod
-    def _compute_thresholds(indices, objective, cur_threshold, learning_rate, dtype):
+    def _compute_thresholds(
+        indices: np.ndarray,
+        objective: np.ndarray,
+        cur_threshold: np.ndarray,
+        learning_rate: float,
+        dtype: np.dtype,
+    ) -> np.ndarray:
         """Computes new thresholds with the CMA-MAE batch threshold update rule.
 
         If entries in `indices` are duplicated, they receive the same threshold.
@@ -374,7 +392,13 @@ class CategoricalArchive(ArchiveBase):
 
         return new_threshold
 
-    def add(self, solution, objective, measures, **fields):
+    def add(
+        self,
+        solution: ArrayLike,
+        objective: ArrayLike,
+        measures: ArrayLike,
+        **fields: ArrayLike,
+    ) -> BatchData:
         """Inserts a batch of solutions into the archive.
 
         Each solution is only inserted if it has a higher ``objective`` than the
@@ -397,18 +421,17 @@ class CategoricalArchive(ArchiveBase):
             solution parameters, objective, and measures for solution ``i``.
 
         Args:
-            solution (array-like): (batch_size, :attr:`solution_dim`) array of solution
-                parameters.
-            objective (array-like): (batch_size,) array with objective function
-                evaluations of the solutions.
-            measures (array-like): (batch_size, :attr:`measure_dim`) array with measure
-                space coordinates of all the solutions.
-            fields (keyword arguments): Additional data for each solution. Each argument
-                should be an array with batch_size as the first dimension.
+            solution: (batch_size, :attr:`solution_dim`) array of solution parameters.
+            objective: (batch_size,) array with objective function evaluations of the
+                solutions.
+            measures: (batch_size, :attr:`measure_dim`) array with measure space
+                coordinates of all the solutions.
+            fields: Additional data for each solution. Each argument should be an array
+                with batch_size as the first dimension.
 
         Returns:
-            dict: Information describing the result of the add operation. The dict
-            contains the following keys:
+            Information describing the result of the add operation. The dict contains
+            the following keys:
 
             - ``"status"`` (:class:`numpy.ndarray` of :class:`numpy.int32`): An array of
               integers that represent the "status" obtained when attempting to insert
@@ -567,7 +590,13 @@ class CategoricalArchive(ArchiveBase):
 
         return add_info
 
-    def add_single(self, solution, objective, measures, **fields):
+    def add_single(
+        self,
+        solution: ArrayLike,
+        objective: ArrayLike,
+        measures: ArrayLike,
+        **fields: ArrayLike,
+    ) -> SingleData:
         """Inserts a single solution into the archive.
 
         The solution is only inserted if it has a higher ``objective`` than the
@@ -582,15 +611,15 @@ class CategoricalArchive(ArchiveBase):
             time. For better performance, see :meth:`add`.
 
         Args:
-            solution (array-like): Parameters of the solution.
-            objective (float): Objective function evaluation of the solution.
-            measures (array-like): Coordinates in measure space of the solution.
-            fields (keyword arguments): Additional data for the solution.
+            solution: Parameters of the solution.
+            objective: Objective function evaluation of the solution.
+            measures: Coordinates in measure space of the solution.
+            fields: Additional data for the solution.
 
         Returns:
-            dict: Information describing the result of the add operation. The
-            dict contains ``status`` and ``value`` keys; refer to :meth:`add`
-            for the meaning of status and value.
+            Information describing the result of the add operation. The dict contains
+            ``status`` and ``value`` keys; refer to :meth:`add` for the meaning of
+            status and value.
 
         Raises:
             ValueError: The array arguments do not match their specified shapes.
@@ -695,7 +724,7 @@ class CategoricalArchive(ArchiveBase):
 
         return add_info
 
-    def clear(self):
+    def clear(self) -> None:
         """Removes all elites in the archive."""
         self._store.clear()
         self._stats_reset()
@@ -703,8 +732,8 @@ class CategoricalArchive(ArchiveBase):
     ## Methods for reading from the archive ##
     ## Refer to ArchiveBase for documentation of these methods. ##
 
-    def retrieve(self, measures):
-        measures = np.asarray(measures, dtype=self.dtypes["measures"])
+    def retrieve(self, measures: ArrayLike) -> tuple[np.ndarray, BatchData]:
+        measures = np.asarray(measures)
         check_batch_shape(measures, "measures", self.measure_dim, "measure_dim")
 
         occupied, data = self._store.retrieve(self.index_of(measures))
@@ -712,18 +741,50 @@ class CategoricalArchive(ArchiveBase):
 
         return occupied, data
 
-    def retrieve_single(self, measures):
-        measures = np.asarray(measures, dtype=self.dtypes["measures"])
+    def retrieve_single(self, measures: ArrayLike) -> tuple[bool, SingleData]:
+        measures = np.asarray(measures)
         check_shape(measures, "measures", self.measure_dim, "measure_dim")
 
         occupied, data = self.retrieve(measures[None])
 
         return occupied[0], {field: arr[0] for field, arr in data.items()}
 
-    def data(self, fields=None, return_type="dict"):
+    @overload
+    def data(
+        self,
+        fields: str,
+        return_type: Literal["dict", "tuple", "pandas"] = "dict",
+    ) -> Array: ...
+
+    @overload
+    def data(
+        self,
+        fields: None | Collection[str] = None,
+        return_type: Literal["dict"] = "dict",
+    ) -> BatchData: ...
+
+    @overload
+    def data(
+        self,
+        fields: None | Collection[str] = None,
+        return_type: Literal["tuple"] = "tuple",
+    ) -> tuple[Array]: ...
+
+    @overload
+    def data(
+        self,
+        fields: None | Collection[str] = None,
+        return_type: Literal["pandas"] = "pandas",
+    ) -> ArchiveDataFrame: ...
+
+    def data(
+        self,
+        fields: None | Collection[str] | str = None,
+        return_type: Literal["dict", "tuple", "pandas"] = "dict",
+    ) -> Array | BatchData | tuple[Array] | ArchiveDataFrame:
         return self._store.data(fields, return_type)
 
-    def sample_elites(self, n):
+    def sample_elites(self, n: Int) -> BatchData:
         if self.empty:
             raise IndexError("No elements in archive.")
 

--- a/ribs/archives/_categorical_archive.py
+++ b/ribs/archives/_categorical_archive.py
@@ -32,9 +32,9 @@ class CategoricalArchive(ArchiveBase):
     while the integer ``index`` uniquely identifies each cell.
 
     Args:
-        solution_dim (int or tuple of int): Dimensionality of the solution space. Scalar
-            or multi-dimensional solution shapes are allowed by passing an empty tuple
-            or tuple of integers, respectively.
+        solution_dim: Dimensionality of the solution space. Scalar or multi-dimensional
+            solution shapes are allowed by passing an empty tuple or tuple of integers,
+            respectively.
         categories (list of list of any): The name of each category for each dimension
             of the measure space. The length of this list is the dimensionality of the
             measure space. An example is ``[["A", "B", "C"], ["One", "Two", "Three",

--- a/ribs/archives/_categorical_archive.py
+++ b/ribs/archives/_categorical_archive.py
@@ -73,7 +73,8 @@ class CategoricalArchive(ArchiveBase):
         dtype: Data type of the solutions, objectives, and measures. This can be ``"f"``
             / ``np.float32``, ``"d"`` / ``np.float64``, or a dict specifying separate
             dtypes, of the form ``{"solution": <dtype>, "objective": <dtype>,
-            "measures": <dtype>}``.
+            "measures": <dtype>}``. By default, unless this parameter is a dict,
+            measures will default to have ``object`` dtype.
         extra_fields: Description of extra fields of data that are stored next to elite
             data like solutions and objectives. The description is a dict mapping from a
             field name (str) to a tuple of ``(shape, dtype)``. For instance, ``{"foo":

--- a/ribs/archives/_cqd_score.py
+++ b/ribs/archives/_cqd_score.py
@@ -3,11 +3,14 @@
 from __future__ import annotations
 
 import dataclasses
-import typing
+from typing import Any
 
 import numpy as np
+from numpy.typing import ArrayLike
 
 from ribs._utils import check_is_1d
+from ribs.archives._archive_base import ArchiveBase
+from ribs.typing import Float, Int
 
 
 @dataclasses.dataclass
@@ -15,10 +18,10 @@ class CQDScoreResult:
     """Stores the result of running :func:`cqd_score`."""
 
     #: Number of times the score was computed.
-    iterations: int | np.integer
+    iterations: Int
 
     #: The mean score. This is the result most users will need.
-    mean: float | np.floating
+    mean: Float
 
     #: Array of scores obtained on each iteration.
     scores: np.ndarray
@@ -31,30 +34,30 @@ class CQDScoreResult:
     penalties: np.ndarray
 
     #: Minimum objective passed into the function.
-    obj_min: float | np.floating
+    obj_min: Float
 
     #: Maximum objective passed into the function.
-    obj_max: float | np.floating
+    obj_max: Float
 
     #: Max distance passed into the function.
-    dist_max: float | np.floating
+    dist_max: Float
 
     #: Order of the norm for distance that was passed into the function. Refer to the
     #: ``ord`` argument in :func:`numpy.linalg.norm` for type info.
-    dist_ord: typing.Any
+    dist_ord: Any
 
 
 def cqd_score(
-    archive,
+    archive: ArchiveBase,
     *,
-    iterations,
-    target_points,
-    penalties,
-    obj_min,
-    obj_max,
-    dist_max,
-    dist_ord=None,
-):
+    iterations: Int,
+    target_points: ArrayLike,
+    penalties: Int | ArrayLike,
+    obj_min: Float,
+    obj_max: Float,
+    dist_max: Float,
+    dist_ord: Any = None,
+) -> CQDScoreResult:
     r"""Computes the CQD score of an archive.
 
     The Continuous Quality Diversity (CQD) score was introduced in `Kent 2022
@@ -63,25 +66,25 @@ def cqd_score(
     archive.
 
     Args:
-        archive (ArchiveBase): Archive for which to compute the CQD score. The archive
-            must implement the :meth:`~ribs.archives.ArchiveBase.data` method.
-        iterations (int): Number of times to compute the CQD score.
-        target_points (array-like): (iterations, n, measure_dim) array that lists n
-            target points to use on each iteration.
-        penalties (int or array-like): Number of penalty values over which to compute
-            the score (the values are distributed evenly over the range [0,1]).
-            Alternatively, this may be a 1D array that explicitly lists the penalty
-            values. Known as :math:`\theta` in Kent 2022.
-        obj_min (float): Minimum objective value, used when normalizing the objectives.
-        obj_max (float): Maximum objective value, used when normalizing the objectives.
-        dist_max (float): Maximum distance between points in measure space.
+        archive: Archive for which to compute the CQD score. The archive must implement
+            the :meth:`~ribs.archives.ArchiveBase.data` method.
+        iterations: Number of times to compute the CQD score.
+        target_points: (iterations, n, measure_dim) array that lists n target points to
+            use on each iteration.
+        penalties: Number of penalty values over which to compute the score (the values
+            are distributed evenly over the range [0,1]). Alternatively, this may be a
+            1D array that explicitly lists the penalty values. Known as :math:`\theta`
+            in Kent 2022.
+        obj_min: Minimum objective value, used when normalizing the objectives.
+        obj_max: Maximum objective value, used when normalizing the objectives.
+        dist_max: Maximum distance between points in measure space.
         dist_ord: Order of the norm to use for calculating measure space distance; this
             is passed to :func:`numpy.linalg.norm` as the ``ord`` argument. See
             :func:`numpy.linalg.norm` for possible values. The default is to use
             Euclidean distance (L2 norm).
 
     Returns:
-        CQDScoreResult: Object containing results of the CQD score calculations.
+        Object containing results of the CQD score calculations.
 
     Raises:
         ValueError: target_points or penalties is an array with the wrong shape.

--- a/ribs/archives/_cvt_archive.py
+++ b/ribs/archives/_cvt_archive.py
@@ -1,8 +1,13 @@
 """Contains the CVTArchive."""
 
+from __future__ import annotations
+
 import numbers
+from collections.abc import Collection, Iterator
+from typing import Literal, overload
 
 import numpy as np
+from numpy.typing import ArrayLike
 from numpy_groupies import aggregate_nb as aggregate
 from scipy.spatial import cKDTree  # ty: ignore[unresolved-import]
 from scipy.stats.qmc import Halton, Sobol
@@ -16,12 +21,22 @@ from ribs._utils import (
     validate_single,
 )
 from ribs.archives._archive_base import ArchiveBase
+from ribs.archives._archive_data_frame import ArchiveDataFrame
 from ribs.archives._archive_stats import ArchiveStats
 from ribs.archives._array_store import ArrayStore
 from ribs.archives._utils import (
     fill_sentinel_values,
     parse_dtype,
     validate_cma_mae_settings,
+)
+from ribs.typing import (
+    ArchiveDType,
+    Array,
+    BatchData,
+    FieldDesc,
+    Float,
+    Int,
+    SingleData,
 )
 
 
@@ -74,60 +89,57 @@ class CVTArchive(ArchiveBase):
         solution_dim: Dimensionality of the solution space. Scalar or multi-dimensional
             solution shapes are allowed by passing an empty tuple or tuple of integers,
             respectively.
-        cells (int): The number of cells to use in the archive, equivalent to the number
-            of centroids/areas in the CVT.
-        ranges (array-like of (float, float)): Upper and lower bound of each dimension
-            of the measure space, e.g. ``[(-1, 1), (-2, 2)]`` indicates the first
-            dimension should have bounds :math:`[-1,1]` (inclusive), and the second
-            dimension should have bounds :math:`[-2,2]` (inclusive). ``ranges`` should
-            be the same length as ``dims``.
-        learning_rate (float): The learning rate for threshold updates. Defaults to 1.0.
-        threshold_min (float): The initial threshold value for all the cells.
-        qd_score_offset (float): Archives often contain negative objective values, and
-            if the QD score were to be computed with these negative objectives, the
-            algorithm would be penalized for adding new cells with negative objectives.
-            Thus, a standard practice is to normalize all the objectives so that they
-            are non-negative by introducing an offset. This QD score offset will be
+        cells: The number of cells to use in the archive, equivalent to the number of
+            centroids/areas in the CVT.
+        ranges: Upper and lower bound of each dimension of the measure space, e.g.
+            ``[(-1, 1), (-2, 2)]`` indicates the first dimension should have bounds
+            :math:`[-1,1]` (inclusive), and the second dimension should have bounds
+            :math:`[-2,2]` (inclusive). ``ranges`` should be the same length as
+            ``dims``.
+        learning_rate: The learning rate for threshold updates. Defaults to 1.0.
+        threshold_min: The initial threshold value for all the cells.
+        qd_score_offset: Archives often contain negative objective values, and if the QD
+            score were to be computed with these negative objectives, the algorithm
+            would be penalized for adding new cells with negative objectives. Thus, a
+            standard practice is to normalize all the objectives so that they are
+            non-negative by introducing an offset. This QD score offset will be
             *subtracted* from all objectives in the archive, e.g., if your objectives go
             as low as -300, pass in -300 so that each objective will be transformed as
             ``objective - (-300)``.
-        seed (int): Value to seed the random number generator as well as
+        seed: Value to seed the random number generator as well as
             :func:`~sklearn.cluster.k_means`. Set to None to avoid a fixed seed.
-        dtype (str or data-type or dict): Data type of the solutions, objectives, and
-            measures. This can be ``"f"`` / ``np.float32``, ``"d"`` / ``np.float64``, or
-            a dict specifying separate dtypes, of the form ``{"solution": <dtype>,
-            "objective": <dtype>, "measures": <dtype>}``.
-        extra_fields (dict): Description of extra fields of data that is stored next to
-            elite data like solutions and objectives. The description is a dict mapping
-            from a field name (str) to a tuple of ``(shape, dtype)``. For instance,
-            ``{"foo": ((), np.float32), "bar": ((10,), np.float32)}`` will create a
-            "foo" field that contains scalar values and a "bar" field that contains 10D
-            values. Note that field names must be valid Python identifiers, and names
-            already used in the archive are not allowed.
-        custom_centroids (array-like): If passed in, this (cells, measure_dim) array
-            will be used as the centroids of the CVT instead of generating new ones. In
-            this case, ``samples`` will be ignored, and ``archive.samples`` will be
-            None. This can be useful when one wishes to use the same CVT across
-            experiments for fair comparison.
-        centroid_method (str): Pass in the following methods for generating centroids:
-            "random", "sobol", "scrambled_sobol", "halton". Default method is "kmeans".
-            These methods are derived from Mouret 2023:
+        dtype: Data type of the solutions, objectives, and measures. This can be ``"f"``
+            / ``np.float32``, ``"d"`` / ``np.float64``, or a dict specifying separate
+            dtypes, of the form ``{"solution": <dtype>, "objective": <dtype>,
+            "measures": <dtype>}``.
+        extra_fields: Description of extra fields of data that are stored next to elite
+            data like solutions and objectives. The description is a dict mapping from a
+            field name (str) to a tuple of ``(shape, dtype)``. For instance, ``{"foo":
+            ((), np.float32), "bar": ((10,), np.float32)}`` will create a "foo" field
+            that contains scalar values and a "bar" field that contains 10D values. Note
+            that field names must be valid Python identifiers, and names already used in
+            the archive are not allowed.
+        custom_centroids: If passed in, this (cells, measure_dim) array will be used as
+            the centroids of the CVT instead of generating new ones. In this case,
+            ``samples`` will be ignored, and ``archive.samples`` will be None. This can
+            be useful when one wishes to use the same CVT across experiments for fair
+            comparison.
+        centroid_method: Centroid generation method, as presented in Mouret 2023:
             https://dl.acm.org/doi/pdf/10.1145/3583133.3590726. Note: Samples are only
             used when method is "kmeans".
-        samples (int or array-like): If it is an int, this specifies the number of
-            samples to generate when creating the CVT. Otherwise, this must be a
-            (num_samples, measure_dim) array where samples[i] is a sample to use when
-            creating the CVT. It can be useful to pass in custom samples when there are
-            restrictions on what samples in the measure space are (physically) possible.
-        k_means_kwargs (dict): kwargs for :func:`~sklearn.cluster.k_means`. By default,
-            we pass in `n_init=1`, `init="random"`, `algorithm="lloyd"`, and
-            `random_state=seed`.
-        use_kd_tree (bool): If True, use a k-D tree for finding the closest centroid
-            when inserting into the archive. If False, brute force will be used instead.
-        ckdtree_kwargs (dict): kwargs for :class:`~scipy.spatial.cKDTree`. By default,
-            we do not pass in any kwargs.
-        chunk_size (int): If passed, brute forcing the closest centroid search will
-            chunk the distance calculations to compute chunk_size inputs at a time.
+        samples: If it is an int, this specifies the number of samples to generate when
+            creating the CVT. Otherwise, this must be a (num_samples, measure_dim) array
+            where samples[i] is a sample to use when creating the CVT. It can be useful
+            to pass in custom samples when there are restrictions on what samples in the
+            measure space are (physically) possible.
+        k_means_kwargs: kwargs for :func:`~sklearn.cluster.k_means`. By default, we pass
+            `n_init=1`, `init="random"`, `algorithm="lloyd"`, and `random_state=seed`.
+        use_kd_tree: If True, use a k-D tree for finding the closest centroid when
+            inserting into the archive. If False, brute force will be used instead.
+        ckdtree_kwargs: kwargs for :class:`~scipy.spatial.cKDTree`. By default, we do
+            not pass in any kwargs.
+        chunk_size: If passed, brute forcing the closest centroid search will chunk the
+            distance calculations to compute chunk_size inputs at a time.
 
     Raises:
         ValueError: Invalid values for learning_rate and threshold_min.
@@ -139,23 +151,25 @@ class CVTArchive(ArchiveBase):
     def __init__(
         self,
         *,
-        solution_dim,
-        cells,
-        ranges,
-        learning_rate=None,
-        threshold_min=-np.inf,
-        qd_score_offset=0.0,
-        seed=None,
-        dtype=np.float64,
-        extra_fields=None,
-        custom_centroids=None,
-        centroid_method="kmeans",
-        samples=100_000,
-        k_means_kwargs=None,
-        use_kd_tree=True,
-        ckdtree_kwargs=None,
-        chunk_size=None,
-    ):
+        solution_dim: Int | tuple[Int, ...],
+        cells: Int,
+        ranges: Collection[tuple[Float, Float]],
+        learning_rate: Float | None = None,
+        threshold_min: Float = -np.inf,
+        qd_score_offset: Float = 0.0,
+        seed: Int | None = None,
+        dtype: ArchiveDType = np.float64,
+        extra_fields: FieldDesc | None = None,
+        custom_centroids: ArrayLike = None,
+        centroid_method: Literal[
+            "kmeans", "random", "sobol", "scrambled_sobol", "halton"
+        ] = "kmeans",
+        samples: Int | ArrayLike = 100_000,
+        k_means_kwargs: dict | None = None,
+        use_kd_tree: bool = True,
+        ckdtree_kwargs: dict | None = None,
+        chunk_size: Int = None,
+    ) -> None:
         self._rng = np.random.default_rng(seed)
 
         ArchiveBase.__init__(
@@ -306,27 +320,27 @@ class CVTArchive(ArchiveBase):
     ## Properties inherited from ArchiveBase ##
 
     @property
-    def field_list(self):
+    def field_list(self) -> list[str]:
         return self._store.field_list_with_index
 
     @property
-    def dtypes(self):
+    def dtypes(self) -> dict[str, np.dtype]:
         return self._store.dtypes_with_index
 
     @property
-    def stats(self):
+    def stats(self) -> ArchiveStats:
         return self._stats
 
     @property
-    def empty(self):
+    def empty(self) -> bool:
         return len(self._store) == 0
 
     ## Properties that are not in ArchiveBase ##
     ## Roughly ordered by the parameter list in the constructor. ##
 
     @property
-    def best_elite(self):
-        """dict: The elite with the highest objective in the archive.
+    def best_elite(self) -> SingleData:
+        """The elite with the highest objective in the archive.
 
         None if there are no elites in the archive.
 
@@ -347,8 +361,8 @@ class CVTArchive(ArchiveBase):
         return self._best_elite
 
     @property
-    def cells(self):
-        """int: Total number of cells in the archive."""
+    def cells(self) -> Int:
+        """Total number of cells in the archive."""
         return self._store.capacity
 
     @property
@@ -367,28 +381,28 @@ class CVTArchive(ArchiveBase):
         return self._interval_size
 
     @property
-    def learning_rate(self):
-        """float: The learning rate for threshold updates."""
+    def learning_rate(self) -> float:
+        """The learning rate for threshold updates."""
         return self._learning_rate
 
     @property
-    def threshold_min(self):
-        """float: The initial threshold value for all the cells."""
+    def threshold_min(self) -> float:
+        """The initial threshold value for all the cells."""
         return self._threshold_min
 
     @property
-    def qd_score_offset(self):
-        """float: Subtracted from objective values when computing the QD score."""
+    def qd_score_offset(self) -> float:
+        """Subtracted from objective values when computing the QD score."""
         return self._qd_score_offset
 
     @property
-    def centroids(self):
-        """(n_centroids, measure_dim) numpy.ndarray: Centroids used in the CVT."""
+    def centroids(self) -> np.ndarray:
+        """(n_centroids, measure_dim) array of centroids used in the CVT."""
         return self._centroids
 
     @property
-    def samples(self):
-        """(num_samples, measure_dim) numpy.ndarray: Samples used in creating the CVT.
+    def samples(self) -> np.ndarray:
+        """(num_samples, measure_dim) samples used when creating the CVT.
 
         None if custom centroids were passed in to the archive.
         """
@@ -396,15 +410,15 @@ class CVTArchive(ArchiveBase):
 
     ## dunder methods ##
 
-    def __len__(self):
+    def __len__(self) -> int:
         return len(self._store)
 
-    def __iter__(self):
+    def __iter__(self) -> Iterator[SingleData]:
         return iter(self._store)
 
     ## Utilities ##
 
-    def _stats_reset(self):
+    def _stats_reset(self) -> None:
         """Resets the archive stats."""
         self._best_elite = None
         self._objective_sum = np.asarray(0.0, dtype=self.dtypes["objective"])
@@ -417,8 +431,8 @@ class CVTArchive(ArchiveBase):
             obj_mean=None,
         )
 
-    def _stats_update(self, new_objective_sum, new_best_index):
-        """Updates archive statistics.
+    def _stats_update(self, new_objective_sum: Float, new_best_index: Float) -> None:
+        """Updates statistics.
 
         Update is based on a new sum of objective values (new_objective_sum) and the
         index of a potential new best elite (new_best_index).
@@ -454,7 +468,7 @@ class CVTArchive(ArchiveBase):
             ),
         )
 
-    def index_of(self, measures):
+    def index_of(self, measures: ArrayLike) -> np.ndarray:
         """Finds indices of the centroids closest to the given measures.
 
         If ``index_batch`` is the batch of indices returned by this method, then
@@ -465,12 +479,12 @@ class CVTArchive(ArchiveBase):
         depending on the value of ``use_kd_tree`` in the constructor.
 
         Args:
-            measures (array-like): (batch_size, :attr:`measure_dim`) array of
-                coordinates in measure space.
+            measures: (batch_size, :attr:`measure_dim`) array of coordinates in measure
+                space.
 
         Returns:
-            numpy.ndarray: (batch_size,) array of centroid indices
-            corresponding to each measure space coordinate.
+            (batch_size,) array of centroid indices corresponding to each measure space
+            coordinate.
 
         Raises:
             ValueError: ``measures`` is not of shape (batch_size, :attr:`measure_dim`).
@@ -507,18 +521,16 @@ class CVTArchive(ArchiveBase):
                 distances = np.sum(np.square(distances), axis=2)
                 return np.argmin(distances, axis=1).astype(np.int32)
 
-    def index_of_single(self, measures):
+    def index_of_single(self, measures: ArrayLike) -> Int:
         """Returns the index of the measures for one solution.
 
         See :meth:`index_of`.
 
         Args:
-            measures (array-like): (:attr:`measure_dim`,) array of measures for a single
-                solution.
+            measures: (:attr:`measure_dim`,) array of measures for a single solution.
 
         Returns:
-            int or numpy.integer: Integer index of the measures in the archive's storage
-            arrays.
+            Integer index of the measures in the archive's storage arrays.
 
         Raises:
             ValueError: ``measures`` is not of shape (:attr:`measure_dim`,).
@@ -532,7 +544,13 @@ class CVTArchive(ArchiveBase):
     ## Methods for writing to the archive ##
 
     @staticmethod
-    def _compute_thresholds(indices, objective, cur_threshold, learning_rate, dtype):
+    def _compute_thresholds(
+        indices: np.ndarray,
+        objective: np.ndarray,
+        cur_threshold: np.ndarray,
+        learning_rate: float,
+        dtype: np.dtype,
+    ) -> np.ndarray:
         """Computes new thresholds with the CMA-MAE batch threshold update rule.
 
         If entries in `indices` are duplicated, they receive the same threshold.
@@ -570,7 +588,13 @@ class CVTArchive(ArchiveBase):
 
         return new_threshold
 
-    def add(self, solution, objective, measures, **fields):
+    def add(
+        self,
+        solution: ArrayLike,
+        objective: ArrayLike,
+        measures: ArrayLike,
+        **fields: ArrayLike,
+    ) -> BatchData:
         """Inserts a batch of solutions into the archive.
 
         Each solution is only inserted if it has a higher ``objective`` than the
@@ -593,18 +617,17 @@ class CVTArchive(ArchiveBase):
             solution parameters, objective, and measures for solution ``i``.
 
         Args:
-            solution (array-like): (batch_size, :attr:`solution_dim`) array of solution
-                parameters.
-            objective (array-like): (batch_size,) array with objective function
-                evaluations of the solutions.
-            measures (array-like): (batch_size, :attr:`measure_dim`) array with measure
-                space coordinates of all the solutions.
-            fields (keyword arguments): Additional data for each solution. Each argument
-                should be an array with batch_size as the first dimension.
+            solution: (batch_size, :attr:`solution_dim`) array of solution parameters.
+            objective: (batch_size,) array with objective function evaluations of the
+                solutions.
+            measures: (batch_size, :attr:`measure_dim`) array with measure space
+                coordinates of all the solutions.
+            fields: Additional data for each solution. Each argument should be an array
+                with batch_size as the first dimension.
 
         Returns:
-            dict: Information describing the result of the add operation. The dict
-            contains the following keys:
+            Information describing the result of the add operation. The dict contains
+            the following keys:
 
             - ``"status"`` (:class:`numpy.ndarray` of :class:`numpy.int32`): An array of
               integers that represent the "status" obtained when attempting to insert
@@ -763,7 +786,13 @@ class CVTArchive(ArchiveBase):
 
         return add_info
 
-    def add_single(self, solution, objective, measures, **fields):
+    def add_single(
+        self,
+        solution: ArrayLike,
+        objective: ArrayLike,
+        measures: ArrayLike,
+        **fields: ArrayLike,
+    ) -> SingleData:
         """Inserts a single solution into the archive.
 
         The solution is only inserted if it has a higher ``objective`` than the
@@ -778,15 +807,15 @@ class CVTArchive(ArchiveBase):
             time. For better performance, see :meth:`add`.
 
         Args:
-            solution (array-like): Parameters of the solution.
-            objective (float): Objective function evaluation of the solution.
-            measures (array-like): Coordinates in measure space of the solution.
-            fields (keyword arguments): Additional data for the solution.
+            solution: Parameters of the solution.
+            objective: Objective function evaluation of the solution.
+            measures: Coordinates in measure space of the solution.
+            fields: Additional data for the solution.
 
         Returns:
-            dict: Information describing the result of the add operation. The
-            dict contains ``status`` and ``value`` keys; refer to :meth:`add`
-            for the meaning of status and value.
+            Information describing the result of the add operation. The dict contains
+            ``status`` and ``value`` keys; refer to :meth:`add` for the meaning of
+            status and value.
 
         Raises:
             ValueError: The array arguments do not match their specified shapes.
@@ -891,7 +920,7 @@ class CVTArchive(ArchiveBase):
 
         return add_info
 
-    def clear(self):
+    def clear(self) -> None:
         """Removes all elites in the archive."""
         self._store.clear()
         self._stats_reset()
@@ -899,7 +928,7 @@ class CVTArchive(ArchiveBase):
     ## Methods for reading from the archive ##
     ## Refer to ArchiveBase for documentation of these methods. ##
 
-    def retrieve(self, measures):
+    def retrieve(self, measures: ArrayLike) -> tuple[np.ndarray, BatchData]:
         measures = np.asarray(measures)
         check_batch_shape(measures, "measures", self.measure_dim, "measure_dim")
         check_finite(measures, "measures")
@@ -909,7 +938,7 @@ class CVTArchive(ArchiveBase):
 
         return occupied, data
 
-    def retrieve_single(self, measures):
+    def retrieve_single(self, measures: ArrayLike) -> SingleData:
         measures = np.asarray(measures)
         check_shape(measures, "measures", self.measure_dim, "measure_dim")
         check_finite(measures, "measures")
@@ -918,10 +947,42 @@ class CVTArchive(ArchiveBase):
 
         return occupied[0], {field: arr[0] for field, arr in data.items()}
 
-    def data(self, fields=None, return_type="dict"):
+    @overload
+    def data(
+        self,
+        fields: str,
+        return_type: Literal["dict", "tuple", "pandas"] = "dict",
+    ) -> Array: ...
+
+    @overload
+    def data(
+        self,
+        fields: None | Collection[str] = None,
+        return_type: Literal["dict"] = "dict",
+    ) -> BatchData: ...
+
+    @overload
+    def data(
+        self,
+        fields: None | Collection[str] = None,
+        return_type: Literal["tuple"] = "tuple",
+    ) -> tuple[Array]: ...
+
+    @overload
+    def data(
+        self,
+        fields: None | Collection[str] = None,
+        return_type: Literal["pandas"] = "pandas",
+    ) -> ArchiveDataFrame: ...
+
+    def data(
+        self,
+        fields: None | Collection[str] | str = None,
+        return_type: Literal["dict", "tuple", "pandas"] = "dict",
+    ) -> Array | BatchData | tuple[Array] | ArchiveDataFrame:
         return self._store.data(fields, return_type)
 
-    def sample_elites(self, n):
+    def sample_elites(self, n: Int) -> BatchData:
         if self.empty:
             raise IndexError("No elements in archive.")
 

--- a/ribs/archives/_cvt_archive.py
+++ b/ribs/archives/_cvt_archive.py
@@ -71,9 +71,9 @@ class CVTArchive(ArchiveBase):
         :pr:`38`.
 
     Args:
-        solution_dim (int or tuple of int): Dimensionality of the solution space. Scalar
-            or multi-dimensional solution shapes are allowed by passing an empty tuple
-            or tuple of integers, respectively.
+        solution_dim: Dimensionality of the solution space. Scalar or multi-dimensional
+            solution shapes are allowed by passing an empty tuple or tuple of integers,
+            respectively.
         cells (int): The number of cells to use in the archive, equivalent to the number
             of centroids/areas in the CVT.
         ranges (array-like of (float, float)): Upper and lower bound of each dimension

--- a/ribs/archives/_cvt_archive.py
+++ b/ribs/archives/_cvt_archive.py
@@ -352,18 +352,18 @@ class CVTArchive(ArchiveBase):
         return self._store.capacity
 
     @property
-    def lower_bounds(self):
-        """(measure_dim,) numpy.ndarray: Lower bound of each dimension."""
+    def lower_bounds(self) -> np.ndarray:
+        """(:attr:`measure_dim`,) array listing the lower bound of each dimension."""
         return self._lower_bounds
 
     @property
-    def upper_bounds(self):
-        """(measure_dim,) numpy.ndarray: Upper bound of each dimension."""
+    def upper_bounds(self) -> np.ndarray:
+        """(:attr:`measure_dim`,) array listing the upper bound of each dimension."""
         return self._upper_bounds
 
     @property
-    def interval_size(self):
-        """(measure_dim,) numpy.ndarray: The size of each dim (upper_bounds - lower_bounds)."""
+    def interval_size(self) -> np.ndarray:
+        """(:attr:`measure_dim`,) array listing the size of each dim (upper_bounds - lower_bounds)."""
         return self._interval_size
 
     @property

--- a/ribs/archives/_cvt_archive.py
+++ b/ribs/archives/_cvt_archive.py
@@ -938,7 +938,7 @@ class CVTArchive(ArchiveBase):
 
         return occupied, data
 
-    def retrieve_single(self, measures: ArrayLike) -> SingleData:
+    def retrieve_single(self, measures: ArrayLike) -> tuple[bool, SingleData]:
         measures = np.asarray(measures)
         check_shape(measures, "measures", self.measure_dim, "measure_dim")
         check_finite(measures, "measures")

--- a/ribs/archives/_grid_archive.py
+++ b/ribs/archives/_grid_archive.py
@@ -866,7 +866,7 @@ class GridArchive(ArchiveBase):
 
         return occupied, data
 
-    def retrieve_single(self, measures: ArrayLike) -> SingleData:
+    def retrieve_single(self, measures: ArrayLike) -> tuple[bool, SingleData]:
         measures = np.asarray(measures)
         check_shape(measures, "measures", self.measure_dim, "measure_dim")
         check_finite(measures, "measures")

--- a/ribs/archives/_grid_archive.py
+++ b/ribs/archives/_grid_archive.py
@@ -1,6 +1,12 @@
 """Contains the GridArchive."""
 
+from __future__ import annotations
+
+from collections.abc import Iterator, Sequence
+from typing import Literal, Type
+
 import numpy as np
+from numpy.typing import ArrayLike, DTypeLike
 from numpy_groupies import aggregate_nb as aggregate
 
 from ribs._utils import (
@@ -12,6 +18,7 @@ from ribs._utils import (
     validate_single,
 )
 from ribs.archives._archive_base import ArchiveBase
+from ribs.archives._archive_data_frame import ArchiveDataFrame
 from ribs.archives._archive_stats import ArchiveStats
 from ribs.archives._array_store import ArrayStore
 from ribs.archives._utils import (
@@ -19,6 +26,7 @@ from ribs.archives._utils import (
     parse_dtype,
     validate_cma_mae_settings,
 )
+from ribs.typing import BatchData, SingleData
 
 
 class GridArchive(ArchiveBase):
@@ -41,46 +49,45 @@ class GridArchive(ArchiveBase):
     while the integer ``index`` uniquely identifies each cell.
 
     Args:
-        solution_dim (int or tuple of int): Dimensionality of the solution space. Scalar
-            or multi-dimensional solution shapes are allowed by passing an empty tuple
-            or tuple of integers, respectively.
-        dims (array-like of int): Number of cells in each dimension of the measure
-            space, e.g. ``[20, 30, 40]`` indicates there should be 3 dimensions with 20,
-            30, and 40 cells. (The number of dimensions is implicitly defined in the
-            length of this argument).
-        ranges (array-like of (float, float)): Upper and lower bound of each dimension
-            of the measure space, e.g. ``[(-1, 1), (-2, 2)]`` indicates the first
-            dimension should have bounds :math:`[-1,1]` (inclusive), and the second
-            dimension should have bounds :math:`[-2,2]` (inclusive). ``ranges`` should
-            be the same length as ``dims``.
-        epsilon (float): Due to floating point precision errors, a small epsilon is
-            added when computing the archive indices in the :meth:`index_of` method --
-            refer to the implementation `here
+        solution_dim: Dimensionality of the solution space. Scalar or multi-dimensional
+            solution shapes are allowed by passing an empty tuple or tuple of integers,
+            respectively.
+        dims: Number of cells in each dimension of the measure space, e.g. ``[20, 30,
+            40]`` indicates there should be 3 dimensions with 20, 30, and 40 cells. (The
+            number of dimensions is implicitly defined in the length of this argument).
+        ranges: Upper and lower bound of each dimension of the measure space, e.g.
+            ``[(-1, 1), (-2, 2)]`` indicates the first dimension should have bounds
+            :math:`[-1,1]` (inclusive), and the second dimension should have bounds
+            :math:`[-2,2]` (inclusive). ``ranges`` should be the same length as
+            ``dims``.
+        learning_rate: The learning rate for threshold updates. Defaults to 1.0.
+        threshold_min: The initial threshold value for all the cells.
+        epsilon: Due to floating point precision errors, a small epsilon is added when
+            computing the archive indices in the :meth:`index_of` method -- refer to the
+            implementation `here
             <../_modules/ribs/archives/_grid_archive.html#GridArchive.index_of>`_. Pass
             this parameter to configure that epsilon.
-        learning_rate (float): The learning rate for threshold updates. Defaults to 1.0.
-        threshold_min (float): The initial threshold value for all the cells.
-        qd_score_offset (float): Archives often contain negative objective values, and
-            if the QD score were to be computed with these negative objectives, the
-            algorithm would be penalized for adding new cells with negative objectives.
-            Thus, a standard practice is to normalize all the objectives so that they
-            are non-negative by introducing an offset. This QD score offset will be
+        qd_score_offset: Archives often contain negative objective values, and if the QD
+            score were to be computed with these negative objectives, the algorithm
+            would be penalized for adding new cells with negative objectives. Thus, a
+            standard practice is to normalize all the objectives so that they are
+            non-negative by introducing an offset. This QD score offset will be
             *subtracted* from all objectives in the archive, e.g., if your objectives go
             as low as -300, pass in -300 so that each objective will be transformed as
             ``objective - (-300)``.
-        seed (int): Value to seed the random number generator. Set to None to avoid a
-            fixed seed.
-        dtype (str or data-type or dict): Data type of the solutions, objectives, and
-            measures. This can be ``"f"`` / ``np.float32``, ``"d"`` / ``np.float64``, or
-            a dict specifying separate dtypes, of the form ``{"solution": <dtype>,
-            "objective": <dtype>, "measures": <dtype>}``.
-        extra_fields (dict): Description of extra fields of data that is stored next to
-            elite data like solutions and objectives. The description is a dict mapping
-            from a field name (str) to a tuple of ``(shape, dtype)``. For instance,
-            ``{"foo": ((), np.float32), "bar": ((10,), np.float32)}`` will create a
-            "foo" field that contains scalar values and a "bar" field that contains 10D
-            values. Note that field names must be valid Python identifiers, and names
-            already used in the archive are not allowed.
+        seed: Value to seed the random number generator. Set to None to avoid a fixed
+            seed.
+        dtype: Data type of the solutions, objectives, and measures. This can be ``"f"``
+            / ``np.float32``, ``"d"`` / ``np.float64``, or a dict specifying separate
+            dtypes, of the form ``{"solution": <dtype>, "objective": <dtype>,
+            "measures": <dtype>}``.
+        extra_fields: Description of extra fields of data that are stored next to elite
+            data like solutions and objectives. The description is a dict mapping from a
+            field name (str) to a tuple of ``(shape, dtype)``. For instance, ``{"foo":
+            ((), np.float32), "bar": ((10,), np.float32)}`` will create a "foo" field
+            that contains scalar values and a "bar" field that contains 10D values. Note
+            that field names must be valid Python identifiers, and names already used in
+            the archive are not allowed.
 
     Raises:
         ValueError: Invalid values for learning_rate and threshold_min.
@@ -91,17 +98,20 @@ class GridArchive(ArchiveBase):
     def __init__(
         self,
         *,
-        solution_dim,
-        dims,
-        ranges,
-        learning_rate=None,
-        threshold_min=-np.inf,
-        epsilon=1e-6,
-        qd_score_offset=0.0,
-        seed=None,
-        dtype=np.float64,
-        extra_fields=None,
-    ):
+        solution_dim: int | tuple[int],
+        dims: Sequence[int],
+        ranges: Sequence[tuple[float, float]],
+        learning_rate: float | None = None,
+        threshold_min: float = -np.inf,
+        epsilon: float = 1e-6,
+        qd_score_offset: float = 0.0,
+        seed: int | None = None,
+        dtype: Literal["f", "d"]
+        | Type[np.float32]
+        | Type[np.float64]
+        | dict[str, DTypeLike] = np.float64,
+        extra_fields: dict[str, tuple[int | tuple[int], DTypeLike]] | None = None,
+    ) -> None:
         self._rng = np.random.default_rng(seed)
         self._dims = np.array(dims, dtype=np.int32)
 
@@ -163,7 +173,9 @@ class GridArchive(ArchiveBase):
         self._stats_reset()
 
     @staticmethod
-    def _compute_boundaries(dims, lower_bounds, upper_bounds):
+    def _compute_boundaries(
+        dims: np.ndarray, lower_bounds: np.ndarray, upper_bounds: np.ndarray
+    ) -> list[np.ndarray]:
         """Computes grid cell boundaries of the archive."""
         boundaries = []
         for dim, lower_bound, upper_bound in zip(dims, lower_bounds, upper_bounds):
@@ -173,27 +185,27 @@ class GridArchive(ArchiveBase):
     ## Properties inherited from ArchiveBase ##
 
     @property
-    def field_list(self):
+    def field_list(self) -> list[str]:
         return self._store.field_list_with_index
 
     @property
-    def dtypes(self):
+    def dtypes(self) -> dict[str, np.dtype]:
         return self._store.dtypes_with_index
 
     @property
-    def stats(self):
+    def stats(self) -> ArchiveStats:
         return self._stats
 
     @property
-    def empty(self):
+    def empty(self) -> bool:
         return len(self._store) == 0
 
     ## Properties that are not in ArchiveBase ##
     ## Roughly ordered by the parameter list in the constructor. ##
 
     @property
-    def best_elite(self):
-        """dict: The elite with the highest objective in the archive.
+    def best_elite(self) -> SingleData:
+        """The elite with the highest objective in the archive.
 
         None if there are no elites in the archive.
 
@@ -214,33 +226,33 @@ class GridArchive(ArchiveBase):
         return self._best_elite
 
     @property
-    def dims(self):
-        """(measure_dim,) numpy.ndarray: Number of cells in each dimension."""
+    def dims(self) -> np.ndarray:
+        """(:attr:`measure_dim`,) array listing the number of cells in each dimension."""
         return self._dims
 
     @property
-    def cells(self):
-        """int: Total number of cells in the archive."""
+    def cells(self) -> int:
+        """Total number of cells in the archive."""
         return self._store.capacity
 
     @property
-    def lower_bounds(self):
-        """(measure_dim,) numpy.ndarray: Lower bound of each dimension."""
+    def lower_bounds(self) -> np.ndarray:
+        """(:attr:`measure_dim`,) array listing the lower bound of each dimension."""
         return self._lower_bounds
 
     @property
-    def upper_bounds(self):
-        """(measure_dim,) numpy.ndarray: Upper bound of each dimension."""
+    def upper_bounds(self) -> np.ndarray:
+        """(:attr:`measure_dim`,) array listing the upper bound of each dimension."""
         return self._upper_bounds
 
     @property
-    def interval_size(self):
-        """(measure_dim,) numpy.ndarray: The size of each dim (upper_bounds - lower_bounds)."""
+    def interval_size(self) -> np.ndarray:
+        """(:attr:`measure_dim`,) array listing the size of each dim (upper_bounds - lower_bounds)."""
         return self._interval_size
 
     @property
-    def boundaries(self):
-        """list of numpy.ndarray: The boundaries of the cells in each dimension.
+    def boundaries(self) -> list[np.ndarray]:
+        """The boundaries of the cells in each dimension.
 
         Entry ``i`` in this list is an array that contains the boundaries of the cells
         in dimension ``i``. The array contains ``self.dims[i] + 1`` entries laid out
@@ -253,43 +265,40 @@ class GridArchive(ArchiveBase):
         bounds of cell ``j`` in dimension ``i``. To access the lower bounds of all the
         cells in dimension ``i``, use ``boundaries[i][:-1]``, and to access all the
         upper bounds, use ``boundaries[i][1:]``.
-        """  # noqa: D403
+        """
         return self._boundaries
 
     @property
-    def epsilon(self):
-        """dtypes["measures"]: Epsilon for computing archive indices.
-
-        Refer to the documentation for this class.
-        """
+    def epsilon(self) -> float:
+        """Epsilon for computing archive indices."""
         return self._epsilon
 
     @property
-    def learning_rate(self):
-        """float: The learning rate for threshold updates."""
+    def learning_rate(self) -> float:
+        """The learning rate for threshold updates."""
         return self._learning_rate
 
     @property
-    def threshold_min(self):
-        """float: The initial threshold value for all the cells."""
+    def threshold_min(self) -> float:
+        """The initial threshold value for all the cells."""
         return self._threshold_min
 
     @property
-    def qd_score_offset(self):
-        """float: Subtracted from objective values when computing the QD score."""
+    def qd_score_offset(self) -> float:
+        """Subtracted from objective values when computing the QD score."""
         return self._qd_score_offset
 
     ## dunder methods ##
 
-    def __len__(self):
+    def __len__(self) -> int:
         return len(self._store)
 
-    def __iter__(self):
+    def __iter__(self) -> Iterator[SingleData]:
         return iter(self._store)
 
     ## Utilities ##
 
-    def _stats_reset(self):
+    def _stats_reset(self) -> None:
         """Resets the archive stats."""
         self._best_elite = None
         self._objective_sum = np.asarray(0.0, dtype=self.dtypes["objective"])
@@ -302,8 +311,8 @@ class GridArchive(ArchiveBase):
             obj_mean=None,
         )
 
-    def _stats_update(self, new_objective_sum, new_best_index):
-        """Updates archive statistics.
+    def _stats_update(self, new_objective_sum: float, new_best_index: float) -> None:
+        """Updates statistics.
 
         Update is based on a new sum of objective values (new_objective_sum) and the
         index of a potential new best elite (new_best_index).
@@ -339,7 +348,7 @@ class GridArchive(ArchiveBase):
             ),
         )
 
-    def index_of(self, measures):
+    def index_of(self, measures: ArrayLike) -> np.ndarray:
         """Returns archive indices for the given batch of measures.
 
         First, values are clipped to the bounds of the measure space. Then, the values
@@ -361,12 +370,12 @@ class GridArchive(ArchiveBase):
             upper = archive.boundaries[0][idx[0] + 1]
 
         Args:
-            measures (array-like): (batch_size, :attr:`measure_dim`) array of
-                coordinates in measure space.
+            measures: (batch_size, :attr:`measure_dim`) array of coordinates in measure
+                space.
 
         Returns:
-            numpy.ndarray: (batch_size,) array of integer indices representing the
-            flattened grid coordinates.
+            (batch_size,) array of integer indices representing the flattened grid
+            coordinates.
 
         Raises:
             ValueError: ``measures`` is not of shape (batch_size, :attr:`measure_dim`).
@@ -389,18 +398,16 @@ class GridArchive(ArchiveBase):
 
         return self.grid_to_int_index(grid_indices)
 
-    def index_of_single(self, measures):
+    def index_of_single(self, measures: ArrayLike) -> int:
         """Returns the index of the measures for one solution.
 
         See :meth:`index_of`.
 
         Args:
-            measures (array-like): (:attr:`measure_dim`,) array of measures for a single
-                solution.
+            measures: (:attr:`measure_dim`,) array of measures for a single solution.
 
         Returns:
-            int or numpy.integer: Integer index of the measures in the archive's storage
-            arrays.
+            Integer index of the measures in the archive's storage arrays.
 
         Raises:
             ValueError: ``measures`` is not of shape (:attr:`measure_dim`,).
@@ -411,17 +418,17 @@ class GridArchive(ArchiveBase):
         check_finite(measures, "measures")
         return self.index_of(measures[None])[0]
 
-    def grid_to_int_index(self, grid_indices):
+    def grid_to_int_index(self, grid_indices: ArrayLike) -> np.ndarray:
         """Converts a batch of grid indices into a batch of integer indices.
 
         Refer to :meth:`index_of` for more info.
 
         Args:
-            grid_indices (array-like): (batch_size, :attr:`measure_dim`) array of
-                indices in the archive grid.
+            grid_indices: (batch_size, :attr:`measure_dim`) array of indices in the
+                archive grid.
 
         Returns:
-            numpy.ndarray: (batch_size,) array of integer indices.
+            (batch_size,) array of integer indices.
 
         Raises:
             ValueError: ``grid_indices`` is not of shape (batch_size,
@@ -432,18 +439,17 @@ class GridArchive(ArchiveBase):
 
         return np.ravel_multi_index(grid_indices.T, self._dims).astype(np.int32)
 
-    def int_to_grid_index(self, int_indices):
+    def int_to_grid_index(self, int_indices: ArrayLike) -> np.ndarray:
         """Converts a batch of indices into indices in the archive's grid.
 
         Refer to :meth:`index_of` for more info.
 
         Args:
-            int_indices (array-like): (batch_size,) array of integer indices such as
-                those output by :meth:`index_of`.
+            int_indices: (batch_size,) array of integer indices such as those output by
+                :meth:`index_of`.
 
         Returns:
-            numpy.ndarray: (batch_size, :attr:`measure_dim`) array of indices in the
-            archive grid.
+            (batch_size, :attr:`measure_dim`) array of indices in the archive grid.
 
         Raises:
             ValueError: ``int_indices`` is not of shape (batch_size,).
@@ -461,7 +467,13 @@ class GridArchive(ArchiveBase):
     ## Methods for writing to the archive ##
 
     @staticmethod
-    def _compute_thresholds(indices, objective, cur_threshold, learning_rate, dtype):
+    def _compute_thresholds(
+        indices: np.ndarray,
+        objective: np.ndarray,
+        cur_threshold: np.ndarray,
+        learning_rate: float,
+        dtype: np.dtype,
+    ) -> np.ndarray:
         """Computes new thresholds with the CMA-MAE batch threshold update rule.
 
         If entries in `indices` are duplicated, they receive the same threshold.
@@ -499,7 +511,13 @@ class GridArchive(ArchiveBase):
 
         return new_threshold
 
-    def add(self, solution, objective, measures, **fields):
+    def add(
+        self,
+        solution: ArrayLike,
+        objective: ArrayLike,
+        measures: ArrayLike,
+        **fields: ArrayLike,
+    ) -> BatchData:
         """Inserts a batch of solutions into the archive.
 
         Each solution is only inserted if it has a higher ``objective`` than the
@@ -522,18 +540,17 @@ class GridArchive(ArchiveBase):
             solution parameters, objective, and measures for solution ``i``.
 
         Args:
-            solution (array-like): (batch_size, :attr:`solution_dim`) array of solution
-                parameters.
-            objective (array-like): (batch_size,) array with objective function
-                evaluations of the solutions.
-            measures (array-like): (batch_size, :attr:`measure_dim`) array with measure
-                space coordinates of all the solutions.
-            fields (keyword arguments): Additional data for each solution. Each argument
-                should be an array with batch_size as the first dimension.
+            solution: (batch_size, :attr:`solution_dim`) array of solution parameters.
+            objective: (batch_size,) array with objective function evaluations of the
+                solutions.
+            measures: (batch_size, :attr:`measure_dim`) array with measure space
+                coordinates of all the solutions.
+            fields: Additional data for each solution. Each argument should be an array
+                with batch_size as the first dimension.
 
         Returns:
-            dict: Information describing the result of the add operation. The dict
-            contains the following keys:
+            Information describing the result of the add operation. The dict contains
+            the following keys:
 
             - ``"status"`` (:class:`numpy.ndarray` of :class:`numpy.int32`): An array of
               integers that represent the "status" obtained when attempting to insert
@@ -692,7 +709,13 @@ class GridArchive(ArchiveBase):
 
         return add_info
 
-    def add_single(self, solution, objective, measures, **fields):
+    def add_single(
+        self,
+        solution: ArrayLike,
+        objective: ArrayLike,
+        measures: ArrayLike,
+        **fields: ArrayLike,
+    ) -> SingleData:
         """Inserts a single solution into the archive.
 
         The solution is only inserted if it has a higher ``objective`` than the
@@ -707,15 +730,15 @@ class GridArchive(ArchiveBase):
             time. For better performance, see :meth:`add`.
 
         Args:
-            solution (array-like): Parameters of the solution.
-            objective (float): Objective function evaluation of the solution.
-            measures (array-like): Coordinates in measure space of the solution.
-            fields (keyword arguments): Additional data for the solution.
+            solution: Parameters of the solution.
+            objective: Objective function evaluation of the solution.
+            measures: Coordinates in measure space of the solution.
+            fields: Additional data for the solution.
 
         Returns:
-            dict: Information describing the result of the add operation. The
-            dict contains ``status`` and ``value`` keys; refer to :meth:`add`
-            for the meaning of status and value.
+            Information describing the result of the add operation. The dict contains
+            ``status`` and ``value`` keys; refer to :meth:`add` for the meaning of
+            status and value.
 
         Raises:
             ValueError: The array arguments do not match their specified shapes.
@@ -820,7 +843,7 @@ class GridArchive(ArchiveBase):
 
         return add_info
 
-    def clear(self):
+    def clear(self) -> None:
         """Removes all elites in the archive."""
         self._store.clear()
         self._stats_reset()
@@ -828,7 +851,7 @@ class GridArchive(ArchiveBase):
     ## Methods for reading from the archive ##
     ## Refer to ArchiveBase for documentation of these methods. ##
 
-    def retrieve(self, measures):
+    def retrieve(self, measures: ArrayLike) -> tuple[np.ndarray, BatchData]:
         measures = np.asarray(measures)
         check_batch_shape(measures, "measures", self.measure_dim, "measure_dim")
         check_finite(measures, "measures")
@@ -838,7 +861,7 @@ class GridArchive(ArchiveBase):
 
         return occupied, data
 
-    def retrieve_single(self, measures):
+    def retrieve_single(self, measures: ArrayLike) -> SingleData:
         measures = np.asarray(measures)
         check_shape(measures, "measures", self.measure_dim, "measure_dim")
         check_finite(measures, "measures")
@@ -847,10 +870,14 @@ class GridArchive(ArchiveBase):
 
         return occupied[0], {field: arr[0] for field, arr in data.items()}
 
-    def data(self, fields=None, return_type="dict"):
+    def data(
+        self,
+        fields: None | Sequence[str] | str = None,
+        return_type: Literal["dict", "tuple", "pandas"] = "dict",
+    ) -> np.ndarray | BatchData | tuple[np.ndarray] | ArchiveDataFrame:
         return self._store.data(fields, return_type)
 
-    def sample_elites(self, n):
+    def sample_elites(self, n: int) -> BatchData:
         if self.empty:
             raise IndexError("No elements in archive.")
 
@@ -861,7 +888,7 @@ class GridArchive(ArchiveBase):
 
     ## retessellate ##
 
-    def retessellate(self, new_dims):
+    def retessellate(self, new_dims: Sequence[int]) -> None:
         """Updates the resolution of this archive to the given dimensions.
 
         Upon resizing the archive, this method re-inserts the solutions that are
@@ -878,10 +905,10 @@ class GridArchive(ArchiveBase):
         determined after retessellating.
 
         Args:
-            new_dims (array-like of int):  Number of cells in each dimension of the
-                measure space, e.g., ``[20, 30, 40]`` indicates there should be 3
-                dimensions with 20, 30, and 40 cells. The format is identical to the
-                ``dims`` argument in ``__init__``.
+            new_dims:  Number of cells in each dimension of the measure space, e.g.,
+                ``[20, 30, 40]`` indicates there should be 3 dimensions with 20, 30, and
+                40 cells. The format is identical to the ``dims`` argument in
+                ``__init__``.
 
         Raises:
             ValueError: Attempted to retessellate an archive with learning rate not
@@ -909,5 +936,4 @@ class GridArchive(ArchiveBase):
             self._dims, self._lower_bounds, self._upper_bounds
         )
         self._store = ArrayStore(self._store.field_desc, capacity=np.prod(self._dims))
-
         self.add(**cur_data)

--- a/ribs/archives/_grid_archive.py
+++ b/ribs/archives/_grid_archive.py
@@ -106,7 +106,7 @@ class GridArchive(ArchiveBase):
     def __init__(
         self,
         *,
-        solution_dim: Int | tuple[Int],
+        solution_dim: Int | tuple[Int, ...],
         dims: Collection[Int],
         ranges: Collection[tuple[Float, Float]],
         learning_rate: Float | None = None,

--- a/ribs/archives/_grid_archive.py
+++ b/ribs/archives/_grid_archive.py
@@ -6,7 +6,7 @@ from collections.abc import Collection, Iterator
 from typing import Literal, overload
 
 import numpy as np
-from numpy.typing import ArrayLike, DTypeLike
+from numpy.typing import ArrayLike
 from numpy_groupies import aggregate_nb as aggregate
 
 from ribs._utils import (
@@ -26,7 +26,15 @@ from ribs.archives._utils import (
     parse_dtype,
     validate_cma_mae_settings,
 )
-from ribs.typing import Array, BatchData, FieldDesc, Float, Int, SingleData
+from ribs.typing import (
+    ArchiveDType,
+    Array,
+    BatchData,
+    FieldDesc,
+    Float,
+    Int,
+    SingleData,
+)
 
 
 class GridArchive(ArchiveBase):
@@ -106,9 +114,7 @@ class GridArchive(ArchiveBase):
         epsilon: Float = 1e-6,
         qd_score_offset: Float = 0.0,
         seed: Int | None = None,
-        dtype: Literal["f", "d"]
-        | type[np.float32 | np.float64]
-        | dict[str, DTypeLike] = np.float64,
+        dtype: ArchiveDType = np.float64,
         extra_fields: FieldDesc | None = None,
     ) -> None:
         self._rng = np.random.default_rng(seed)

--- a/ribs/archives/_grid_archive.py
+++ b/ribs/archives/_grid_archive.py
@@ -236,7 +236,7 @@ class GridArchive(ArchiveBase):
         return self._dims
 
     @property
-    def cells(self) -> int:
+    def cells(self) -> Int:
         """Total number of cells in the archive."""
         return self._store.capacity
 

--- a/ribs/archives/_proximity_archive.py
+++ b/ribs/archives/_proximity_archive.py
@@ -1,6 +1,12 @@
 """Contains the ProximityArchive."""
 
+from __future__ import annotations
+
+from collections.abc import Collection, Iterator
+from typing import Literal, overload
+
 import numpy as np
+from numpy.typing import ArrayLike
 from numpy_groupies import aggregate_nb as aggregate
 from scipy.spatial import cKDTree  # ty: ignore[unresolved-import]
 
@@ -12,9 +18,19 @@ from ribs._utils import (
     validate_single,
 )
 from ribs.archives._archive_base import ArchiveBase
+from ribs.archives._archive_data_frame import ArchiveDataFrame
 from ribs.archives._archive_stats import ArchiveStats
 from ribs.archives._array_store import ArrayStore
 from ribs.archives._utils import fill_sentinel_values, parse_dtype
+from ribs.typing import (
+    ArchiveDType,
+    Array,
+    BatchData,
+    FieldDesc,
+    Float,
+    Int,
+    SingleData,
+)
 
 
 class ProximityArchive(ArchiveBase):
@@ -66,49 +82,49 @@ class ProximityArchive(ArchiveBase):
         solution_dim: Dimensionality of the solution space. Scalar or multi-dimensional
             solution shapes are allowed by passing an empty tuple or tuple of integers,
             respectively.
-        measure_dim (int): Dimensionality of the measure space.
-        k_neighbors (int): The maximum number of nearest neighbors for computing novelty
+        measure_dim: Dimensionality of the measure space.
+        k_neighbors: The maximum number of nearest neighbors for computing novelty
             (`maximum` here is indicated since there may be fewer than ``k_neighbors``
             solutions in the archive).
-        novelty_threshold (float): The level of novelty required to add a solution to
-            the archive.
-        local_competition (bool): Whether to turn on local competition behavior. If
-            turned on, the archive will require objectives to be passed in during
-            :meth:`add`. Furthermore, the ``add_info`` returned by :meth:`add` will
-            include local competition information. Finally, solutions can be replaced in
-            the archive. Specifically, if a candidate solution's novelty is below the
-            novelty threshold, its objective will be compared to that of its nearest
-            neighbor. If the candidate's objective is higher, it will replace the
-            nearest neighbor.
-        initial_capacity (int): Since this archive is unstructured, it does not have a
+        novelty_threshold: The level of novelty required to add a solution to the
+            archive.
+        local_competition: Whether to turn on local competition behavior. If turned on,
+            the archive will require objectives to be passed in during :meth:`add`.
+            Furthermore, the ``add_info`` returned by :meth:`add` will include local
+            competition information. Finally, solutions can be replaced in the archive.
+            Specifically, if a candidate solution's novelty is below the novelty
+            threshold, its objective will be compared to that of its nearest neighbor.
+            If the candidate's objective is higher, it will replace the nearest
+            neighbor.
+        initial_capacity: Since this archive is unstructured, it does not have a
             fixed size, and it will grow as solutions are added. In the implementation,
             we store solutions in fixed-size arrays, and every time the capacity of
             these arrays is reached, we double their sizes (similar to the vector in
             C++). This parameter determines the initial capacity of the archive's
             arrays. It may be useful when it is known in advance how large the archive
             will grow.
-        qd_score_offset (float): Archives often contain negative objective values, and
-            if the QD score were to be computed with these negative objectives, the
-            algorithm would be penalized for adding new cells with negative objectives.
-            Thus, a standard practice is to normalize all the objectives so that they
-            are non-negative by introducing an offset. This QD score offset will be
+        qd_score_offset: Archives often contain negative objective values, and if the QD
+            score were to be computed with these negative objectives, the algorithm
+            would be penalized for adding new cells with negative objectives. Thus, a
+            standard practice is to normalize all the objectives so that they are
+            non-negative by introducing an offset. This QD score offset will be
             *subtracted* from all objectives in the archive, e.g., if your objectives go
             as low as -300, pass in -300 so that each objective will be transformed as
             ``objective - (-300)``.
-        seed (int): Value to seed the random number generator. Set to None to avoid a
-            fixed seed.
-        dtype (str or data-type or dict): Data type of the solutions, objectives, and
-            measures. This can be ``"f"`` / ``np.float32``, ``"d"`` / ``np.float64``, or
-            a dict specifying separate dtypes, of the form ``{"solution": <dtype>,
-            "objective": <dtype>, "measures": <dtype>}``.
-        extra_fields (dict): Description of extra fields of data that is stored next to
-            elite data like solutions and objectives. The description is a dict mapping
-            from a field name (str) to a tuple of ``(shape, dtype)``. For instance,
-            ``{"foo": ((), np.float32), "bar": ((10,), np.float32)}`` will create a
-            "foo" field that contains scalar values and a "bar" field that contains 10D
-            values. Note that field names must be valid Python identifiers, and names
-            already used in the archive are not allowed.
-        ckdtree_kwargs (dict): When computing nearest neighbors, we construct a
+        seed: Value to seed the random number generator. Set to None to avoid a fixed
+            seed.
+        dtype: Data type of the solutions, objectives, and measures. This can be ``"f"``
+            / ``np.float32``, ``"d"`` / ``np.float64``, or a dict specifying separate
+            dtypes, of the form ``{"solution": <dtype>, "objective": <dtype>,
+            "measures": <dtype>}``.
+        extra_fields: Description of extra fields of data that are stored next to elite
+            data like solutions and objectives. The description is a dict mapping from a
+            field name (str) to a tuple of ``(shape, dtype)``. For instance, ``{"foo":
+            ((), np.float32), "bar": ((10,), np.float32)}`` will create a "foo" field
+            that contains scalar values and a "bar" field that contains 10D values. Note
+            that field names must be valid Python identifiers, and names already used in
+            the archive are not allowed.
+        ckdtree_kwargs: When computing nearest neighbors, we construct a
             :class:`~scipy.spatial.cKDTree`. This parameter will pass additional kwargs
             when constructing the tree. By default, we do not pass in any kwargs.
 
@@ -119,18 +135,18 @@ class ProximityArchive(ArchiveBase):
     def __init__(
         self,
         *,
-        solution_dim,
-        measure_dim,
-        k_neighbors,
-        novelty_threshold,
-        local_competition=False,
-        initial_capacity=128,
-        qd_score_offset=0.0,
-        seed=None,
-        dtype=np.float64,
-        extra_fields=None,
-        ckdtree_kwargs=None,
-    ):
+        solution_dim: Int | tuple[Int, ...],
+        measure_dim: Int,
+        k_neighbors: Int,
+        novelty_threshold: Float,
+        local_competition: bool = False,
+        initial_capacity: Int = 128,
+        qd_score_offset: Float = 0.0,
+        seed: Int | None = None,
+        dtype: ArchiveDType = np.float64,
+        extra_fields: FieldDesc | None = None,
+        ckdtree_kwargs: dict | None = None,
+    ) -> None:
         self._rng = np.random.default_rng(seed)
 
         ArchiveBase.__init__(
@@ -188,58 +204,58 @@ class ProximityArchive(ArchiveBase):
     ## Properties inherited from ArchiveBase ##
 
     @property
-    def field_list(self):
+    def field_list(self) -> list[str]:
         return self._store.field_list_with_index
 
     @property
-    def dtypes(self):
+    def dtypes(self) -> dict[str, np.dtype]:
         return self._store.dtypes_with_index
 
     @property
-    def stats(self):
+    def stats(self) -> ArchiveStats:
         return self._stats
 
     @property
-    def empty(self):
+    def empty(self) -> bool:
         return len(self._store) == 0
 
     ## Properties that are not in ArchiveBase ##
     ## Roughly ordered by the parameter list in the constructor. ##
 
     @property
-    def best_elite(self):
-        """dict: The elite with the highest objective in the archive.
+    def best_elite(self) -> SingleData:
+        """The elite with the highest objective in the archive.
 
         None if there are no elites in the archive.
         """
         return self._best_elite
 
     @property
-    def k_neighbors(self):
-        """int: The number of nearest neighbors for computing novelty."""
+    def k_neighbors(self) -> int:
+        """The number of nearest neighbors for computing novelty."""
         return self._k_neighbors
 
     @property
-    def novelty_threshold(self):
-        """dtypes["measures"]: The degree of novelty required add a solution to the archive."""
+    def novelty_threshold(self) -> float:
+        """The degree of novelty required add a solution to the archive."""
         return self._novelty_threshold
 
     @property
-    def local_competition(self):
-        """bool: Whether local competition behavior is turned on."""
+    def local_competition(self) -> bool:
+        """Whether local competition behavior is turned on."""
         return self._local_competition
 
     @property
-    def capacity(self):
-        """int: Number of solutions that can currently be stored in this archive.
+    def capacity(self) -> int:
+        """Number of solutions that can currently be stored in this archive.
 
         The capacity doubles every time the archive fills up.
         """
         return self._store.capacity
 
     @property
-    def cells(self):
-        """int: Included for API compatibility; equivalent to :meth:`__len__`.
+    def cells(self) -> int:
+        """Included for API compatibility; equivalent to :meth:`__len__`.
 
         Strictly speaking, this archive does not have "cells" since it does not have a
         tessellation like other archives. However, for API compatibility, we set the
@@ -248,21 +264,21 @@ class ProximityArchive(ArchiveBase):
         return len(self)
 
     @property
-    def qd_score_offset(self):
-        """float: Subtracted from objective values when computing the QD score."""
+    def qd_score_offset(self) -> float:
+        """Subtracted from objective values when computing the QD score."""
         return self._qd_score_offset
 
     ## dunder methods ##
 
-    def __len__(self):
+    def __len__(self) -> int:
         return len(self._store)
 
-    def __iter__(self):
+    def __iter__(self) -> Iterator[SingleData]:
         return iter(self._store)
 
     ## Utilities ##
 
-    def _stats_reset(self):
+    def _stats_reset(self) -> None:
         """Resets the archive stats."""
         self._best_elite = None
         self._objective_sum = np.asarray(0.0, dtype=self.dtypes["objective"])
@@ -275,8 +291,8 @@ class ProximityArchive(ArchiveBase):
             obj_mean=None,
         )
 
-    def _stats_update(self, new_objective_sum, new_best_index):
-        """Updates archive statistics.
+    def _stats_update(self, new_objective_sum: Float, new_best_index: Float) -> None:
+        """Updates statistics.
 
         Update is based on a new sum of objective values (new_objective_sum) and the
         index of a potential new best elite (new_best_index).
@@ -312,7 +328,7 @@ class ProximityArchive(ArchiveBase):
             ),
         )
 
-    def index_of(self, measures) -> np.ndarray:
+    def index_of(self, measures: ArrayLike) -> np.ndarray:
         """Returns the index of the closest solution to the given measures.
 
         Unlike the structured archives like :class:`~ribs.archives.GridArchive`, this
@@ -324,12 +340,12 @@ class ProximityArchive(ArchiveBase):
         measure to each measure passed into that method.
 
         Args:
-            measures (array-like): (batch_size, :attr:`measure_dim`) array of
-                coordinates in measure space.
+            measures: (batch_size, :attr:`measure_dim`) array of coordinates in measure
+                space.
 
         Returns:
-            numpy.ndarray: (batch_size,) array of integer indices representing the
-            location of the solution in the archive.
+            (batch_size,) array of integer indices representing the location of the
+            solution in the archive.
 
         Raises:
             RuntimeError: There were no entries in the archive.
@@ -351,18 +367,16 @@ class ProximityArchive(ArchiveBase):
         _, indices = self._cur_kd_tree.query(measures)
         return indices.astype(np.int32)
 
-    def index_of_single(self, measures):
+    def index_of_single(self, measures: ArrayLike) -> Int:
         """Returns the index of the measures for one solution.
 
         See :meth:`index_of`.
 
         Args:
-            measures (array-like): (:attr:`measure_dim`,) array of measures for a single
-                solution.
+            measures: (:attr:`measure_dim`,) array of measures for a single solution.
 
         Returns:
-            int or numpy.integer: Integer index of the measures in the archive's storage
-            arrays.
+            Integer index of the measures in the archive's storage arrays.
 
         Raises:
             ValueError: ``measures`` is not of shape (:attr:`measure_dim`,).
@@ -373,25 +387,26 @@ class ProximityArchive(ArchiveBase):
         check_finite(measures, "measures")
         return self.index_of(measures[None])[0]
 
-    def compute_novelty(self, measures, local_competition=None):
+    def compute_novelty(
+        self, measures: ArrayLike, local_competition: ArrayLike | None = None
+    ) -> np.ndarray | tuple[np.ndarray, np.ndarray]:
         """Computes the novelty and local competition of the given measures.
 
         Args:
-            measures (array-like): (batch_size, :attr:`measure_dim`) array of
-                coordinates in measure space.
-            local_competition (None or array-like): This can be None to indicate not to
-                compute local competition. Otherwise, it can be a (batch_size,) array of
-                objective values to use as references for computing objective values.
+            measures: (batch_size, :attr:`measure_dim`) array of coordinates in measure
+                space.
+            local_competition: This can be None to indicate not to compute local
+                competition. Otherwise, it can be a (batch_size,) array of objective
+                values to use as references for computing objective values.
 
         Returns:
-            numpy.ndarray or tuple: Either one value or a tuple of two values:
+            Either one array or a tuple of two arrays:
 
-            - numpy.ndarray: (batch_size,) array holding the novelty score of each
-              measure. If the archive is empty, the novelty is set to the
-              :attr:`novelty_threshold`.
-            - numpy.ndarray: If ``local_competition`` is passed in, a (batch_size,)
-              array holding the local competition of each solution will also be
-              returned. If the archive is empty, the local competition will be set to 0.
+            - (batch_size,) array holding the novelty score of each measure. If the
+              archive is empty, the novelty is set to the :attr:`novelty_threshold`.
+            - If ``local_competition`` is passed in, a (batch_size,) array holding the
+              local competition of each solution will also be returned. If the archive
+              is empty, the local competition will be set to 0.
         """
         measures = np.asarray(measures)
         batch_size = len(measures)
@@ -445,7 +460,7 @@ class ProximityArchive(ArchiveBase):
 
     ## Methods for writing to the archive ##
 
-    def _maybe_resize(self, new_size):
+    def _maybe_resize(self, new_size: int) -> None:
         """Resizes the store by doubling its capacity.
 
         We may need to double the capacity multiple times. The log2 below indicates how
@@ -456,7 +471,13 @@ class ProximityArchive(ArchiveBase):
             multiplier = 2 ** int(np.ceil(np.log2(new_size / self.capacity)))
             self._store.resize(multiplier * self.capacity)
 
-    def add(self, solution, objective, measures, **fields):
+    def add(
+        self,
+        solution: ArrayLike,
+        objective: ArrayLike | None,
+        measures: ArrayLike,
+        **fields: ArrayLike,
+    ) -> BatchData:
         """Inserts a batch of solutions into the archive.
 
         Solutions are inserted if they have a high enough novelty score as discussed in
@@ -475,21 +496,20 @@ class ProximityArchive(ArchiveBase):
             solution parameters, objective, and measures for solution ``i``.
 
         Args:
-            solution (array-like): (batch_size, :attr:`solution_dim`) array of solution
-                parameters.
-            objective (None or array-like): A value of None will cause the objective
-                values to default to 0. However, if the user wishes to associate an
-                objective with each solution, this can be a (batch_size,) array with
-                objective function evaluations of the solutions. If
-                :attr:`local_competition` is turned on, this argument must be provided.
-            measures (array-like): (batch_size, :attr:`measure_dim`) array with measure
-                space coordinates of all the solutions.
-            fields (keyword arguments): Additional data for each solution. Each argument
-                should be an array with batch_size as the first dimension.
+            solution: (batch_size, :attr:`solution_dim`) array of solution parameters.
+            objective: A value of None will cause the objective values to default to 0.
+                However, if the user wishes to associate an objective with each
+                solution, this can be a (batch_size,) array with objective function
+                evaluations of the solutions. If :attr:`local_competition` is turned on,
+                this argument must be provided.
+            measures: (batch_size, :attr:`measure_dim`) array with measure space
+                coordinates of all the solutions.
+            fields: Additional data for each solution. Each argument should be an array
+                with batch_size as the first dimension.
 
         Returns:
-            dict: Information describing the result of the add operation. The dict
-            contains the following keys:
+            Information describing the result of the add operation. The dict contains
+            the following keys:
 
             - ``"status"`` (:class:`numpy.ndarray` of :class:`numpy.int32`): An array of
               integers that represent the "status" obtained when attempting to insert
@@ -709,20 +729,26 @@ class ProximityArchive(ArchiveBase):
 
             return add_info
 
-    def add_single(self, solution, objective, measures, **fields):
+    def add_single(
+        self,
+        solution: ArrayLike,
+        objective: ArrayLike | None,
+        measures: ArrayLike,
+        **fields: ArrayLike,
+    ) -> SingleData:
         """Inserts a single solution into the archive.
 
         Args:
-            solution (array-like): Parameters of the solution.
-            objective (None or float): Set to None to get the default value of 0;
-                otherwise, a valid objective value is also acceptable.
-            measures (array-like): Coordinates in measure space of the solution.
-            fields (keyword arguments): Additional data for the solution.
+            solution: Parameters of the solution.
+            objective: Set to None to get the default value of 0; otherwise, a valid
+                objective value is also acceptable.
+            measures: Coordinates in measure space of the solution.
+            fields: Additional data for the solution.
 
         Returns:
-            dict: Information describing the result of the add operation. The dict
-            contains ``status`` and ``novelty`` keys; refer to :meth:`add` for the
-            meaning of status and novelty.
+            Information describing the result of the add operation. The dict contains
+            ``status`` and ``novelty`` keys; refer to :meth:`add` for the meaning of
+            status and novelty.
 
         Raises:
             ValueError: The array arguments do not match their specified shapes.
@@ -752,7 +778,7 @@ class ProximityArchive(ArchiveBase):
 
         return self.add(**{key: [val] for key, val in data.items()})
 
-    def clear(self):
+    def clear(self) -> None:
         """Removes all elites in the archive."""
         self._store.clear()
         self._stats_reset()
@@ -760,7 +786,7 @@ class ProximityArchive(ArchiveBase):
     ## Methods for reading from the archive ##
     ## Refer to ArchiveBase for documentation of these methods. ##
 
-    def retrieve(self, measures):
+    def retrieve(self, measures: ArrayLike) -> tuple[np.ndarray, BatchData]:
         measures = np.asarray(measures)
         check_batch_shape(measures, "measures", self.measure_dim, "measure_dim")
         check_finite(measures, "measures")
@@ -770,7 +796,7 @@ class ProximityArchive(ArchiveBase):
 
         return occupied, data
 
-    def retrieve_single(self, measures):
+    def retrieve_single(self, measures: ArrayLike) -> tuple[bool, SingleData]:
         measures = np.asarray(measures)
         check_shape(measures, "measures", self.measure_dim, "measure_dim")
         check_finite(measures, "measures")
@@ -779,10 +805,42 @@ class ProximityArchive(ArchiveBase):
 
         return occupied[0], {field: arr[0] for field, arr in data.items()}
 
-    def data(self, fields=None, return_type="dict"):
+    @overload
+    def data(
+        self,
+        fields: str,
+        return_type: Literal["dict", "tuple", "pandas"] = "dict",
+    ) -> Array: ...
+
+    @overload
+    def data(
+        self,
+        fields: None | Collection[str] = None,
+        return_type: Literal["dict"] = "dict",
+    ) -> BatchData: ...
+
+    @overload
+    def data(
+        self,
+        fields: None | Collection[str] = None,
+        return_type: Literal["tuple"] = "tuple",
+    ) -> tuple[Array]: ...
+
+    @overload
+    def data(
+        self,
+        fields: None | Collection[str] = None,
+        return_type: Literal["pandas"] = "pandas",
+    ) -> ArchiveDataFrame: ...
+
+    def data(
+        self,
+        fields: None | Collection[str] | str = None,
+        return_type: Literal["dict", "tuple", "pandas"] = "dict",
+    ) -> Array | BatchData | tuple[Array] | ArchiveDataFrame:
         return self._store.data(fields, return_type)
 
-    def sample_elites(self, n):
+    def sample_elites(self, n: Int) -> BatchData:
         if self.empty:
             raise IndexError("No elements in archive.")
 

--- a/ribs/archives/_proximity_archive.py
+++ b/ribs/archives/_proximity_archive.py
@@ -63,9 +63,9 @@ class ProximityArchive(ArchiveBase):
     identifies each cell.
 
     Args:
-        solution_dim (int or tuple of int): Dimensionality of the solution space. Scalar
-            or multi-dimensional solution shapes are allowed by passing an empty tuple
-            or tuple of integers, respectively.
+        solution_dim: Dimensionality of the solution space. Scalar or multi-dimensional
+            solution shapes are allowed by passing an empty tuple or tuple of integers,
+            respectively.
         measure_dim (int): Dimensionality of the measure space.
         k_neighbors (int): The maximum number of nearest neighbors for computing novelty
             (`maximum` here is indicated since there may be fewer than ``k_neighbors``

--- a/ribs/archives/_sliding_boundaries_archive.py
+++ b/ribs/archives/_sliding_boundaries_archive.py
@@ -111,9 +111,9 @@ class SlidingBoundariesArchive(ArchiveBase):
     identifies each cell.
 
     Args:
-        solution_dim (int or tuple of int): Dimensionality of the solution space. Scalar
-            or multi-dimensional solution shapes are allowed by passing an empty tuple
-            or tuple of integers, respectively.
+        solution_dim: Dimensionality of the solution space. Scalar or multi-dimensional
+            solution shapes are allowed by passing an empty tuple or tuple of integers,
+            respectively.
         dims (array-like): Number of cells in each dimension of the measure space, e.g.
             ``[20, 30, 40]`` indicates there should be 3 dimensions with 20, 30, and 40
             cells. (The number of dimensions is implicitly defined in the length of this

--- a/ribs/archives/_sliding_boundaries_archive.py
+++ b/ribs/archives/_sliding_boundaries_archive.py
@@ -272,28 +272,28 @@ class SlidingBoundariesArchive(ArchiveBase):
         return self._best_elite
 
     @property
-    def dims(self):
-        """(measure_dim,) numpy.ndarray: Number of cells in each dimension."""
+    def dims(self) -> np.ndarray:
+        """(:attr:`measure_dim`,) array listing the number of cells in each dimension."""
         return self._dims
 
     @property
-    def cells(self):
-        """int: Total number of cells in the archive."""
+    def cells(self) -> int:
+        """Total number of cells in the archive."""
         return self._store.capacity
 
     @property
-    def lower_bounds(self):
-        """(measure_dim,) numpy.ndarray: Lower bound of each dimension."""
+    def lower_bounds(self) -> np.ndarray:
+        """(:attr:`measure_dim`,) array listing the lower bound of each dimension."""
         return self._lower_bounds
 
     @property
-    def upper_bounds(self):
-        """(measure_dim,) numpy.ndarray: Upper bound of each dimension."""
+    def upper_bounds(self) -> np.ndarray:
+        """(:attr:`measure_dim`,) array listing the upper bound of each dimension."""
         return self._upper_bounds
 
     @property
-    def interval_size(self):
-        """(measure_dim,) numpy.ndarray: The size of each dim (upper_bounds - lower_bounds)."""
+    def interval_size(self) -> np.ndarray:
+        """(:attr:`measure_dim`,) array listing the size of each dim (upper_bounds - lower_bounds)."""
         return self._interval_size
 
     @property

--- a/ribs/archives/_utils.py
+++ b/ribs/archives/_utils.py
@@ -2,8 +2,10 @@
 
 import numpy as np
 
+from ribs.typing import ArchiveDType
 
-def parse_dtype(dtype):
+
+def parse_dtype(dtype: ArchiveDType) -> dict[str, np.dtype]:
     """Parses dtypes for the archive.
 
     At the end, all dtypes will be scalar types like np.float32 or np.float64 -- note
@@ -75,5 +77,4 @@ def fill_sentinel_values(occupied, data):
             fill_val = 0
         else:  # Floating-point and other fields.
             fill_val = np.nan
-
         arr[unoccupied] = fill_val

--- a/ribs/typing.py
+++ b/ribs/typing.py
@@ -55,9 +55,6 @@ ArrayVar = TypeVar("ArrayVar")
 #: be the batch dimension.
 BatchData = dict[str, Array]
 
-#: Same as above but allowing for optional values.
-OptionalBatchData = dict[str, Array | None]
-
 #: Represents data about a single solution.
 SingleData = dict[str, Any]
 

--- a/ribs/typing.py
+++ b/ribs/typing.py
@@ -55,11 +55,14 @@ ArrayVar = TypeVar("ArrayVar")
 #: be the batch dimension.
 BatchData = dict[str, Array]
 
+#: Same as above but allowing for optional values.
+OptionalBatchData = dict[str, Array | None]
+
 #: Represents data about a single solution.
 SingleData = dict[str, Any]
 
 #: Description of fields for archives.
-FieldDesc = dict[str, tuple[Int | tuple[Int], DTypeLike]]
+FieldDesc = dict[str, tuple[Int | tuple[Int, ...], DTypeLike]]
 
 #: Description of dtypes for archives.
 ArchiveDType = Union[

--- a/ribs/typing.py
+++ b/ribs/typing.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-from typing import Any, TypeVar, Union
+from typing import Any, Literal, TypeVar, Union
 
 import numpy as np
 from numpy.typing import DTypeLike
@@ -60,3 +60,8 @@ SingleData = dict[str, Any]
 
 #: Description of fields for archives.
 FieldDesc = dict[str, tuple[Int | tuple[Int], DTypeLike]]
+
+#: Description of dtypes for archives.
+ArchiveDType = Union[
+    Literal["f", "d"], type[Union[np.float32, np.float64]], dict[str, DTypeLike]
+]

--- a/ribs/typing.py
+++ b/ribs/typing.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from typing import Any, TypeVar, Union
 
 import numpy as np
+from numpy.typing import DTypeLike
 
 try:
     import torch
@@ -56,3 +57,6 @@ BatchData = dict[str, Array]
 
 #: Represents data about a single solution.
 SingleData = dict[str, Any]
+
+#: Description of fields for archives.
+FieldDesc = dict[str, tuple[Int | tuple[Int], DTypeLike]]

--- a/ribs/visualize/_cvt_archive_heatmap.py
+++ b/ribs/visualize/_cvt_archive_heatmap.py
@@ -299,8 +299,8 @@ def cvt_archive_heatmap(
 
         # Retrieve and initialize the axis.
         ax = plt.gca() if ax is None else ax
-        ax.set_xlim(lower_bounds[0], upper_bounds[0])
-        ax.set_ylim(lower_bounds[1], upper_bounds[1])
+        ax.set_xlim(lower_bounds[0], upper_bounds[0])  # ty: ignore[invalid-argument-type]
+        ax.set_ylim(lower_bounds[1], upper_bounds[1])  # ty: ignore[invalid-argument-type]
         ax.set_aspect(aspect)
 
         # Add faraway points so that the edge regions of the Voronoi diagram are filled

--- a/ribs/visualize/_grid_archive_heatmap.py
+++ b/ribs/visualize/_grid_archive_heatmap.py
@@ -208,8 +208,8 @@ def grid_archive_heatmap(
 
         # Initialize the axis.
         ax = plt.gca() if ax is None else ax
-        ax.set_xlim(lower_bounds[0], upper_bounds[0])
-        ax.set_ylim(lower_bounds[1], upper_bounds[1])
+        ax.set_xlim(lower_bounds[0], upper_bounds[0])  # ty: ignore[invalid-argument-type]
+        ax.set_ylim(lower_bounds[1], upper_bounds[1])  # ty: ignore[invalid-argument-type]
 
         ax.set_aspect(aspect)
 

--- a/ribs/visualize/_sliding_boundaries_archive_heatmap.py
+++ b/ribs/visualize/_sliding_boundaries_archive_heatmap.py
@@ -154,8 +154,8 @@ def sliding_boundaries_archive_heatmap(
 
     # Initialize the axis.
     ax = plt.gca() if ax is None else ax
-    ax.set_xlim(lower_bounds[0], upper_bounds[0])
-    ax.set_ylim(lower_bounds[1], upper_bounds[1])
+    ax.set_xlim(lower_bounds[0], upper_bounds[0])  # ty: ignore[invalid-argument-type]
+    ax.set_ylim(lower_bounds[1], upper_bounds[1])  # ty: ignore[invalid-argument-type]
     ax.set_aspect(aspect)
 
     # Create the plot.

--- a/ribs/visualize/_utils.py
+++ b/ribs/visualize/_utils.py
@@ -134,7 +134,7 @@ def archive_heatmap_1d(
     """
     # Initialize the axis.
     ax = plt.gca() if ax is None else ax
-    ax.set_xlim(archive.lower_bounds[0], archive.upper_bounds[0])
+    ax.set_xlim(archive.lower_bounds[0], archive.upper_bounds[0])  # ty: ignore[invalid-argument-type]
     ax.set_aspect(aspect)
 
     # Turn off yticks; this is a 1D plot so only the x-axis matters.

--- a/tests/archives/archive_base_test.py
+++ b/tests/archives/archive_base_test.py
@@ -260,7 +260,7 @@ def test_best_elite_extended(add_mode):
     assert archive.best_elite["objective"].shape == ()
     assert archive.best_elite["measures"].shape == (2,)
     assert archive.best_elite["threshold"].shape == ()
-    assert archive.stats.obj_max.shape == ()
+    assert archive.stats.obj_max.shape == ()  # ty: ignore[possibly-unbound-attribute]
 
     assert np.isclose(archive.best_elite["solution"], [1, 2, 3]).all()
     assert np.isclose(archive.best_elite["objective"], 1.0)


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the PR's purpose here. -->

Annotate remaining archives. We mostly assume things are still written in numpy, and will update later as Array API is added.

## TODO

<!-- Notable points that this PR has either accomplished or will accomplish. -->

- [x] CategoricalArchive
- [x] CVTArchive
- [x] DensityArchive
- [x] GridArchive
- [x] ProximityArchive
- [x] SlidingBoundariesArchive
- [x] Copy solution_dim from ArchiveBase to other archives
- [x] Fix headers in documentation; they don't show up very nicely -- it seems this is caused by having `np.float64` as the default value. So I added an autodoc extension in `conf.py` that replaces the `np.float64` repr() with simple text. Now the docstrings show up fine. The final result isn't as good as it could be because `DTypeLike` gets expanded, but it's much better than before.

## Status

- [x] I have read the guidelines in
      [CONTRIBUTING.md](https://github.com/icaros-usc/pyribs/blob/master/CONTRIBUTING.md)
- [x] I have linted and formatted my code with `ruff` and `ty`
- [x] I have tested my code by running `pytest`
- [x] I have added a description of my change to the changelog in `HISTORY.md`
- [x] This PR is ready to go
