### PR TITLE
Replace `dtype` parameter in archives with `solution_dtype`, `objective_dtype`, and `measures_dtype`

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,6 +6,8 @@
 
 #### API
 
+- **Backwards-incompatible:** Replace `dtype` parameter in archives with
+  `solution_dtype`, `objective_dtype`, and `measures_dtype` ({pr}`639`)
 - Raise `KeyError` in `ArchiveDataFrame.get_field` when field not found
   ({pr}`626`)
 - Support array backends via Python array API Standard ({issue}`570`)

--- a/docs/api/ribs.typing.rst
+++ b/docs/api/ribs.typing.rst
@@ -17,4 +17,3 @@ ribs.typing
 .. autodata:: ribs.typing.BatchData
 .. autodata:: ribs.typing.SingleData
 .. autodata:: ribs.typing.FieldDesc
-.. autodata:: ribs.typing.ArchiveDType

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ dev = [
   "pytest==8.3.5",
   "pytest-cov==6.0.0",
   "pytest-benchmark==5.1.0",
-  "pytest-xdist==3.6.1",
+  "pytest-xdist==3.8.0",
 
   # Documentation
   "myst-nb==1.3.0",

--- a/ribs/archives/_archive_base.py
+++ b/ribs/archives/_archive_base.py
@@ -11,7 +11,7 @@ from numpy.typing import ArrayLike
 
 from ribs.archives._archive_data_frame import ArchiveDataFrame
 from ribs.archives._archive_stats import ArchiveStats
-from ribs.typing import Array, BatchData, Int, SingleData
+from ribs.typing import Array, BatchData, DType, Int, SingleData
 
 
 class ArchiveBase(ABC):
@@ -84,7 +84,7 @@ class ArchiveBase(ABC):
         )
 
     @property
-    def dtypes(self) -> dict[str, np.dtype]:
+    def dtypes(self) -> dict[str, DType]:
         """Mapping from field name to dtype for all fields in the archive."""
         raise NotImplementedError("`dtypes` has not been implemented in this archive")
 

--- a/ribs/archives/_categorical_archive.py
+++ b/ribs/archives/_categorical_archive.py
@@ -21,7 +21,7 @@ from ribs.archives._utils import (
     parse_dtype,
     validate_cma_mae_settings,
 )
-from ribs.typing import Array, BatchData, FieldDesc, Float, Int, SingleData
+from ribs.typing import Array, BatchData, DType, FieldDesc, Float, Int, SingleData
 
 
 class CategoricalArchive(ArchiveBase):
@@ -165,7 +165,7 @@ class CategoricalArchive(ArchiveBase):
         return self._store.field_list_with_index
 
     @property
-    def dtypes(self) -> dict[str, np.dtype]:
+    def dtypes(self) -> dict[str, DType]:
         return self._store.dtypes_with_index
 
     @property

--- a/ribs/archives/_categorical_archive.py
+++ b/ribs/archives/_categorical_archive.py
@@ -5,8 +5,9 @@ from __future__ import annotations
 from collections.abc import Collection, Hashable, Iterator
 from typing import Literal, overload
 
+import array_api_compat.numpy as np_compat
 import numpy as np
-from numpy.typing import ArrayLike
+from numpy.typing import ArrayLike, DTypeLike
 from numpy_groupies import aggregate_nb as aggregate
 
 from ribs._utils import check_batch_shape, check_shape, validate_batch, validate_single
@@ -20,15 +21,7 @@ from ribs.archives._utils import (
     parse_dtype,
     validate_cma_mae_settings,
 )
-from ribs.typing import (
-    ArchiveDType,
-    Array,
-    BatchData,
-    FieldDesc,
-    Float,
-    Int,
-    SingleData,
-)
+from ribs.typing import Array, BatchData, FieldDesc, Float, Int, SingleData
 
 
 class CategoricalArchive(ArchiveBase):
@@ -70,11 +63,10 @@ class CategoricalArchive(ArchiveBase):
             ``objective - (-300)``.
         seed: Value to seed the random number generator. Set to None to avoid a fixed
             seed.
