### PR TITLE
Support multi-dimensional solutions in GaussianEmitter and IsoLineEmitter

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,6 +6,8 @@
 
 #### API
 
+- Support multi-dimensional solutions in GaussianEmitter and IsoLineEmitter
+  ({pr}`650`)
 - **Backwards-incompatible:** Replace emitter `bounds` params with
   `lower_bounds` and `upper_bounds` ({pr}`649`)
 - **Backwards-incompatible:** Replace `dtype` parameter in archives with

--- a/ribs/emitters/_gaussian_emitter.py
+++ b/ribs/emitters/_gaussian_emitter.py
@@ -1,5 +1,7 @@
 """Provides the GaussianEmitter."""
 
+import numbers
+
 import numpy as np
 
 from ribs._utils import check_batch_shape, check_shape, deprecate_bounds
@@ -70,6 +72,11 @@ class GaussianEmitter(EmitterBase):
         self._sigma = np.asarray(sigma, dtype=archive.dtypes["solution"])
         self._x0 = None
         self._initial_solutions = None
+        self._noise_shape = (
+            (self.batch_size, self.solution_dim)
+            if isinstance(self.solution_dim, numbers.Integral)
+            else (self.batch_size, *self.solution_dim)
+        )
 
         if x0 is None and initial_solutions is None:
             raise ValueError("Either x0 or initial_solutions must be provided.")
@@ -143,7 +150,6 @@ class GaussianEmitter(EmitterBase):
 
         noise = self._rng.normal(
             scale=self.sigma,
-            size=(self.batch_size, self.solution_dim),
+            size=self._noise_shape,
         ).astype(self.archive.dtypes["solution"])
-
         return self._clip(parents + noise)

--- a/tests/emitters/gaussian_emitter_test.py
+++ b/tests/emitters/gaussian_emitter_test.py
@@ -103,5 +103,12 @@ def test_multidim_solutions():
     )
     x0 = np.zeros((5, 5))
     emitter = GaussianEmitter(archive, sigma=0.1, x0=x0, batch_size=2)
+
+    solutions = emitter.ask()
+    assert solutions.shape == (2, 5, 5)
+
+    archive.add(solutions, objective=np.ones(2), measures=[[-1, -1], [1, 1]])
+
+    # Ask again since behavior changes once the archive is not empty.
     solutions = emitter.ask()
     assert solutions.shape == (2, 5, 5)

--- a/tests/emitters/gaussian_emitter_test.py
+++ b/tests/emitters/gaussian_emitter_test.py
@@ -3,6 +3,7 @@
 import numpy as np
 import pytest
 
+from ribs.archives import GridArchive
 from ribs.emitters import GaussianEmitter
 
 
@@ -92,3 +93,15 @@ def test_degenerate_gauss_emits_parent(archive_fixture):
     solutions = emitter.ask()
 
     assert (solutions == np.expand_dims(parent_sol, axis=0)).all()
+
+
+def test_multidim_solutions():
+    archive = GridArchive(
+        solution_dim=(5, 5),
+        dims=[20, 20],
+        ranges=[(-1, 1), (-1, 1)],
+    )
+    x0 = np.zeros((5, 5))
+    emitter = GaussianEmitter(archive, sigma=0.1, x0=x0, batch_size=2)
+    solutions = emitter.ask()
+    assert solutions.shape == (2, 5, 5)

--- a/tests/emitters/iso_line_emitter_test.py
+++ b/tests/emitters/iso_line_emitter_test.py
@@ -3,6 +3,7 @@
 import numpy as np
 import pytest
 
+from ribs.archives import GridArchive
 from ribs.emitters import IsoLineEmitter
 
 
@@ -116,3 +117,24 @@ def test_degenerate_gauss_emits_along_line(archive_fixture):
     # cases. In any case, this assertion should hold for all solutions
     # generated.
     assert (solutions[:, 1:] == 0).all()
+
+
+def test_multidim_solutions():
+    archive = GridArchive(
+        solution_dim=(5, 5),
+        dims=[20, 20],
+        ranges=[(-1, 1), (-1, 1)],
+    )
+    x0 = np.zeros((5, 5))
+    emitter = IsoLineEmitter(
+        archive, x0=x0, iso_sigma=0.1, line_sigma=0.2, batch_size=2
+    )
+
+    solutions = emitter.ask()
+    assert solutions.shape == (2, 5, 5)
+
+    archive.add(solutions, objective=np.ones(2), measures=[[-1, -1], [1, 1]])
+
+    # Ask again since behavior changes once the archive is not empty.
+    solutions = emitter.ask()
+    assert solutions.shape == (2, 5, 5)

