### PR TITLE
Use typevars to make scheduler types more precise

### DIFF
--- a/ribs/schedulers/_bandit_scheduler.py
+++ b/ribs/schedulers/_bandit_scheduler.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import warnings
 from collections import defaultdict
 from collections.abc import Sequence
-from typing import Literal
+from typing import Literal, TypeVar
 
 import numpy as np
 from numpy.typing import ArrayLike
@@ -15,6 +15,10 @@ from ribs.archives import ArchiveBase
 from ribs.emitters import EmitterBase
 from ribs.schedulers._scheduler import Scheduler
 from ribs.typing import Float, Int
+
+ArchiveT = TypeVar("ArchiveT", bound=ArchiveBase)
+EmittersT = TypeVar("EmittersT", bound=Sequence[EmitterBase])
+ResultArchiveT = TypeVar("ResultArchiveT", bound=ArchiveBase)
 
 
 class BanditScheduler:
@@ -81,9 +85,9 @@ class BanditScheduler:
 
     def __init__(
         self,
-        archive: ArchiveBase,
-        emitter_pool: Sequence[EmitterBase],
-        result_archive: ArchiveBase | None = None,
+        archive: ArchiveT,
+        emitter_pool: EmittersT,
+        result_archive: ResultArchiveT | None = None,
         *,
         num_active: Int,
         reselect: Literal["terminated", "all"] = "terminated",
@@ -171,12 +175,12 @@ class BanditScheduler:
         self._num_emitted = np.array([None for _ in self._active_arr])
 
     @property
-    def archive(self) -> ArchiveBase:
+    def archive(self) -> ArchiveT:
         """Archive for storing solutions found in this scheduler."""
         return self._archive
 
     @property
-    def emitter_pool(self) -> Sequence[EmitterBase]:
+    def emitter_pool(self) -> EmittersT:
         """The pool of emitters available in the scheduler."""
         return self._emitter_pool
 
@@ -186,7 +190,7 @@ class BanditScheduler:
         return arr_readonly(self._active_arr, view=True)
 
     @property
-    def result_archive(self) -> ArchiveBase:
+    def result_archive(self) -> ResultArchiveT | ArchiveT:
         """An additional archive for storing solutions found in this scheduler.
 
         If ``result_archive`` was not passed to the constructor, this property is the

--- a/ribs/schedulers/_bandit_scheduler.py
+++ b/ribs/schedulers/_bandit_scheduler.py
@@ -16,6 +16,7 @@ from ribs.emitters import EmitterBase
 from ribs.schedulers._scheduler import Scheduler
 from ribs.typing import Float, Int
 
+# Make sure to update the notes below if these change!
 ArchiveT = TypeVar("ArchiveT", bound=ArchiveBase)
 EmittersT = TypeVar("EmittersT", bound=Sequence[EmitterBase])
 ResultArchiveT = TypeVar("ResultArchiveT", bound=ArchiveBase)
@@ -81,6 +82,16 @@ class BanditScheduler:
         ValueError: Invalid value for ``add_mode``.
         ValueError: The ``result_archive`` and ``archive`` are the same object
             (``result_archive`` should not be passed in this case).
+
+    Notes:
+        The following :class:`~typing.TypeVar`'s are used in this class:
+
+        .. py:type:: ArchiveT
+            :canonical: TypeVar(bound=ArchiveBase)
+        .. py:type:: EmittersT
+            :canonical: TypeVar(bound=Sequence[EmitterBase])
+        .. py:type:: ResultArchiveT
+            :canonical: TypeVar(bound=ArchiveBase)
     """
 
     def __init__(

--- a/ribs/schedulers/_scheduler.py
+++ b/ribs/schedulers/_scheduler.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import warnings
 from collections import defaultdict
 from collections.abc import Sequence
-from typing import Literal
+from typing import Literal, TypeVar
 
 import numpy as np
 from numpy.typing import ArrayLike
@@ -13,6 +13,10 @@ from numpy.typing import ArrayLike
 from ribs.archives import ArchiveBase
 from ribs.emitters import EmitterBase
 from ribs.typing import BatchData
+
+ArchiveT = TypeVar("ArchiveT", bound=ArchiveBase)
+EmittersT = TypeVar("EmittersT", bound=Sequence[EmitterBase])
+ResultArchiveT = TypeVar("ResultArchiveT", bound=ArchiveBase)
 
 
 class Scheduler:
@@ -60,9 +64,9 @@ class Scheduler:
 
     def __init__(
         self,
-        archive: ArchiveBase,
-        emitters: Sequence[EmitterBase],
-        result_archive: ArchiveBase | None = None,
+        archive: ArchiveT,
+        emitters: EmittersT,
+        result_archive: ResultArchiveT | None = None,
         *,
         add_mode: Literal["batch", "single"] = "batch",
     ) -> None:
@@ -124,17 +128,17 @@ class Scheduler:
         self._num_emitted = [None for _ in self._emitters]
 
     @property
-    def archive(self) -> ArchiveBase:
+    def archive(self) -> ArchiveT:
         """Archive for storing solutions found in this scheduler."""
         return self._archive
 
     @property
-    def emitters(self) -> Sequence[EmitterBase]:
+    def emitters(self) -> EmittersT:
         """Emitters for generating solutions in this scheduler."""
         return self._emitters
 
     @property
-    def result_archive(self) -> ArchiveBase:
+    def result_archive(self) -> ResultArchiveT | ArchiveT:
         """An additional archive for storing solutions found in this scheduler.
 
         If ``result_archive`` was not passed to the constructor, this property is the

--- a/ribs/schedulers/_scheduler.py
+++ b/ribs/schedulers/_scheduler.py
@@ -14,6 +14,7 @@ from ribs.archives import ArchiveBase
 from ribs.emitters import EmitterBase
 from ribs.typing import BatchData
 
+# Make sure to update the notes below if these change!
 ArchiveT = TypeVar("ArchiveT", bound=ArchiveBase)
 EmittersT = TypeVar("EmittersT", bound=Sequence[EmitterBase])
 ResultArchiveT = TypeVar("ResultArchiveT", bound=ArchiveBase)
@@ -60,6 +61,16 @@ class Scheduler:
         ValueError: Invalid value for ``add_mode``.
         ValueError: The ``result_archive`` and ``archive`` are the same object
             (``result_archive`` should not be passed in this case).
+
+    Notes:
+        The following :class:`~typing.TypeVar`'s are used in this class:
+
+        .. py:type:: ArchiveT
+            :canonical: TypeVar(bound=ArchiveBase)
+        .. py:type:: EmittersT
+            :canonical: TypeVar(bound=Sequence[EmitterBase])
+        .. py:type:: ResultArchiveT
+            :canonical: TypeVar(bound=ArchiveBase)
     """
 
     def __init__(


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the PR's purpose here. -->

Towards #624. With these typevars, it is now clearer that the archive, result_archive, and emitter properties take their types from the inputs passed into the scheduler.

## Status

- [x] I have read the guidelines in
      [CONTRIBUTING.md](https://github.com/icaros-usc/pyribs/blob/master/CONTRIBUTING.md)
- [x] I have linted and formatted my code with `ruff` and `ty`
- [x] I have tested my code by running `pytest`
- [x] I have added a description of my change to the changelog in `HISTORY.md`
- [x] This PR is ready to go