-        dtype: Data type of the solutions, objectives, and measures. This can be ``"f"``
-            / ``np.float32``, ``"d"`` / ``np.float64``, or a dict specifying separate
-            dtypes, of the form ``{"solution": <dtype>, "objective": <dtype>,
-            "measures": <dtype>}``. By default, unless this parameter is a dict,
-            measures will default to have ``object`` dtype.
+        solution_dtype: Data type of the solution. Defaults to float64.
+        objective_dtype: Data type of the objective. Defaults to float64.
+        measures_dtype: Data type of the measures. Defaults to object.
+        dtype: DEPRECATED.
         extra_fields: Description of extra fields of data that are stored next to elite
             data like solutions and objectives. The description is a dict mapping from a
             field name (str) to a tuple of ``(shape, dtype)``. For instance, ``{"foo":
@@ -97,9 +89,18 @@ class CategoricalArchive(ArchiveBase):
         threshold_min: Float = -np.inf,
         qd_score_offset: Float = 0.0,
         seed: Int | None = None,
-        dtype: ArchiveDType = np.float64,
+        solution_dtype: DTypeLike = None,
+        objective_dtype: DTypeLike = None,
+        measures_dtype: DTypeLike = None,
+        dtype: None = None,
         extra_fields: FieldDesc | None = None,
     ) -> None:
+        if dtype is not None:
+            raise ValueError(
+                "dtype is deprecated. Please specify solution_dtype, "
+                "objective_dtype, and/or measures_dtype instead."
+            )
+
         self._rng = np.random.default_rng(seed)
         self._categories = [list(measure_dim) for measure_dim in categories]
         self._dims = np.array(
@@ -122,21 +123,16 @@ class CategoricalArchive(ArchiveBase):
                 "The following names are not allowed in "
                 f"extra_fields: {reserved_fields}"
             )
-        if not isinstance(dtype, dict):
-            # Make measures default to `object` dtype.
-            dtype = {
-                "solution": dtype,
-                "measures": object,
-                "objective": dtype,
-            }
-        dtype = parse_dtype(dtype)
+        solution_dtype = parse_dtype(solution_dtype, np_compat)
+        objective_dtype = parse_dtype(objective_dtype, np_compat)
+        measures_dtype = object if measures_dtype is None else measures_dtype
         self._store = ArrayStore(
             field_desc={
-                "solution": (self.solution_dim, dtype["solution"]),
-                "objective": ((), dtype["objective"]),
-                "measures": (self.measure_dim, dtype["measures"]),
+                "solution": (self.solution_dim, solution_dtype),
+                "objective": ((), objective_dtype),
+                "measures": (self.measure_dim, measures_dtype),
                 # Must be same dtype as the objective since they share calculations.
-                "threshold": ((), dtype["objective"]),
+                "threshold": ((), objective_dtype),
                 **extra_fields,
             },
             capacity=np.prod(self._dims),

--- a/ribs/archives/_cvt_archive.py
+++ b/ribs/archives/_cvt_archive.py
@@ -30,7 +30,7 @@ from ribs.archives._utils import (
     parse_dtype,
     validate_cma_mae_settings,
 )
-from ribs.typing import Array, BatchData, FieldDesc, Float, Int, SingleData
+from ribs.typing import Array, BatchData, DType, FieldDesc, Float, Int, SingleData
 
 
 class CVTArchive(ArchiveBase):
@@ -331,7 +331,7 @@ class CVTArchive(ArchiveBase):
         return self._store.field_list_with_index
 
     @property
-    def dtypes(self) -> dict[str, np.dtype]:
+    def dtypes(self) -> dict[str, DType]:
         return self._store.dtypes_with_index
 
     @property

--- a/ribs/archives/_density_archive.py
+++ b/ribs/archives/_density_archive.py
@@ -4,15 +4,16 @@ from __future__ import annotations
 
 from typing import Literal
 
+import array_api_compat.numpy as np_compat
 import numpy as np
-from numpy.typing import ArrayLike
+from numpy.typing import ArrayLike, DTypeLike
 from scipy.spatial.distance import cdist
 from sklearn.neighbors import KernelDensity
 
 from ribs._utils import arr_readonly, check_batch_shape, check_finite
 from ribs.archives._archive_base import ArchiveBase
 from ribs.archives._utils import parse_dtype
-from ribs.typing import ArchiveDType, BatchData, Float, Int
+from ribs.typing import BatchData, Float, Int
 
 
 def gkern(x: np.ndarray) -> np.ndarray:
@@ -90,10 +91,9 @@ class DensityArchive(ArchiveBase):
             passed in via the ``bandwidth`` parameter above.
         seed: Value to seed the random number generator. Set to None to avoid a fixed
             seed.
-        dtype: Data type of the measures. This can be ``"f"`` / ``np.float32``, ``"d"``
-            / ``np.float64``. For consistency with other archives, this can also be a
-            dict specifying separate dtypes, of the form ``{"solution": <dtype>,
-            "objective": <dtype>, "measures": <dtype>}``.
+        measures_dtype: Data type of the measures. Defaults to float64 for numpy/cupy,
+            and float32 for torch.
+        dtype: DEPRECATED.
 
     Raises:
         ValueError: Unknown ``density_method`` provided.
@@ -108,11 +108,17 @@ class DensityArchive(ArchiveBase):
         bandwidth: Float | None = None,
         sklearn_kwargs: dict | None = None,
         seed: Int | None = None,
-        dtype: ArchiveDType = np.float64,
+        measures_dtype: DTypeLike = None,
+        dtype: None = None,
     ) -> None:
+        if dtype is not None:
+            raise ValueError(
+                "dtype is deprecated. Please specify solution_dtype, "
+                "objective_dtype, and/or measures_dtype instead."
+            )
+
         self._rng = np.random.default_rng(seed)
-        dtypes = parse_dtype(dtype)
-        self._measure_dtype = dtypes["measures"]
+        self._measure_dtype = parse_dtype(measures_dtype, np_compat)
 
         ArchiveBase.__init__(
             self,

--- a/ribs/archives/_grid_archive.py
+++ b/ribs/archives/_grid_archive.py
@@ -27,7 +27,7 @@ from ribs.archives._utils import (
     parse_dtype,
     validate_cma_mae_settings,
 )
-from ribs.typing import Array, BatchData, FieldDesc, Float, Int, SingleData
+from ribs.typing import Array, BatchData, DType, FieldDesc, Float, Int, SingleData
 
 
 class GridArchive(ArchiveBase):
@@ -201,7 +201,7 @@ class GridArchive(ArchiveBase):
         return self._store.field_list_with_index
 
     @property
-    def dtypes(self) -> dict[str, np.dtype]:
+    def dtypes(self) -> dict[str, DType]:
         return self._store.dtypes_with_index
 
     @property

--- a/ribs/archives/_grid_archive.py
+++ b/ribs/archives/_grid_archive.py
@@ -5,8 +5,9 @@ from __future__ import annotations
 from collections.abc import Collection, Iterator
 from typing import Literal, overload
 
+import array_api_compat.numpy as np_compat
 import numpy as np
-from numpy.typing import ArrayLike
+from numpy.typing import ArrayLike, DTypeLike
 from numpy_groupies import aggregate_nb as aggregate
 
 from ribs._utils import (
@@ -26,15 +27,7 @@ from ribs.archives._utils import (
     parse_dtype,
     validate_cma_mae_settings,
 )
-from ribs.typing import (
-    ArchiveDType,
-    Array,
-    BatchData,
-    FieldDesc,
-    Float,
-    Int,
-    SingleData,
-)
+from ribs.typing import Array, BatchData, FieldDesc, Float, Int, SingleData
 
 
 class GridArchive(ArchiveBase):
@@ -85,10 +78,13 @@ class GridArchive(ArchiveBase):
             ``objective - (-300)``.
         seed: Value to seed the random number generator. Set to None to avoid a fixed
             seed.
-        dtype: Data type of the solutions, objectives, and measures. This can be ``"f"``
-            / ``np.float32``, ``"d"`` / ``np.float64``, or a dict specifying separate
-            dtypes, of the form ``{"solution": <dtype>, "objective": <dtype>,
-            "measures": <dtype>}``.
+        solution_dtype: Data type of the solution. Defaults to float64 for numpy/cupy,
+            and float32 for torch.
+        objective_dtype: Data type of the objective. Defaults to float64 for numpy/cupy,
+            and float32 for torch.
+        measures_dtype: Data type of the measures. Defaults to float64 for numpy/cupy,
+            and float32 for torch.
+        dtype: DEPRECATED.
         extra_fields: Description of extra fields of data that are stored next to elite
             data like solutions and objectives. The description is a dict mapping from a
             field name (str) to a tuple of ``(shape, dtype)``. For instance, ``{"foo":
@@ -114,9 +110,18 @@ class GridArchive(ArchiveBase):
         epsilon: Float = 1e-6,
         qd_score_offset: Float = 0.0,
         seed: Int | None = None,
-        dtype: ArchiveDType = np.float64,
+        solution_dtype: DTypeLike = None,
+        objective_dtype: DTypeLike = None,
+        measures_dtype: DTypeLike = None,
+        dtype: None = None,
         extra_fields: FieldDesc | None = None,
     ) -> None:
+        if dtype is not None:
+            raise ValueError(
+                "dtype is deprecated. Please specify solution_dtype, "
+                "objective_dtype, and/or measures_dtype instead."
+            )
+
         self._rng = np.random.default_rng(seed)
         self._dims = np.array(dims, dtype=np.int32)
 
@@ -136,14 +141,16 @@ class GridArchive(ArchiveBase):
                 "The following names are not allowed in "
                 f"extra_fields: {reserved_fields}"
             )
-        dtype = parse_dtype(dtype)
+        solution_dtype = parse_dtype(solution_dtype, np_compat)
+        objective_dtype = parse_dtype(objective_dtype, np_compat)
+        measures_dtype = parse_dtype(measures_dtype, np_compat)
         self._store = ArrayStore(
             field_desc={
-                "solution": (self.solution_dim, dtype["solution"]),
-                "objective": ((), dtype["objective"]),
-                "measures": (self.measure_dim, dtype["measures"]),
+                "solution": (self.solution_dim, solution_dtype),
+                "objective": ((), objective_dtype),
+                "measures": (self.measure_dim, measures_dtype),
                 # Must be same dtype as the objective since they share calculations.
-                "threshold": ((), dtype["objective"]),
+                "threshold": ((), objective_dtype),
                 **extra_fields,
             },
             capacity=np.prod(self._dims),

--- a/ribs/archives/_proximity_archive.py
+++ b/ribs/archives/_proximity_archive.py
@@ -23,7 +23,7 @@ from ribs.archives._archive_data_frame import ArchiveDataFrame
 from ribs.archives._archive_stats import ArchiveStats
 from ribs.archives._array_store import ArrayStore
 from ribs.archives._utils import fill_sentinel_values, parse_dtype
-from ribs.typing import Array, BatchData, FieldDesc, Float, Int, SingleData
+from ribs.typing import Array, BatchData, DType, FieldDesc, Float, Int, SingleData
 
 
 class ProximityArchive(ArchiveBase):
@@ -215,7 +215,7 @@ class ProximityArchive(ArchiveBase):
         return self._store.field_list_with_index
 
     @property
-    def dtypes(self) -> dict[str, np.dtype]:
+    def dtypes(self) -> dict[str, DType]:
         return self._store.dtypes_with_index
 
     @property

--- a/ribs/archives/_sliding_boundaries_archive.py
+++ b/ribs/archives/_sliding_boundaries_archive.py
@@ -24,7 +24,7 @@ from ribs.archives._archive_stats import ArchiveStats
 from ribs.archives._array_store import ArrayStore
 from ribs.archives._grid_archive import GridArchive
 from ribs.archives._utils import fill_sentinel_values, parse_dtype
-from ribs.typing import Array, BatchData, FieldDesc, Float, Int, SingleData
+from ribs.typing import Array, BatchData, DType, FieldDesc, Float, Int, SingleData
 
 
 class SolutionBuffer:
@@ -270,7 +270,7 @@ class SlidingBoundariesArchive(ArchiveBase):
         return self._store.field_list_with_index
 
     @property
-    def dtypes(self) -> dict[str, np.dtype]:
+    def dtypes(self) -> dict[str, DType]:
         return self._store.dtypes_with_index
 
     @property

--- a/ribs/archives/_utils.py
+++ b/ribs/archives/_utils.py
@@ -15,6 +15,8 @@ def parse_dtype(dtype: DTypeLike, xp: ModuleType) -> DTypeLike:
     provided array backend.
     """
     if dtype is None:
+        # See here for info on array API inspection:
+        # https://data-apis.org/array-api/latest/API_specification/inspection.html
         return xp.__array_namespace_info__().default_dtypes()["real floating"]  # ty: ignore[unresolved-attribute]
     return dtype
 

--- a/ribs/archives/_utils.py
+++ b/ribs/archives/_utils.py
@@ -1,46 +1,22 @@
 """Utilities specific to archives."""
 
+from __future__ import annotations
+
+from types import ModuleType
+
 import numpy as np
+from numpy.typing import DTypeLike
 
-from ribs.typing import ArchiveDType
 
+def parse_dtype(dtype: DTypeLike, xp: ModuleType) -> DTypeLike:
+    """Makes any necessary modifications to the input dtype.
 
-def parse_dtype(dtype: ArchiveDType) -> dict[str, np.dtype]:
-    """Parses dtypes for the archive.
-
-    At the end, all dtypes will be scalar types like np.float32 or np.float64 -- note
-    that this is different from the numpy.dtype like np.dtype("f"). See here:
-    https://numpy.org/doc/stable/reference/arrays.dtypes.html
+    Any dtypes that are `None` are set to the default "real floating" dtype for the
+    provided array backend.
     """
-    if isinstance(dtype, dict):
-        if (
-            "solution" not in dtype
-            or "objective" not in dtype
-            or "measures" not in dtype
-        ):
-            raise ValueError(
-                "If dtype is a dict, it must contain 'solution',"
-                "'objective', and 'measures' keys."
-            )
-        dtype_dict = dtype
-    else:
-        if dtype not in ["f", np.float32, "d", np.float64]:
-            raise ValueError(
-                "Unsupported dtype. Must be np.float32 or np.float64, or dict "
-                '{"solution": <dtype>, "objective": <dtype>, '
-                '"measures": <dtype>}'
-            )
-        dtype_dict = {
-            "solution": dtype,
-            "objective": dtype,
-            "measures": dtype,
-        }
-
-    # Cast everything to scalar types, including string abbreviations like "f".
-    for key in dtype_dict:
-        dtype_dict[key] = np.dtype(dtype_dict[key]).type
-
-    return dtype_dict
+    if dtype is None:
+        return xp.__array_namespace_info__().default_dtypes()["real floating"]  # ty: ignore[unresolved-attribute]
+    return dtype
 
 
 def validate_cma_mae_settings(learning_rate, threshold_min, dtype):

--- a/ribs/typing.py
+++ b/ribs/typing.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Literal, TypeVar, Union
+from typing import Any, TypeVar, Union
 
 import numpy as np
 from numpy.typing import DTypeLike
@@ -60,8 +60,3 @@ SingleData = dict[str, Any]
 
 #: Description of fields for archives.
 FieldDesc = dict[str, tuple[Int | tuple[Int, ...], DTypeLike]]
-
-#: Description of dtypes for archives.
-ArchiveDType = Union[
-    Literal["f", "d"], type[Union[np.float32, np.float64]], dict[str, DTypeLike]
-]

--- a/tests/archives/archive_base_test.py
+++ b/tests/archives/archive_base_test.py
@@ -46,16 +46,14 @@ def test_str_dtype_float(name, dtype):
     assert archive.dtypes["index"] == np.int32
 
 
-def test_dict_dtype():
+def test_different_dtypes():
     archive = GridArchive(
         solution_dim=3,
         dims=[10, 10],
         ranges=[(-1, 1), (-2, 2)],
-        dtype={
-            "solution": object,
-            "objective": np.float32,
-            "measures": np.float32,
-        },
+        solution_dtype=object,
+        objective_dtype=np.float32,
+        measures_dtype=np.float32,
     )
 
     assert archive.dtypes["solution"] == np.object_
@@ -63,25 +61,6 @@ def test_dict_dtype():
     assert archive.dtypes["measures"] == np.float32
     assert archive.dtypes["threshold"] == np.float32
     assert archive.dtypes["index"] == np.int32
-
-
-def test_invalid_dtype():
-    with pytest.raises(ValueError):
-        GridArchive(solution_dim=0, dims=[20, 20], ranges=[(-1, 1)] * 2, dtype=np.int32)
-
-
-def test_invalid_dict_dtype():
-    with pytest.raises(ValueError):
-        GridArchive(
-            solution_dim=3,
-            dims=[10, 10],
-            ranges=[(-1, 1), (-2, 2)],
-            dtype={
-                "solution": object,
-                "objective": np.float32,
-                # Missing measures.
-            },
-        )
 
 
 #

--- a/tests/archives/archive_base_test.py
+++ b/tests/archives/archive_base_test.py
@@ -46,6 +46,20 @@ def test_str_dtype_float(name, dtype):
     assert archive.dtypes["index"] == np.int32
 
 
+def test_default_dtypes():
+    archive = GridArchive(
+        solution_dim=3,
+        dims=[10, 10],
+        ranges=[(-1, 1), (-2, 2)],
+    )
+
+    assert archive.dtypes["solution"] == np.float64
+    assert archive.dtypes["objective"] == np.float64
+    assert archive.dtypes["measures"] == np.float64
+    assert archive.dtypes["threshold"] == np.float64
+    assert archive.dtypes["index"] == np.int32
+
+
 def test_different_dtypes():
     archive = GridArchive(
         solution_dim=3,

--- a/tests/archives/categorical_archive_test.py
+++ b/tests/archives/categorical_archive_test.py
@@ -48,11 +48,7 @@ def test_str_solutions():
             ["A", "B", "C"],
             ["One", "Two", "Three", "Four"],
         ],
-        dtype={
-            "solution": object,
-            "objective": np.float32,
-            "measures": object,
-        },
+        solution_dtype=object,
     )
     assert archive.solution_dim == ()
     assert archive.dtypes["solution"] == np.object_

--- a/tests/archives/conftest.py
+++ b/tests/archives/conftest.py
@@ -86,14 +86,18 @@ def get_archive_data(name, dtype=np.float64):
             solution_dim=len(solution),
             dims=[10, 20],
             ranges=[(-1, 1), (-2, 2)],
-            dtype=dtype,
+            solution_dtype=dtype,
+            objective_dtype=dtype,
+            measures_dtype=dtype,
         )
 
         archive_with_elite = GridArchive(
             solution_dim=len(solution),
             dims=[10, 20],
             ranges=[(-1, 1), (-2, 2)],
-            dtype=dtype,
+            solution_dtype=dtype,
+            objective_dtype=dtype,
+            measures_dtype=dtype,
         )
         grid_indices = (6, 11)
         int_index = 131