--- a/tests/schedulers/scheduler_test.py
+++ b/tests/schedulers/scheduler_test.py
@@ -445,3 +445,31 @@ def test_scheduler_with_categorical_archive(add_mode):
         objective_batch=np.ones(batch_size),
         measures_batch=measures_batch,
     )
+
+
+def test_multidim_solutions(add_mode):
+    batch_size = 4
+    archive = GridArchive(
+        solution_dim=(5, 5), dims=[100, 100], ranges=[(-1, 1), (-1, 1)]
+    )
+    emitters = [
+        GaussianEmitter(archive, sigma=1, x0=np.zeros((5, 5)), batch_size=batch_size)
+    ]
+    scheduler = Scheduler(archive, emitters, add_mode=add_mode)
+
+    measures_batch = [[1.0, 1.0], [-1.0, 1.0], [-1.0, -1.0], [1.0, -1.0]]
+
+    solutions = scheduler.ask()
+    assert solutions.shape == (4, 5, 5)
+
+    # We pass in 4 solutions with unique measures, so all should go into
+    # the archive.
+    scheduler.tell(np.ones(batch_size), measures_batch)
+
+    assert_archive_elites(
+        archive=scheduler.archive,
+        batch_size=batch_size,
+        solution_batch=solutions,
+        objective_batch=np.ones(batch_size),
+        measures_batch=measures_batch,
+    )

--- a/tutorials/fooling_mnist.ipynb
+++ b/tutorials/fooling_mnist.ipynb
@@ -176,9 +176,12 @@
     "from ribs.archives import GridArchive\n",
     "\n",
     "img_size = (28, 28)\n",
-    "flat_img_size = 784  # 28 * 28\n",
     "\n",
-    "archive = GridArchive(solution_dim=flat_img_size, dims=[10], ranges=[(0, 10)])"
+    "# Note that GridArchive and GaussianEmitter are able to support multi-dimensional\n",
+    "# solutions, so we can simply set solution_dim to be img_size. This way, the archive\n",
+    "# stores the images in their original shape. This does not necessarily work for all\n",
+    "# emitters.\n",
+    "archive = GridArchive(solution_dim=img_size, dims=[10], ranges=[(0, 10)])"
    ]
   },
   {
@@ -201,10 +204,10 @@
     "        archive,\n",
     "        sigma=0.5,\n",
     "        # Start with a grey image.\n",
-    "        x0=np.full(flat_img_size, 0.5),\n",
+    "        x0=np.full(img_size, 0.5),\n",
     "        # Bound the generated images to the pixel range.\n",
-    "        lower_bounds=np.full(flat_img_size, 0.0),\n",
-    "        upper_bounds=np.full(flat_img_size, 1.0),\n",
+    "        lower_bounds=np.full(img_size, 0.0),\n",
+    "        upper_bounds=np.full(img_size, 1.0),\n",
     "        batch_size=30,\n",
     "    )\n",
     "]"
@@ -308,7 +311,7 @@
     "    found.add(digit)\n",
     "\n",
     "    # No need to normalize image because we want to see the original.\n",
-    "    ax[digit].imshow(elite[\"solution\"].reshape(28, 28), cmap=\"Greys\")\n",
+    "    ax[digit].imshow(elite[\"solution\"], cmap=\"Greys\")\n",
     "    ax[digit].set_axis_off()\n",
     "    ax[digit].set_title(f\"{digit} | Score: {elite['objective']:.3f}\", pad=8)\n",
     "\n",


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the PR's purpose here. -->

Now that the `lower_bounds` and `upper_bounds` are more flexible (#649), it makes sense to support multi-dimensional solutions in certain emitters. This PR adds that support in `GaussianEmitter` and `IsoLineEmitter`. The `Fooling MNIST` tutorial is also updated to leverage this capability.

## Status

- [x] I have read the guidelines in
      [CONTRIBUTING.md](https://github.com/icaros-usc/pyribs/blob/master/CONTRIBUTING.md)
- [x] I have linted and formatted my code with `ruff` and `ty`
- [x] I have tested my code by running `pytest`
- [x] I have added a description of my change to the changelog in `HISTORY.md`
- [x] This PR is ready to go
