### PR TITLE
Wrap args docstrings to length 88

### DIFF
--- a/ribs/archives/_proximity_archive.py
+++ b/ribs/archives/_proximity_archive.py
@@ -89,13 +89,12 @@ class ProximityArchive(ArchiveBase):
             threshold, its objective will be compared to that of its nearest neighbor.
             If the candidate's objective is higher, it will replace the nearest
             neighbor.
-        initial_capacity: Since this archive is unstructured, it does not have a
-            fixed size, and it will grow as solutions are added. In the implementation,
-            we store solutions in fixed-size arrays, and every time the capacity of
-            these arrays is reached, we double their sizes (similar to the vector in
-            C++). This parameter determines the initial capacity of the archive's
-            arrays. It may be useful when it is known in advance how large the archive
-            will grow.
+        initial_capacity: Since this archive is unstructured, it does not have a fixed
+            size, and it will grow as solutions are added. In the implementation, we
+            store solutions in fixed-size arrays, and every time the capacity of these
+            arrays is reached, we double their sizes (similar to the vector in C++).
+            This parameter determines the initial capacity of the archive's arrays. It
+            may be useful when it is known in advance how large the archive will grow.
         qd_score_offset: Archives often contain negative objective values, and if the QD
             score were to be computed with these negative objectives, the algorithm
             would be penalized for adding new cells with negative objectives. Thus, a

--- a/ribs/archives/_sliding_boundaries_archive.py
+++ b/ribs/archives/_sliding_boundaries_archive.py
@@ -130,9 +130,9 @@ class SlidingBoundariesArchive(ArchiveBase):
             :math:`[-1,1]` (inclusive), and the second dimension should have bounds
             :math:`[-2,2]` (inclusive). ``ranges`` should be the same length as
             ``dims``.
-        epsilon: Due to floating point precision errors, we add a small epsilon
-            when computing the archive indices in the :meth:`index_of` method -- refer
-            to the implementation `here
+        epsilon: Due to floating point precision errors, we add a small epsilon when
+            computing the archive indices in the :meth:`index_of` method -- refer to the
+            implementation `here
             <../_modules/ribs/archives/_sliding_boundaries_archive.html#SlidingBoundariesArchive.index_of>`_.
             Pass this parameter to configure that epsilon.
         qd_score_offset: Archives often contain negative objective values, and if the QD

--- a/ribs/schedulers/_bandit_scheduler.py
+++ b/ribs/schedulers/_bandit_scheduler.py
@@ -64,8 +64,8 @@ class BanditScheduler:
             :meth:`~ribs.archives.ArchiveBase.add`. Alternatively, use "single" to add
             the solutions one at a time with
             :meth:`~ribs.archives.ArchiveBase.add_single`. "single" mode is included
-            since implementing batch addition on an archive is sometimes non-trivial.
-            We highly recommend "batch" mode since it is significantly faster.
+            since implementing batch addition on an archive is sometimes non-trivial. We
+            highly recommend "batch" mode since it is significantly faster.
 
     Raises:
         TypeError: The ``emitter_pool`` argument was not a list of emitters.

--- a/ribs/schedulers/_bayesian_opt_scheduler.py
+++ b/ribs/schedulers/_bayesian_opt_scheduler.py
@@ -29,8 +29,8 @@ class BayesianOptimizationScheduler(Scheduler):
             :meth:`~ribs.archives.ArchiveBase.add`. Alternatively, use "single" to add
             the solutions one at a time with
             :meth:`~ribs.archives.ArchiveBase.add_single`. "single" mode is included
-            since implementing batch addition on an archive is sometimes non-trivial.
-            We highly recommend "batch" mode since it is significantly faster.
+            since implementing batch addition on an archive is sometimes non-trivial. We
+            highly recommend "batch" mode since it is significantly faster.
 
     Raises:
         TypeError: Some emitters are not BayesianOptimizationEmitter.

--- a/ribs/schedulers/_scheduler.py
+++ b/ribs/schedulers/_scheduler.py
@@ -44,8 +44,8 @@ class Scheduler:
             :meth:`~ribs.archives.ArchiveBase.add`. Alternatively, use "single" to add
             the solutions one at a time with
             :meth:`~ribs.archives.ArchiveBase.add_single`. "single" mode is included