@@ -112,7 +116,9 @@ def get_archive_data(name, dtype=np.float64):
             ranges=[(-1, 1), (-1, 1)],
             samples=samples,
             use_kd_tree=kd_tree,
-            dtype=dtype,
+            solution_dtype=dtype,
+            objective_dtype=dtype,
+            measures_dtype=dtype,
         )
 
         archive_with_elite = CVTArchive(
@@ -121,7 +127,9 @@ def get_archive_data(name, dtype=np.float64):
             ranges=[(-1, 1), (-1, 1)],
             samples=samples,
             use_kd_tree=kd_tree,
-            dtype=dtype,
+            solution_dtype=dtype,
+            objective_dtype=dtype,
+            measures_dtype=dtype,
         )
     elif name == "SlidingBoundariesArchive":
         # Sliding boundary archive with 10 cells and range (-1, 1) in first dim,
@@ -133,7 +141,9 @@ def get_archive_data(name, dtype=np.float64):
             ranges=[(-1, 1), (-2, 2)],
             remap_frequency=100,
             buffer_capacity=1000,
-            dtype=dtype,
+            solution_dtype=dtype,
+            objective_dtype=dtype,
+            measures_dtype=dtype,
         )
 
         archive_with_elite = SlidingBoundariesArchive(
@@ -142,7 +152,9 @@ def get_archive_data(name, dtype=np.float64):
             ranges=[(-1, 1), (-2, 2)],
             remap_frequency=100,
             buffer_capacity=1000,
-            dtype=dtype,
+            solution_dtype=dtype,
+            objective_dtype=dtype,
+            measures_dtype=dtype,
         )
         grid_indices = (6, 11)
         int_index = 131
