### PR TITLE
Remove manual ribs.typing API listing and upgrade docs CI

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -170,7 +170,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: conda-incubator/setup-miniconda@v3
         with:
-          python-version: "3.10"
+          python-version: "3.12"
       - name: Install deps
         run: pip install jupyter nbconvert
       - name: Replace pyribs installation with local installation
@@ -184,7 +184,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: conda-incubator/setup-miniconda@v3
         with:
-          python-version: "3.10"
+          python-version: "3.12"
       - name: Install deps
         run: pip install .[all,dev,dev-array-api]
       - name: Build docs

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -7,7 +7,7 @@ version: 2
 build:
   os: ubuntu-lts-latest
   tools:
-    python: "3.10"
+    python: "3.12"
 
 # Build documentation with Sphinx.
 sphinx:

--- a/docs/api/ribs.typing.rst
+++ b/docs/api/ribs.typing.rst
@@ -5,15 +5,3 @@ ribs.typing
    :no-members:
    :no-inherited-members:
    :no-special-members:
-   :no-undoc-members:
-
-.. This list is updated manually when types are added to ribs/typing.py.
-.. autodata:: ribs.typing.Int
-.. autodata:: ribs.typing.Float
-.. autodata:: ribs.typing.Array
-.. autodata:: ribs.typing.DType
-.. autodata:: ribs.typing.Device
-.. autodata:: ribs.typing.ArrayVar
-.. autodata:: ribs.typing.BatchData
-.. autodata:: ribs.typing.SingleData
-.. autodata:: ribs.typing.FieldDesc

--- a/docs/api/ribs.typing.rst
+++ b/docs/api/ribs.typing.rst
@@ -2,6 +2,6 @@ ribs.typing
 ===========
 
 .. automodule:: ribs.typing
-   :no-members:
+   :members:
    :no-inherited-members:
    :no-special-members:

--- a/docs/api/ribs.typing.rst
+++ b/docs/api/ribs.typing.rst
@@ -3,5 +3,6 @@ ribs.typing
 
 .. automodule:: ribs.typing
    :members:
+   :member-order: bysource
    :no-inherited-members:
    :no-special-members:

--- a/ribs/typing.py
+++ b/ribs/typing.py
@@ -1,7 +1,18 @@
-"""Custom data types for pyribs."""
+"""Custom data types for pyribs.
 
-# Developer Note: When adding new types, make sure to update the API listing in
-# `docs/api/ribs.typing.rst`.
+.. autodata:: ribs.typing.Int
+.. autodata:: ribs.typing.Float
+.. autodata:: ribs.typing.Array
+.. autodata:: ribs.typing.DType
+.. autodata:: ribs.typing.Device
+.. autodata:: ribs.typing.ArrayVar
+.. autodata:: ribs.typing.BatchData
+.. autodata:: ribs.typing.SingleData
+.. autodata:: ribs.typing.FieldDesc
+"""
+
+# Developer Note: When adding new types, make sure to update the API listing in the
+# docstring above.
 
 from __future__ import annotations
 

--- a/ribs/typing.py
+++ b/ribs/typing.py
@@ -1,18 +1,4 @@
-"""Custom data types for pyribs.
-
-.. autodata:: ribs.typing.Int
-.. autodata:: ribs.typing.Float
-.. autodata:: ribs.typing.Array
-.. autodata:: ribs.typing.DType
-.. autodata:: ribs.typing.Device
-.. autodata:: ribs.typing.ArrayVar
-.. autodata:: ribs.typing.BatchData
-.. autodata:: ribs.typing.SingleData
-.. autodata:: ribs.typing.FieldDesc
-"""
-
-# Developer Note: When adding new types, make sure to update the API listing in the
-# docstring above.
+"""Custom data types for pyribs."""
 
 from __future__ import annotations
 


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the PR's purpose here. -->

The listing was previously in the ribs.typing.rst file, and we had to maintain it manually. Now, we just use `automodule`. 

~~The downside to this is that generic type aliases (`SingleData`, `BatchData`, and `FieldDesc`) all do not show their values -- see the screenshot below where `Array` shows up as an alias but `SingleData` does not.~~

<img width="585" height="296" alt="image" src="https://github.com/user-attachments/assets/dd97de88-8ad9-4d30-80d9-ed26c3061e13" />

~~This seems to be because they are aliases of `dict`, which Sphinx does not recognize as type aliases. Sphinx does recognize `typing.Dict`, but `typing.Dict` is deprecated. It seems that Sphinx sees things using `dict` into attributes rather than data.~~

I found that the above error no longer happens if I upgrade to Python 3.12 instead of 3.10. Hence, this PR also updates the CI to use Python 3.12 when building the docs.

## Status

- [x] I have read the guidelines in
      [CONTRIBUTING.md](https://github.com/icaros-usc/pyribs/blob/master/CONTRIBUTING.md)
- [x] I have linted and formatted my code with `ruff` and `ty`
- [x] I have tested my code by running `pytest`
- [x] I have added a description of my change to the changelog in `HISTORY.md`
- [x] This PR is ready to go