-            since implementing batch addition on an archive is sometimes non-trivial.
-            We highly recommend "batch" mode since it is significantly faster.
+            since implementing batch addition on an archive is sometimes non-trivial. We
+            highly recommend "batch" mode since it is significantly faster.
 
     Raises:
         TypeError: The ``emitters`` argument was not a list of emitters.

--- a/ribs/visualize/_cvt_archive_3d_plot.py
+++ b/ribs/visualize/_cvt_archive_3d_plot.py
@@ -184,9 +184,9 @@ def cvt_archive_3d_plot(
             see :class:`~matplotlib.colors.ListedColormap`), or a
             :class:`~matplotlib.colors.Colormap` object.
         lw: Line width when plotting the Voronoi diagram.
-        ec: Edge color of the cells in the Voronoi diagram. See
-            `here <https://matplotlib.org/stable/tutorials/colors/colors.html>`_ for
-            more info on specifying colors in Matplotlib.
+        ec: Edge color of the cells in the Voronoi diagram. See `here
+            <https://matplotlib.org/stable/tutorials/colors/colors.html>`_ for more info
+            on specifying colors in Matplotlib.
         cell_alpha: Alpha value for the cell colors. Set to 1.0 for opaque cells; set to
             0.0 for fully transparent cells.
         vmin: Minimum objective value to use in the plot. If ``None``, the minimum
@@ -198,8 +198,8 @@ def cvt_archive_3d_plot(
             is not displayed. If this is an :class:`~matplotlib.axes.Axes`, displays the
             colorbar on the specified Axes.
         cbar_kwargs: Additional kwargs to pass to :func:`~matplotlib.pyplot.colorbar`.
-        plot_elites: If True, we will plot a scatter plot of the elites in the
-            archive. The elites will be colored according to their objective value.
+        plot_elites: If True, we will plot a scatter plot of the elites in the archive.
+            The elites will be colored according to their objective value.
         elite_ms: Marker size for plotting elites.
         elite_alpha: Alpha value for plotting elites.
         plot_centroids: Whether to plot the cluster centroids.

--- a/ribs/visualize/_cvt_archive_heatmap.py
+++ b/ribs/visualize/_cvt_archive_heatmap.py
@@ -131,9 +131,9 @@ def cvt_archive_heatmap(
             ``'auto'`` for 2D and ``0.5`` for 1D. ``'equal'`` is the same as
             ``aspect=1``. See :meth:`matplotlib.axes.Axes.set_aspect` for more info.
         lw: Line width when plotting the Voronoi diagram.
-        ec: Edge color of the cells in the Voronoi diagram. See
-            `here <https://matplotlib.org/stable/tutorials/colors/colors.html>`_ for
-            more info on specifying colors in Matplotlib.
+        ec: Edge color of the cells in the Voronoi diagram. See `here
+            <https://matplotlib.org/stable/tutorials/colors/colors.html>`_ for more info
+            on specifying colors in Matplotlib.
         vmin: Minimum objective value to use in the plot. If ``None``, the minimum
             objective value in the archive is used.
         vmax: Maximum objective value to use in the plot. If ``None``, the maximum

--- a/ribs/visualize/_grid_archive_heatmap.py
+++ b/ribs/visualize/_grid_archive_heatmap.py
@@ -132,8 +132,7 @@ def grid_archive_heatmap(
             raster graphic so that the archive cells will not have to be individually
             rendered. Meanwhile, the surrounding axes, particularly text labels, will
             remain in vector format.
-        pcm_kwargs: Additional kwargs to pass to
-            :func:`~matplotlib.pyplot.pcolormesh`.
+        pcm_kwargs: Additional kwargs to pass to :func:`~matplotlib.pyplot.pcolormesh`.
 
     Raises:
         ValueError: The archive's measure dimension must be 1D or 2D.


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the PR's purpose here. -->

I built a small tool that wraps argument docstrings to length 88 and ran it on the codebase. Will work on releasing the tool later.

## Status

- [x] I have read the guidelines in
      [CONTRIBUTING.md](https://github.com/icaros-usc/pyribs/blob/master/CONTRIBUTING.md)
- [x] I have linted and formatted my code with `ruff` and `ty`
- [x] I have tested my code by running `pytest`
- [N/A] I have added a description of my change to the changelog in `HISTORY.md`
- [x] This PR is ready to go