@@ -157,7 +169,9 @@ def get_archive_data(name, dtype=np.float64):
             k_neighbors=k_neighbors,
             novelty_threshold=novelty_threshold,
             initial_capacity=capacity,
-            dtype=dtype,
+            solution_dtype=dtype,
+            objective_dtype=dtype,
+            measures_dtype=dtype,
         )
 
         archive_with_elite = ProximityArchive(
@@ -166,7 +180,9 @@ def get_archive_data(name, dtype=np.float64):
             k_neighbors=k_neighbors,
             novelty_threshold=novelty_threshold,
             initial_capacity=capacity,
-            dtype=dtype,
+            solution_dtype=dtype,
+            objective_dtype=dtype,
+            measures_dtype=dtype,
         )
     elif name == "CategoricalArchive":
         cells = 3 * 4
@@ -177,7 +193,8 @@ def get_archive_data(name, dtype=np.float64):
                 ["A", "B", "C"],
                 ["One", "Two", "Three", "Four"],
             ],
-            dtype=dtype,
+            solution_dtype=dtype,
+            objective_dtype=dtype,
         )
         archive_with_elite = CategoricalArchive(
             solution_dim=len(solution),
@@ -185,7 +202,8 @@ def get_archive_data(name, dtype=np.float64):
                 ["A", "B", "C"],
                 ["One", "Two", "Three", "Four"],
             ],
-            dtype=dtype,
+            solution_dtype=dtype,
+            objective_dtype=dtype,
         )
     else:
         raise ValueError(f"Unknown name {name}")

--- a/tests/archives/density_archive_test.py
+++ b/tests/archives/density_archive_test.py
@@ -49,7 +49,7 @@ def test_density_dtype(density_method, dtype):
         buffer_size=10000,
         density_method=density_method,
         bandwidth=2.0,
-        dtype=dtype,
+        measures_dtype=dtype,
     )
 
     measures = np.arange(10).reshape((5, 2))

--- a/tests/archives/grid_archive_test.py
+++ b/tests/archives/grid_archive_test.py
@@ -672,7 +672,9 @@ def test_values_go_to_correct_bin(dtype):
         dims=[10],
         ranges=[(0, 0.1)],
         epsilon=1e-6,
-        dtype=dtype,
+        solution_dtype=dtype,
+        objective_dtype=dtype,
+        measures_dtype=dtype,
     )
 
     # Values below the lower bound land in the first bin.
@@ -835,7 +837,7 @@ def test_str_solutions():
         solution_dim=(),
         dims=[10, 20],
         ranges=[(-1, 1), (-2, 2)],
-        dtype={"solution": object, "objective": np.float32, "measures": np.float32},
+        solution_dtype=object,
     )
     assert archive.solution_dim == ()
     assert archive.dtypes["solution"] == np.object_

--- a/tests/emitters/evolution_strategy_emitter_test.py
+++ b/tests/emitters/evolution_strategy_emitter_test.py
@@ -53,7 +53,12 @@ def test_list_as_initial_solution():
 @pytest.mark.parametrize("dtype", [np.float64, np.float32], ids=["float64", "float32"])
 def test_dtypes(dtype):
     archive = GridArchive(
-        solution_dim=10, dims=[20, 20], ranges=[(-1.0, 1.0)] * 2, dtype=dtype
+        solution_dim=10,
+        dims=[20, 20],
+        ranges=[(-1.0, 1.0)] * 2,
+        solution_dtype=dtype,
+        objective_dtype=dtype,
+        measures_dtype=dtype,
     )
     emitter = EvolutionStrategyEmitter(archive, x0=np.zeros(10), sigma0=1.0)
     assert emitter.x0.dtype == dtype

--- a/tests/emitters/gradient_arborescence_emitter_test.py
+++ b/tests/emitters/gradient_arborescence_emitter_test.py
@@ -28,7 +28,12 @@ def test_list_as_initial_solution():
 @pytest.mark.parametrize("dtype", [np.float64, np.float32], ids=["float64", "float32"])
 def test_dtypes(dtype):
     archive = GridArchive(
-        solution_dim=10, dims=[20, 20], ranges=[(-1.0, 1.0)] * 2, dtype=dtype
+        solution_dim=10,
+        dims=[20, 20],
+        ranges=[(-1.0, 1.0)] * 2,
+        solution_dtype=dtype,
+        objective_dtype=dtype,
+        measures_dtype=dtype,
     )
     emitter = GradientArborescenceEmitter(archive, x0=np.zeros(10), sigma0=1.0, lr=1.0)
     assert emitter.x0.dtype == dtype

--- a/tests/emitters/optimizer_test.py
+++ b/tests/emitters/optimizer_test.py
@@ -10,13 +10,14 @@ from ribs.emitters.opt import (
     _get_grad_opt,
 )
 
-# Evolution Strategy Tests
+# Evolution Strategy Tests -- see here for why we sort parameters:
+# https://pytest-xdist.readthedocs.io/en/stable/known-limitations.html
 
 
 @pytest.mark.parametrize(
     "es_name",
     # Exclude since we only test core library in these tests.
-    _NAME_TO_ES_MAP.keys() - {"PyCMAEvolutionStrategy", "pycma_es"},
+    sorted(_NAME_TO_ES_MAP.keys() - {"PyCMAEvolutionStrategy", "pycma_es"}),
 )
 def test_init_with_get_es(es_name):
     es_kwargs = {
@@ -36,7 +37,7 @@ def test_init_with_get_es(es_name):
 # Gradient Optimizer Tests
 
 
-@pytest.mark.parametrize("grad_opt_name", _NAME_TO_GRAD_OPT_MAP.keys())
+@pytest.mark.parametrize("grad_opt_name", sorted(_NAME_TO_GRAD_OPT_MAP.keys()))
 def test_init_with_get_grad_opt(grad_opt_name):
     theta0 = 2.0
     lr = 1

--- a/tests/schedulers/scheduler_test.py
+++ b/tests/schedulers/scheduler_test.py
@@ -426,11 +426,6 @@ def test_scheduler_with_categorical_archive(add_mode):
             ["A", "B", "C"],
             ["One", "Two", "Three", "Four"],
         ],
-        dtype={
-            "solution": np.float32,
-            "objective": np.float32,
-            "measures": object,
-        },
     )
     emitters = [GaussianEmitter(archive, sigma=1, x0=[0.0, 0.0], batch_size=batch_size)]
     scheduler = Scheduler(archive, emitters, add_mode=add_mode)

--- a/tutorials/qdaif.ipynb
+++ b/tutorials/qdaif.ipynb
@@ -419,7 +419,7 @@
     "\n",
     "The archive for QDAIF is a [`GridArchive`](https://docs.pyribs.org/en/latest/api/ribs.archives.GridArchive.html), which divides the measure space into a grid and stores a solution in each grid cell. When a solution is added to this archive, it is assigned to a grid cell based on its measure values. If there is already a solution in that cell, the archive only retains the solution that has the higher objective value.\n",
     "\n",
-    "Below, we specify a $20 \\times 20$ grid (`dims`) where each dimension of the grid ranges from 1 to 10 (`ranges`). For those familiar with `GridArchive` from previous tutorials, several other settings are needed since this `GridArchive` stores text-based solutions, whereas previous tutorials involved continuous vectors. First, we set `solution_dim=()`, indicating a scalar solution. Second, we set `dtype` such that the `solution` is an `object` while the `objective` and `measures` remain as floating-point values. This way, the archive can store pieces of text, which are single objects of type `str` (i.e., \"scalar\" objects)."
+    "Below, we specify a $20 \\times 20$ grid (`dims`) where each dimension of the grid ranges from 1 to 10 (`ranges`). For those familiar with `GridArchive` from previous tutorials, several other settings are needed since this `GridArchive` stores text-based solutions, whereas previous tutorials involved continuous vectors. First, we set `solution_dim=()`, indicating a scalar solution. Second, we set `solution_dtype=object` so that the archive can store pieces of text, which are single objects of type `str` (i.e., \"scalar\" objects)."
    ]
   },
   {
@@ -434,7 +434,9 @@
     "    solution_dim=(),\n",
     "    dims=[20, 20],\n",
     "    ranges=[(1, 10), (1, 10)],\n",
-    "    dtype={\"solution\": object, \"objective\": np.float32, \"measures\": np.float32},\n",
+    "    solution_dtype=object,\n",
+    "    objective_dtype=np.float32,\n",
+    "    measures_dtype=np.float32,\n",
     ")"
    ]
   },
@@ -1601,7 +1603,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.18"
+   "version": "3.10.16"
   }
  },
  "nbformat": 4,

--- a/tutorials/tom_cruise_dqd.ipynb
+++ b/tutorials/tom_cruise_dqd.ipynb
@@ -561,7 +561,7 @@
     "\n",
     "Similar to CMA-MAE, this archive takes in `learning_rate` and `threshold_min` parameters. `learning_rate` ($\\alpha$) controls how quickly the threshold in each cell is updated, and we set this to 0.02. Meanwhile, `threshold_min` ($min_f$) is the starting threshold for each cell. This threshold is typically the minimum objective in the problem, hence we choose 0.0.\n",
     "\n",
-    "Finally, we set `dtype=np.float32` since PyTorch models operate with `float32` rather than the pyribs default of `float64`."
+    "Finally, we set the archive dtypes to be `float32` since PyTorch models operate with `float32` rather than the pyribs default of `float64`."
    ]
   },
   {
@@ -586,7 +586,9 @@
     "    ranges=ranges,\n",
     "    learning_rate=0.02,\n",
     "    threshold_min=0.0,\n",
-    "    dtype=np.float32,\n",
+    "    solution_dtype=np.float32,\n",
+    "    objective_dtype=np.float32,\n",
+    "    measures_dtype=np.float32,\n",
     ")"
    ]
   },


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the PR's purpose here. -->

Resolves #638

## TODO

<!-- Notable points that this PR has either accomplished or will accomplish. -->

- [x] Replace current `parse_dtype` util -- note that it takes in an `xp` parameter that is currently set to `np_compat` across the archives; eventually, it should be the `xp` taken in by the archive.
- [x] Update each archive by doing the following:
  - Mark `dtype` as deprecated
  - Add `solution_dtype`, `objective_dtype`, and `measures_dtype`
  - Add error if `dtype` is passed in
  - Update dtype calls in ArrayStore
- [x] Remove `ArchiveDType` from `ribs.typing`
- [x] Update `dtypes` annotations for archives and ArrayStore
- [x] Migrate current usages of `dtype`

## Status

- [x] I have read the guidelines in
      [CONTRIBUTING.md](https://github.com/icaros-usc/pyribs/blob/master/CONTRIBUTING.md)
- [x] I have linted and formatted my code with `ruff` and `ty`
- [x] I have tested my code by running `pytest`
- [x] I have added a description of my change to the changelog in `HISTORY.md`
- [x] This PR is ready to go
