### PR TITLE
Allow specifying emitter bounds with `lower_bounds` and `upper_bounds`

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -8,8 +8,8 @@
 
 - Support multi-dimensional solutions in GaussianEmitter and IsoLineEmitter
   ({pr}`650`)
-- **Backwards-incompatible:** Replace emitter `bounds` params with
-  `lower_bounds` and `upper_bounds` ({pr}`649`)
+- Allow specifying emitter bounds with `lower_bounds` and `upper_bounds`
+  ({pr}`649`, {pr}`657`)
 - **Backwards-incompatible:** Replace `dtype` parameter in archives with
   `solution_dtype`, `objective_dtype`, and `measures_dtype` ({pr}`639`,
   {pr}`643`)

--- a/ribs/_utils.py
+++ b/ribs/_utils.py
@@ -306,11 +306,3 @@ def deprecate_dtype(dtype: None) -> None:
             "The dtype parameter is deprecated as of pyribs 0.9.0. Please specify "
             "solution_dtype, objective_dtype, and/or measures_dtype instead."
         )
-
-
-def deprecate_bounds(bounds: None) -> None:
-    if bounds is not None:
-        raise ValueError(
-            "The bounds parameter is deprecated as of pyribs 0.9.0. "
-            "Please specify lower_bounds and upper_bounds instead."
-        )

--- a/ribs/emitters/_emitter_base.py
+++ b/ribs/emitters/_emitter_base.py
@@ -4,13 +4,14 @@ from __future__ import annotations
 
 import numbers
 from abc import ABC
+from collections.abc import Collection
 
 import numpy as np
-from numpy.typing import ArrayLike
+from numpy.typing import ArrayLike, DTypeLike
 
-from ribs._utils import check_shape, deprecate_bounds
+from ribs._utils import check_shape
 from ribs.archives import ArchiveBase
-from ribs.typing import BatchData, Int
+from ribs.typing import BatchData, Float, Int
 
 
 class EmitterBase(ABC):
@@ -25,11 +26,19 @@ class EmitterBase(ABC):
     Args:
         archive: Archive of solutions, e.g., :class:`ribs.archives.GridArchive`.
         solution_dim: The dimensionality of solutions produced by this emitter.
-        lower_bounds: Lower bounds of the solution space. Pass None to indicate there
-            are no bounds (i.e., bounds are set to -inf).
-        upper_bounds: Upper bounds of the solution space. Pass None to indicate there
-            are no bounds (i.e., bounds are set to inf).
-        bounds: DEPRECATED.
+        bounds: Bounds of the solution space. Pass None to indicate there are no bounds.
+            Alternatively, pass an array-like to specify the bounds for each dim. Each
+            element in this array-like can be None to indicate no bound, or a tuple of
+            ``(lower_bound, upper_bound)``, where ``lower_bound`` or ``upper_bound`` may
+            be None to indicate no bound. Unbounded upper bounds are set to +inf, and
+            unbounded lower bounds are set to -inf.
+        lower_bounds: Instead of specifying ``bounds``, ``lower_bounds`` and
+            ``upper_bounds`` may be specified. This is useful if, for instance,
+            solutions are multi-dimensional. Here, pass None to indicate there are no
+            bounds (i.e., bounds are set to -inf), or pass an array specifying the lower
+            bounds of the solution space.
+        upper_bounds: Upper bounds of the solution space; see ``lower_bounds`` above.
+            Pass None to indicate there are no bounds (i.e., bounds are set to inf).
 
     Raises:
         ValueError: There is an error in the bounds configuration.
@@ -40,31 +49,78 @@ class EmitterBase(ABC):
         archive: ArchiveBase,
         *,
         solution_dim: Int | tuple[Int, ...],
+        bounds: Collection[tuple[None | Float, None | Float]] | None,
         lower_bounds: ArrayLike | None,
         upper_bounds: ArrayLike | None,
-        bounds: None = None,
     ) -> None:
-        deprecate_bounds(bounds)
-
         self._archive = archive
         self._solution_dim = solution_dim
 
-        self._lower_bounds = (
-            np.full(solution_dim, -np.inf, dtype=archive.dtypes["solution"])
-            if lower_bounds is None
-            else np.asarray(lower_bounds, dtype=archive.dtypes["solution"])
-        )
-        self._upper_bounds = (
-            np.full(solution_dim, np.inf, dtype=archive.dtypes["solution"])
-            if upper_bounds is None
-            else np.asarray(upper_bounds, dtype=archive.dtypes["solution"])
-        )
-        check_shape(
-            self._lower_bounds, "lower_bounds", self._solution_dim, "solution_dim"
-        )
-        check_shape(
-            self._upper_bounds, "upper_bounds", self._solution_dim, "solution_dim"
-        )
+        # Bounds handling.
+        use_bounds = bounds is not None
+        use_lower_upper = lower_bounds is not None or upper_bounds is not None
+        if use_bounds and use_lower_upper:
+            raise ValueError(
+                "Cannot specify both bounds and lower_bounds/upper_bounds; "
+                "either specify bounds or specify lower_bounds/upper_bounds."
+            )
+        elif use_bounds:
+            (self._lower_bounds, self._upper_bounds) = self._process_bounds(
+                bounds, self._solution_dim, archive.dtypes["solution"]
+            )
+        else:
+            # Covers both `use_lower_upper` and the default case where no bounds are
+            # passed in.
+            self._lower_bounds = (
+                np.full(solution_dim, -np.inf, dtype=archive.dtypes["solution"])
+                if lower_bounds is None
+                else np.asarray(lower_bounds, dtype=archive.dtypes["solution"])
+            )
+            self._upper_bounds = (
+                np.full(solution_dim, np.inf, dtype=archive.dtypes["solution"])
+                if upper_bounds is None
+                else np.asarray(upper_bounds, dtype=archive.dtypes["solution"])
+            )
+            check_shape(
+                self._lower_bounds, "lower_bounds", self._solution_dim, "solution_dim"
+            )
+            check_shape(
+                self._upper_bounds, "upper_bounds", self._solution_dim, "solution_dim"
+            )
+
+    @staticmethod
+    def _process_bounds(
+        bounds: Collection[tuple[None | Float, None | Float]],
+        solution_dim: Int,
+        dtype: DTypeLike,
+    ) -> tuple[np.ndarray, np.ndarray]:
+        """Processes the input bounds.
+
+        Returns:
+            tuple: Two arrays containing all the lower bounds and all the upper bounds.
+
+        Raises:
+            ValueError: There is an error in the bounds configuration.
+        """
+        lower_bounds = np.full(solution_dim, -np.inf, dtype=dtype)
+        upper_bounds = np.full(solution_dim, np.inf, dtype=dtype)
+
+        if bounds is None:
+            return lower_bounds, upper_bounds
+
+        # Handle array-like bounds.
+        if len(bounds) != solution_dim:
+            raise ValueError(
+                "If it is an array-like, bounds must have length solution_dim"
+            )
+        for idx, bnd in enumerate(bounds):
+            if bnd is None:
+                continue  # Bounds already default to -inf and inf.
+            if len(bnd) != 2:
+                raise ValueError("All entries of bounds must be length 2")
+            lower_bounds[idx] = -np.inf if bnd[0] is None else bnd[0]
+            upper_bounds[idx] = np.inf if bnd[1] is None else bnd[1]
+        return lower_bounds, upper_bounds
 
     @property
     def archive(self) -> ArchiveBase:

--- a/ribs/emitters/_emitter_base.py
+++ b/ribs/emitters/_emitter_base.py
@@ -65,7 +65,7 @@ class EmitterBase(ABC):
                 "either specify bounds or specify lower_bounds/upper_bounds."
             )
         elif use_bounds:
-            (self._lower_bounds, self._upper_bounds) = self._process_bounds(
+            self._lower_bounds, self._upper_bounds = self._process_bounds(
                 bounds, self._solution_dim, archive.dtypes["solution"]
             )
         else:

--- a/ribs/emitters/_evolution_strategy_emitter.py
+++ b/ribs/emitters/_evolution_strategy_emitter.py
@@ -3,13 +3,13 @@
 from __future__ import annotations
 
 import numbers
-from collections.abc import Callable
+from collections.abc import Callable, Collection
 from typing import Literal
 
 import numpy as np
 from numpy.typing import ArrayLike
 
-from ribs._utils import check_shape, deprecate_bounds, validate_batch
+from ribs._utils import check_shape, validate_batch
 from ribs.archives import ArchiveBase
 from ribs.emitters._emitter_base import EmitterBase
 from ribs.emitters.opt import EvolutionStrategyBase, _get_es
@@ -55,11 +55,19 @@ class EvolutionStrategyEmitter(EmitterBase):
             iteration is a call to :meth:`tell`. With "basic", only the default CMA-ES
             convergence rules will be used, while with "no_improvement", the emitter
             will restart when none of the proposed solutions were added to the archive.
-        lower_bounds: Lower bounds of the solution space. Pass None to indicate there
-            are no bounds (i.e., bounds are set to -inf).
-        upper_bounds: Upper bounds of the solution space. Pass None to indicate there
-            are no bounds (i.e., bounds are set to inf).
-        bounds: DEPRECATED.
+        bounds: Bounds of the solution space. Pass None to indicate there are no bounds.
+            Alternatively, pass an array-like to specify the bounds for each dim. Each
+            element in this array-like can be None to indicate no bound, or a tuple of
+            ``(lower_bound, upper_bound)``, where ``lower_bound`` or ``upper_bound`` may
+            be None to indicate no bound. Unbounded upper bounds are set to +inf, and
+            unbounded lower bounds are set to -inf.
+        lower_bounds: Instead of specifying ``bounds``, ``lower_bounds`` and
+            ``upper_bounds`` may be specified. This is useful if, for instance,
+            solutions are multi-dimensional. Here, pass None to indicate there are no
+            bounds (i.e., bounds are set to -inf), or pass an array specifying the lower
+            bounds of the solution space.
+        upper_bounds: Upper bounds of the solution space; see ``lower_bounds`` above.
+            Pass None to indicate there are no bounds (i.e., bounds are set to inf).
         batch_size: Number of solutions to return in :meth:`ask`. If not passed in, a
             batch size will be automatically calculated using the default CMA-ES rules.
         seed: Value to seed the random number generator. Set to None to avoid a fixed
@@ -82,18 +90,17 @@ class EvolutionStrategyEmitter(EmitterBase):
         es_kwargs: dict | None = None,
         selection_rule: Literal["mu", "filter"] = "filter",
         restart_rule: Literal["no_improvement", "basic"] | int = "no_improvement",
+        bounds: Collection[tuple[None | Float, None | Float]] | None = None,
         lower_bounds: ArrayLike | None = None,
         upper_bounds: ArrayLike | None = None,
-        bounds: None = None,
         batch_size: Int | None = None,
         seed: Int | None = None,
     ) -> None:
-        deprecate_bounds(bounds)
-
         EmitterBase.__init__(
             self,
             archive,
             solution_dim=archive.solution_dim,
+            bounds=bounds,
             lower_bounds=lower_bounds,
             upper_bounds=upper_bounds,
         )

--- a/ribs/emitters/_gaussian_emitter.py
+++ b/ribs/emitters/_gaussian_emitter.py
@@ -3,11 +3,12 @@
 from __future__ import annotations
 
 import numbers
+from collections.abc import Collection
 
 import numpy as np
 from numpy.typing import ArrayLike
 
-from ribs._utils import check_batch_shape, check_shape, deprecate_bounds
+from ribs._utils import check_batch_shape, check_shape
 from ribs.archives import ArchiveBase
 from ribs.emitters._emitter_base import EmitterBase
 from ribs.typing import Float, Int
@@ -33,11 +34,19 @@ class GaussianEmitter(EmitterBase):
             archive is empty. If this argument is None, then solutions will be sampled
             from a Gaussian distribution centered at ``x0`` with standard deviation
             ``sigma``.
-        lower_bounds: Lower bounds of the solution space. Pass None to indicate there
-            are no bounds (i.e., bounds are set to -inf).
-        upper_bounds: Upper bounds of the solution space. Pass None to indicate there
-            are no bounds (i.e., bounds are set to inf).
-        bounds: DEPRECATED.
+        bounds: Bounds of the solution space. Pass None to indicate there are no bounds.
+            Alternatively, pass an array-like to specify the bounds for each dim. Each
+            element in this array-like can be None to indicate no bound, or a tuple of
+            ``(lower_bound, upper_bound)``, where ``lower_bound`` or ``upper_bound`` may
+            be None to indicate no bound. Unbounded upper bounds are set to +inf, and
+            unbounded lower bounds are set to -inf.
+        lower_bounds: Instead of specifying ``bounds``, ``lower_bounds`` and
+            ``upper_bounds`` may be specified. This is useful if, for instance,
+            solutions are multi-dimensional. Here, pass None to indicate there are no
+            bounds (i.e., bounds are set to -inf), or pass an array specifying the lower
+            bounds of the solution space.
+        upper_bounds: Upper bounds of the solution space; see ``lower_bounds`` above.
+            Pass None to indicate there are no bounds (i.e., bounds are set to inf).
         batch_size: Number of solutions to return in :meth:`ask`.
         seed: Value to seed the random number generator. Set to None to avoid a fixed
             seed.
@@ -54,18 +63,17 @@ class GaussianEmitter(EmitterBase):
         sigma: Float | ArrayLike,
         x0: ArrayLike | None = None,
         initial_solutions: ArrayLike | None = None,
+        bounds: Collection[tuple[None | Float, None | Float]] | None = None,
         lower_bounds: ArrayLike | None = None,
         upper_bounds: ArrayLike | None = None,
-        bounds: None = None,
         batch_size: Int = 64,
         seed: Int | None = None,
     ) -> None:
-        deprecate_bounds(bounds)
-
         EmitterBase.__init__(
             self,
             archive,
             solution_dim=archive.solution_dim,
+            bounds=bounds,
             lower_bounds=lower_bounds,
             upper_bounds=upper_bounds,
         )

--- a/ribs/emitters/_genetic_algorithm_emitter.py
+++ b/ribs/emitters/_genetic_algorithm_emitter.py
@@ -2,14 +2,16 @@
 
 from __future__ import annotations
 
+from collections.abc import Collection
+
 import numpy as np
 from numpy.typing import ArrayLike
 
-from ribs._utils import check_batch_shape, check_shape, deprecate_bounds
+from ribs._utils import check_batch_shape, check_shape
 from ribs.archives import ArchiveBase
 from ribs.emitters._emitter_base import EmitterBase
 from ribs.emitters.operators import _get_op
-from ribs.typing import Int
+from ribs.typing import Float, Int
 
 
 class GeneticAlgorithmEmitter(EmitterBase):
@@ -28,11 +30,19 @@ class GeneticAlgorithmEmitter(EmitterBase):
         x0: Initial solution.
         initial_solutions: An (n, solution_dim) array of solutions to be used when the
             archive is empty, in lieu of ``x0``.
-        lower_bounds: Lower bounds of the solution space. Pass None to indicate there
-            are no bounds (i.e., bounds are set to -inf).
-        upper_bounds: Upper bounds of the solution space. Pass None to indicate there
-            are no bounds (i.e., bounds are set to inf).
-        bounds: DEPRECATED.
+        bounds: Bounds of the solution space. Pass None to indicate there are no bounds.
+            Alternatively, pass an array-like to specify the bounds for each dim. Each
+            element in this array-like can be None to indicate no bound, or a tuple of
+            ``(lower_bound, upper_bound)``, where ``lower_bound`` or ``upper_bound`` may
+            be None to indicate no bound. Unbounded upper bounds are set to +inf, and
+            unbounded lower bounds are set to -inf.
+        lower_bounds: Instead of specifying ``bounds``, ``lower_bounds`` and
+            ``upper_bounds`` may be specified. This is useful if, for instance,
+            solutions are multi-dimensional. Here, pass None to indicate there are no
+            bounds (i.e., bounds are set to -inf), or pass an array specifying the lower
+            bounds of the solution space.
+        upper_bounds: Upper bounds of the solution space; see ``lower_bounds`` above.
+            Pass None to indicate there are no bounds (i.e., bounds are set to inf).
         batch_size: Number of solutions to return in :meth:`ask`.
         seed: Value to seed the random number generator. Set to None to avoid a fixed
             seed.
@@ -50,18 +60,17 @@ class GeneticAlgorithmEmitter(EmitterBase):
         operator_kwargs: dict | None = None,
         x0: ArrayLike | None = None,
         initial_solutions: ArrayLike | None = None,
+        bounds: Collection[tuple[None | Float, None | Float]] | None = None,
         lower_bounds: ArrayLike | None = None,
         upper_bounds: ArrayLike | None = None,
-        bounds: None = None,
         batch_size: Int = 64,
         seed: Int | None = None,
     ) -> None:
-        deprecate_bounds(bounds)
-
         EmitterBase.__init__(
             self,
             archive,
             solution_dim=archive.solution_dim,
+            bounds=bounds,
             lower_bounds=lower_bounds,
             upper_bounds=upper_bounds,
         )

--- a/ribs/emitters/_gradient_arborescence_emitter.py
+++ b/ribs/emitters/_gradient_arborescence_emitter.py
@@ -3,13 +3,13 @@
 from __future__ import annotations
 
 import numbers
-from collections.abc import Callable
+from collections.abc import Callable, Collection
 from typing import Literal
 
 import numpy as np
 from numpy.typing import ArrayLike
 
-from ribs._utils import check_shape, deprecate_bounds, validate_batch
+from ribs._utils import check_shape, validate_batch
 from ribs.archives import ArchiveBase
 from ribs.emitters._emitter_base import EmitterBase
 from ribs.emitters.opt import (
@@ -100,6 +100,10 @@ class GradientArborescenceEmitter(EmitterBase):
             arguments allowed by each optimizer.
         normalize_grad: If true (default), then gradient infomation will be normalized.
             Otherwise, it will not be normalized.
+        bounds: This argument may be used for providing solution space bounds in the
+            future. This emitter does not currently support solution space bounds, as
+            bounding solutions for DQD algorithms such as CMA-MEGA is an open problem.
+            Hence, this argument must be set to None.
         lower_bounds: This argument may be used for providing solution space bounds in
             the future. This emitter does not currently support solution space bounds,
             as bounding solutions for DQD algorithms such as CMA-MEGA is an open
@@ -108,7 +112,6 @@ class GradientArborescenceEmitter(EmitterBase):
             the future. This emitter does not currently support solution space bounds,
             as bounding solutions for DQD algorithms such as CMA-MEGA is an open
             problem. Hence, this argument must be set to None.
-        bounds: DEPRECATED.
         batch_size: Number of solutions to return in :meth:`ask`. If not passed in, a
             batch size will be automatically calculated using the default CMA-ES rules.
             This **does not** account for the **one** solution returned by
@@ -142,18 +145,16 @@ class GradientArborescenceEmitter(EmitterBase):
         es: Callable[..., EvolutionStrategyBase] | str = "cma_es",
         es_kwargs: dict | None = None,
         normalize_grad: bool = True,
+        bounds: Collection[tuple[None | Float, None | Float]] | None = None,
         lower_bounds: ArrayLike | None = None,
         upper_bounds: ArrayLike | None = None,
-        bounds: None = None,
         batch_size: Int | None = None,
         epsilon: Float = 1e-8,
         seed: Int | None = None,
     ) -> None:
-        deprecate_bounds(bounds)
-
-        if lower_bounds is not None or upper_bounds is not None:
+        if bounds is not None or lower_bounds is not None or upper_bounds is not None:
             raise ValueError(
-                "lower_bounds and upper_bounds must be set to None. "
+                "bounds, lower_bounds, and upper_bounds must be set to None. "
                 "The GradientArborescenceEmitter does not currently support solution "
                 "space bounds, as bounding solutions for DQD algorithms such as "
                 "CMA-MEGA is an open problem."
@@ -163,6 +164,7 @@ class GradientArborescenceEmitter(EmitterBase):
             self,
             archive,
             solution_dim=archive.solution_dim,
+            bounds=bounds,
             lower_bounds=lower_bounds,
             upper_bounds=upper_bounds,
         )

--- a/ribs/emitters/_gradient_operator_emitter.py
+++ b/ribs/emitters/_gradient_operator_emitter.py
@@ -2,12 +2,13 @@
 
 from __future__ import annotations
 
+from collections.abc import Collection
 from typing import Literal
 
 import numpy as np
 from numpy.typing import ArrayLike
 
-from ribs._utils import check_batch_shape, check_shape, deprecate_bounds, validate_batch
+from ribs._utils import check_batch_shape, check_shape, validate_batch
 from ribs.archives import ArchiveBase
 from ribs.emitters._emitter_base import EmitterBase
 from ribs.typing import BatchData, Float, Int
@@ -81,11 +82,19 @@ class GradientOperatorEmitter(EmitterBase):
             Pass this parameter to configure that epsilon.
         operator_type: Either 'isotropic' or 'iso_line_dd' to mark the operator type for
             intermediate operations. Defaults to 'isotropic'.
-        lower_bounds: Lower bounds of the solution space. Pass None to indicate there
-            are no bounds (i.e., bounds are set to -inf).
-        upper_bounds: Upper bounds of the solution space. Pass None to indicate there
-            are no bounds (i.e., bounds are set to inf).
-        bounds: DEPRECATED.
+        bounds: Bounds of the solution space. Pass None to indicate there are no bounds.
+            Alternatively, pass an array-like to specify the bounds for each dim. Each
+            element in this array-like can be None to indicate no bound, or a tuple of
+            ``(lower_bound, upper_bound)``, where ``lower_bound`` or ``upper_bound`` may
+            be None to indicate no bound. Unbounded upper bounds are set to +inf, and
+            unbounded lower bounds are set to -inf.
+        lower_bounds: Instead of specifying ``bounds``, ``lower_bounds`` and
+            ``upper_bounds`` may be specified. This is useful if, for instance,
+            solutions are multi-dimensional. Here, pass None to indicate there are no
+            bounds (i.e., bounds are set to -inf), or pass an array specifying the lower
+            bounds of the solution space.
+        upper_bounds: Upper bounds of the solution space; see ``lower_bounds`` above.
+            Pass None to indicate there are no bounds (i.e., bounds are set to inf).
         batch_size: Number of solutions to return in :meth:`ask`.
         seed: Value to seed the random number generator. Set to None to avoid a fixed
             seed.
@@ -107,18 +116,17 @@ class GradientOperatorEmitter(EmitterBase):
         normalize_grad: bool = False,
         epsilon: Float = 1e-8,
         operator_type: Literal["isotropic", "iso_line_dd"] = "isotropic",
+        bounds: Collection[tuple[None | Float, None | Float]] | None = None,
         lower_bounds: ArrayLike | None = None,
         upper_bounds: ArrayLike | None = None,
-        bounds: None = None,
         batch_size: Int = 64,
         seed: Int | None = None,
     ) -> None:
-        deprecate_bounds(bounds)
-
         EmitterBase.__init__(
             self,
             archive=archive,
             solution_dim=archive.solution_dim,
+            bounds=bounds,
             lower_bounds=lower_bounds,
             upper_bounds=upper_bounds,
         )

--- a/ribs/emitters/_iso_line_emitter.py
+++ b/ribs/emitters/_iso_line_emitter.py
@@ -3,11 +3,12 @@
 from __future__ import annotations
 
 import numbers
+from collections.abc import Collection
 
 import numpy as np
 from numpy.typing import ArrayLike
 
-from ribs._utils import check_batch_shape, check_shape, deprecate_bounds
+from ribs._utils import check_batch_shape, check_shape
 from ribs.archives import ArchiveBase
 from ribs.emitters._emitter_base import EmitterBase
 from ribs.typing import Float, Int
@@ -43,11 +44,19 @@ class IsoLineEmitter(EmitterBase):
             archive is empty. If this argument is None, then solutions will be sampled
             from a Gaussian distribution centered at ``x0`` with standard deviation
             ``iso_sigma``.
-        lower_bounds: Lower bounds of the solution space. Pass None to indicate there
-            are no bounds (i.e., bounds are set to -inf).
-        upper_bounds: Upper bounds of the solution space. Pass None to indicate there
-            are no bounds (i.e., bounds are set to inf).
-        bounds: DEPRECATED.
+        bounds: Bounds of the solution space. Pass None to indicate there are no bounds.
+            Alternatively, pass an array-like to specify the bounds for each dim. Each
+            element in this array-like can be None to indicate no bound, or a tuple of
+            ``(lower_bound, upper_bound)``, where ``lower_bound`` or ``upper_bound`` may
+            be None to indicate no bound. Unbounded upper bounds are set to +inf, and
+            unbounded lower bounds are set to -inf.
+        lower_bounds: Instead of specifying ``bounds``, ``lower_bounds`` and
+            ``upper_bounds`` may be specified. This is useful if, for instance,
+            solutions are multi-dimensional. Here, pass None to indicate there are no
+            bounds (i.e., bounds are set to -inf), or pass an array specifying the lower
+            bounds of the solution space.
+        upper_bounds: Upper bounds of the solution space; see ``lower_bounds`` above.
+            Pass None to indicate there are no bounds (i.e., bounds are set to inf).
         batch_size: Number of solutions to return in :meth:`ask`.
         seed: Value to seed the random number generator. Set to None to avoid a fixed
             seed.
@@ -65,18 +74,17 @@ class IsoLineEmitter(EmitterBase):
         line_sigma: Float = 0.2,
         x0: ArrayLike | None = None,
         initial_solutions: ArrayLike | None = None,
+        bounds: Collection[tuple[None | Float, None | Float]] | None = None,
         lower_bounds: ArrayLike | None = None,
         upper_bounds: ArrayLike | None = None,
-        bounds: None = None,
         batch_size: Int = 64,
         seed: Int | None = None,
     ) -> None:
-        deprecate_bounds(bounds)
-
         EmitterBase.__init__(
             self,
             archive,
             solution_dim=archive.solution_dim,
+            bounds=bounds,
             lower_bounds=lower_bounds,
             upper_bounds=upper_bounds,
         )

--- a/tests/emitters/emitter_base_test.py
+++ b/tests/emitters/emitter_base_test.py
@@ -207,6 +207,21 @@ def test_default_bounds_correct(archive_fixture):
     assert (emitter.upper_bounds == np.full(archive.solution_dim, np.inf)).all()
 
 
+def test_cannot_specify_both_bounds(archive_fixture):
+    archive, x0 = archive_fixture
+    with pytest.raises(
+        ValueError, match="Cannot specify both bounds and lower_bounds/upper_bounds.*"
+    ):
+        GaussianEmitter(
+            archive,
+            sigma=1,
+            x0=x0,
+            bounds=[(-1, 1)] * len(x0),
+            lower_bounds=[-1] * len(x0),
+            upper_bounds=[1] * len(x0),
+        )
+
+
 @pytest.mark.parametrize("bound_type", ["bounds", "lower_upper"])
 def test_array_bound_correct(archive_fixture, bound_type):
     archive, x0 = archive_fixture

--- a/tests/emitters/emitter_base_test.py
+++ b/tests/emitters/emitter_base_test.py
@@ -207,18 +207,27 @@ def test_default_bounds_correct(archive_fixture):
     assert (emitter.upper_bounds == np.full(archive.solution_dim, np.inf)).all()
 
 
-def test_array_bound_correct(archive_fixture):
+@pytest.mark.parametrize("bound_type", ["bounds", "lower_upper"])
+def test_array_bound_correct(archive_fixture, bound_type):
     archive, x0 = archive_fixture
     lower_bounds = np.concatenate((-np.arange(len(x0) - 1), [-np.inf]))
     upper_bounds = np.concatenate((np.arange(len(x0) - 1), [np.inf]))
 
-    emitter = GaussianEmitter(
-        archive,
-        sigma=1,
-        x0=x0,
-        lower_bounds=lower_bounds,
-        upper_bounds=upper_bounds,
-    )
+    if bound_type == "bounds":
+        emitter = GaussianEmitter(
+            archive,
+            sigma=1,
+            x0=x0,
+            bounds=list(zip(lower_bounds, upper_bounds)),
+        )
+    else:
+        emitter = GaussianEmitter(
+            archive,
+            sigma=1,
+            x0=x0,
+            lower_bounds=lower_bounds,
+            upper_bounds=upper_bounds,
+        )
 
     assert (emitter.lower_bounds == lower_bounds).all()
     assert (emitter.upper_bounds == upper_bounds).all()
@@ -240,30 +249,44 @@ def test_multidim_array_bound_correct():
     assert (emitter.upper_bounds == upper_bounds).all()
 
 
-def test_long_array_bound_fails(archive_fixture):
+@pytest.mark.parametrize("bound_type", ["bounds", "lower_upper"])
+def test_long_array_bound_fails(archive_fixture, bound_type):
     archive, x0 = archive_fixture
 
-    with pytest.raises(
-        ValueError, match="Expected lower_bounds to be an array with shape .*"
-    ):
-        GaussianEmitter(
-            archive,
-            sigma=1,
-            x0=x0,
-            # More bounds than solution dims.
-            lower_bounds=[-1] * (len(x0) + 1),
-            upper_bounds=[1] * len(x0),
-        )
-    with pytest.raises(
-        ValueError, match="Expected upper_bounds to be an array with shape .*"
-    ):
-        GaussianEmitter(
-            archive,
-            sigma=1,
-            x0=x0,
-            lower_bounds=[1] * len(x0),
-            upper_bounds=[-1] * (len(x0) + 1),
-        )
+    if bound_type == "bounds":
+        with pytest.raises(
+            ValueError,
+            match="If it is an array-like, bounds must have length solution_dim",
+        ):
+            GaussianEmitter(
+                archive,
+                sigma=1,
+                x0=x0,
+                # More bounds than solution dims.
+                bounds=[(-1, 1)] * (len(x0) + 1),
+            )
+    else:
+        with pytest.raises(
+            ValueError, match="Expected lower_bounds to be an array with shape .*"
+        ):
+            GaussianEmitter(
+                archive,
+                sigma=1,
+                x0=x0,
+                # More bounds than solution dims.
+                lower_bounds=[-1] * (len(x0) + 1),
+                upper_bounds=[1] * len(x0),
+            )
+        with pytest.raises(
+            ValueError, match="Expected upper_bounds to be an array with shape .*"
+        ):
+            GaussianEmitter(
+                archive,
+                sigma=1,
+                x0=x0,
+                lower_bounds=[1] * len(x0),
+                upper_bounds=[-1] * (len(x0) + 1),
+            )
 
 
 def test_wrong_bound_shape(archive_fixture):

--- a/tests/emitters/evolution_strategy_emitter_test.py
+++ b/tests/emitters/evolution_strategy_emitter_test.py
@@ -106,9 +106,12 @@ if __name__ == "__main__":
         archive,
         x0=np.zeros(31),
         sigma0=1.0,
-        lower_bounds=[0] * 31,
-        upper_bounds=[1] * 31,
+        bounds=[(0, 1)] * 31,
         es="cma_es",
+        # es="sep_cma_es",
+        # es="lm_ma_es",
+        # es="openai_es",
+        # es_kwargs={"mirror_sampling": False},
     )
     #  emitter = EvolutionStrategyEmitter(
     #      archive,
@@ -116,24 +119,11 @@ if __name__ == "__main__":
     #      sigma0=1.0,
     #      lower_bounds=[0] * 31,
     #      upper_bounds=[1] * 31,
-    #      es="sep_cma_es",
-    #  )
-    #  emitter = EvolutionStrategyEmitter(
-    #      archive,
-    #      x0=np.zeros(31),
-    #      sigma0=1.0,
-    #      lower_bounds=[0] * 31,
-    #      upper_bounds=[1] * 31,
-    #      es="lm_ma_es",
-    #  )
-    #  emitter = EvolutionStrategyEmitter(
-    #      archive,
-    #      x0=np.zeros(31),
-    #      sigma0=1.0,
-    #      lower_bounds=[0] * 31,
-    #      upper_bounds=[1] * 31,
-    #      es="openai_es",
-    #      es_kwargs={"mirror_sampling": False},
+    #      es="cma_es",
+    #      # es="sep_cma_es",
+    #      # es="lm_ma_es",
+    #      # es="openai_es",
+    #      # es_kwargs={"mirror_sampling": False},
     #  )
 
     emitter.ask()

--- a/tests/emitters/gaussian_emitter_test.py
+++ b/tests/emitters/gaussian_emitter_test.py
@@ -49,28 +49,46 @@ def test_both_x0_and_initial_solutions_provided(archive_fixture):
         GaussianEmitter(archive, sigma=1.0, x0=x0, initial_solutions=initial_solutions)
 
 
-def test_upper_bounds_enforced(archive_fixture):
+@pytest.mark.parametrize("bound_type", ["bounds", "lower_upper"])
+def test_upper_bounds_enforced(archive_fixture, bound_type):
     archive, _ = archive_fixture
-    emitter = GaussianEmitter(
-        archive,
-        sigma=0,
-        x0=[2, 2, 2, 2],
-        lower_bounds=[-1, -1, -1, -1],
-        upper_bounds=[1, 1, 1, 1],
-    )
+    if bound_type == "bounds":
+        emitter = GaussianEmitter(
+            archive,
+            sigma=0,
+            x0=[2, 2, 2, 2],
+            bounds=[(-1, 1)] * 4,
+        )
+    else:
+        emitter = GaussianEmitter(
+            archive,
+            sigma=0,
+            x0=[2, 2, 2, 2],
+            lower_bounds=[-1, -1, -1, -1],
+            upper_bounds=[1, 1, 1, 1],
+        )
     sols = emitter.ask()
     assert np.all(sols <= 1)
 
 
-def test_lower_bounds_enforced(archive_fixture):
+@pytest.mark.parametrize("bound_type", ["bounds", "lower_upper"])
+def test_lower_bounds_enforced(archive_fixture, bound_type):
     archive, _ = archive_fixture
-    emitter = GaussianEmitter(
-        archive,
-        sigma=0,
-        x0=[-2, -2, -2, -2],
-        lower_bounds=[-1, -1, -1, -1],
-        upper_bounds=[1, 1, 1, 1],
-    )
+    if bound_type == "bounds":
+        emitter = GaussianEmitter(
+            archive,
+            sigma=0,
+            x0=[2, 2, 2, 2],
+            bounds=[(-1, 1)] * 4,
+        )
+    else:
+        emitter = GaussianEmitter(
+            archive,
+            sigma=0,
+            x0=[2, 2, 2, 2],
+            lower_bounds=[-1, -1, -1, -1],
+            upper_bounds=[1, 1, 1, 1],
+        )
     sols = emitter.ask()
     assert np.all(sols >= -1)
 

--- a/tests/emitters/genetic_algorithm_emitter_test.py
+++ b/tests/emitters/genetic_algorithm_emitter_test.py
@@ -82,38 +82,66 @@ def test_both_x0_and_initial_solutions_provided(archive_fixture):
         )
 
 
-def test_upper_bounds_enforced(archive_fixture):
+@pytest.mark.parametrize("bound_type", ["bounds", "lower_upper"])
+def test_upper_bounds_enforced(archive_fixture, bound_type):
     archive, _ = archive_fixture
-    emitter = GeneticAlgorithmEmitter(
-        archive,
-        batch_size=36,
-        x0=[2, 2, 2, 2],
-        lower_bounds=[-1, -1, -1, -1],
-        upper_bounds=[1, 1, 1, 1],
-        operator="isoline",
-        operator_kwargs={
-            "iso_sigma": 0.1,
-            "line_sigma": 0.2,
-        },
-    )
+    if bound_type == "bounds":
+        emitter = GeneticAlgorithmEmitter(
+            archive,
+            batch_size=36,
+            x0=[2, 2, 2, 2],
+            bounds=[(-1, 1)] * 4,
+            operator="isoline",
+            operator_kwargs={
+                "iso_sigma": 0.1,
+                "line_sigma": 0.2,
+            },
+        )
+    else:
+        emitter = GeneticAlgorithmEmitter(
+            archive,
+            batch_size=36,
+            x0=[2, 2, 2, 2],
+            lower_bounds=[-1, -1, -1, -1],
+            upper_bounds=[1, 1, 1, 1],
+            operator="isoline",
+            operator_kwargs={
+                "iso_sigma": 0.1,
+                "line_sigma": 0.2,
+            },
+        )
     sols = emitter.ask()
     assert np.all(sols <= 1)
 
 
-def test_lower_bounds_enforced(archive_fixture):
+@pytest.mark.parametrize("bound_type", ["bounds", "lower_upper"])
+def test_lower_bounds_enforced(archive_fixture, bound_type):
     archive, _ = archive_fixture
-    emitter = GeneticAlgorithmEmitter(
-        archive,
-        batch_size=36,
-        x0=[-2, -2, -2, -2],
-        lower_bounds=[-1, -1, -1, -1],
-        upper_bounds=[1, 1, 1, 1],
-        operator="isoline",
-        operator_kwargs={
-            "iso_sigma": 0.1,
-            "line_sigma": 0.2,
-        },
-    )
+    if bound_type == "bounds":
+        emitter = GeneticAlgorithmEmitter(
+            archive,
+            batch_size=36,
+            x0=[2, 2, 2, 2],
+            bounds=[(-1, 1)] * 4,
+            operator="isoline",
+            operator_kwargs={
+                "iso_sigma": 0.1,
+                "line_sigma": 0.2,
+            },
+        )
+    else:
+        emitter = GeneticAlgorithmEmitter(
+            archive,
+            batch_size=36,
+            x0=[2, 2, 2, 2],
+            lower_bounds=[-1, -1, -1, -1],
+            upper_bounds=[1, 1, 1, 1],
+            operator="isoline",
+            operator_kwargs={
+                "iso_sigma": 0.1,
+                "line_sigma": 0.2,
+            },
+        )
     sols = emitter.ask()
     assert np.all(sols >= -1)
 

--- a/tests/emitters/gradient_arborescence_emitter_test.py
+++ b/tests/emitters/gradient_arborescence_emitter_test.py
@@ -43,9 +43,7 @@ def test_bounds_must_be_none():
     batch_size = 1
     archive = GridArchive(solution_dim=1, dims=[10], ranges=[(-1.0, 1.0)])
 
-    with pytest.raises(
-        ValueError, match="lower_bounds and upper_bounds must be set to None.*"
-    ):
+    with pytest.raises(ValueError, match=".* must be set to None.*"):
         GradientArborescenceEmitter(
             archive,
             x0=np.array([0]),

--- a/tests/emitters/gradient_operator_emitter_test.py
+++ b/tests/emitters/gradient_operator_emitter_test.py
@@ -75,32 +75,52 @@ def test_both_x0_and_initial_solutions_provided(archive_fixture):
         )
 
 
-def test_upper_bounds_enforced(archive_fixture):
+@pytest.mark.parametrize("bound_type", ["bounds", "lower_upper"])
+def test_upper_bounds_enforced(archive_fixture, bound_type):
     archive, _ = archive_fixture
     sigma_g = 0.05
-    emitter = GradientOperatorEmitter(
-        archive,
-        sigma=0,
-        sigma_g=sigma_g,
-        x0=[2, 2, 2, 2],
-        lower_bounds=[-1, -1, -1, -1],
-        upper_bounds=[1, 1, 1, 1],
-    )
+    if bound_type == "bounds":
+        emitter = GradientOperatorEmitter(
+            archive,
+            sigma=0,
+            sigma_g=sigma_g,
+            x0=[2, 2, 2, 2],
+            bounds=[(-1, 1)] * 4,
+        )
+    else:
+        emitter = GradientOperatorEmitter(
+            archive,
+            sigma=0,
+            sigma_g=sigma_g,
+            x0=[2, 2, 2, 2],
+            lower_bounds=[-1, -1, -1, -1],
+            upper_bounds=[1, 1, 1, 1],
+        )
     sols = emitter.ask_dqd()
     assert np.all(sols <= 1)
 
 
-def test_lower_bounds_enforced(archive_fixture):
+@pytest.mark.parametrize("bound_type", ["bounds", "lower_upper"])
+def test_lower_bounds_enforced(archive_fixture, bound_type):
     archive, _ = archive_fixture
     sigma_g = 0.05
-    emitter = GradientOperatorEmitter(
-        archive,
-        sigma=0,
-        sigma_g=sigma_g,
-        x0=[-2, -2, -2, -2],
-        lower_bounds=[-1, -1, -1, -1],
-        upper_bounds=[1, 1, 1, 1],
-    )
+    if bound_type == "bounds":
+        emitter = GradientOperatorEmitter(
+            archive,
+            sigma=0,
+            sigma_g=sigma_g,
+            x0=[2, 2, 2, 2],
+            bounds=[(-1, 1)] * 4,
+        )
+    else:
+        emitter = GradientOperatorEmitter(
+            archive,
+            sigma=0,
+            sigma_g=sigma_g,
+            x0=[2, 2, 2, 2],
+            lower_bounds=[-1, -1, -1, -1],
+            upper_bounds=[1, 1, 1, 1],
+        )
     sols = emitter.ask_dqd()
     assert np.all(sols >= -1)
 

--- a/tests/emitters/iso_line_emitter_test.py
+++ b/tests/emitters/iso_line_emitter_test.py
@@ -57,30 +57,50 @@ def test_both_x0_and_initial_solutions_provided(archive_fixture):
         IsoLineEmitter(archive, x0=x0, initial_solutions=initial_solutions)
 
 
-def test_upper_bounds_enforced(archive_fixture):
+@pytest.mark.parametrize("bound_type", ["bounds", "lower_upper"])
+def test_upper_bounds_enforced(archive_fixture, bound_type):
     archive, _ = archive_fixture
-    emitter = IsoLineEmitter(
-        archive,
-        x0=[2, 2, 2, 2],
-        iso_sigma=0,
-        line_sigma=0,
-        lower_bounds=[-1, -1, -1, -1],
-        upper_bounds=[1, 1, 1, 1],
-    )
+    if bound_type == "bounds":
+        emitter = IsoLineEmitter(
+            archive,
+            x0=[2, 2, 2, 2],
+            iso_sigma=0,
+            line_sigma=0,
+            bounds=[(-1, 1)] * 4,
+        )
+    else:
+        emitter = IsoLineEmitter(
+            archive,
+            x0=[2, 2, 2, 2],
+            iso_sigma=0,
+            line_sigma=0,
+            lower_bounds=[-1, -1, -1, -1],
+            upper_bounds=[1, 1, 1, 1],
+        )
     sols = emitter.ask()
     assert np.all(sols <= 1)
 
 
-def test_lower_bounds_enforced(archive_fixture):
+@pytest.mark.parametrize("bound_type", ["bounds", "lower_upper"])
+def test_lower_bounds_enforced(archive_fixture, bound_type):
     archive, _ = archive_fixture
-    emitter = IsoLineEmitter(
-        archive,
-        x0=[-2, -2, -2, -2],
-        iso_sigma=0,
-        line_sigma=0,
-        lower_bounds=[-1, -1, -1, -1],
-        upper_bounds=[1, 1, 1, 1],
-    )
+    if bound_type == "bounds":
+        emitter = IsoLineEmitter(
+            archive,
+            x0=[2, 2, 2, 2],
+            iso_sigma=0,
+            line_sigma=0,
+            bounds=[(-1, 1)] * 4,
+        )
+    else:
+        emitter = IsoLineEmitter(
+            archive,
+            x0=[2, 2, 2, 2],
+            iso_sigma=0,
+            line_sigma=0,
+            lower_bounds=[-1, -1, -1, -1],
+            upper_bounds=[1, 1, 1, 1],
+        )
     sols = emitter.ask()
     assert np.all(sols >= -1)
 

--- a/tests/emitters_pymoo/bayesopt_emitter_test.py
+++ b/tests/emitters_pymoo/bayesopt_emitter_test.py
@@ -14,21 +14,31 @@ def archive_fixture():
     return archive
 
 
-@pytest.fixture
-def full_archive_emitter_fixture(archive_fixture):
+@pytest.fixture(params=["bounds", "lower_upper"])
+def full_archive_emitter_fixture(archive_fixture, request):
     """Returns a BayesianOptimizationEmitter that has filled its archive to
     100% coverage."""
     rng = np.random.default_rng()
 
-    emitter = BayesianOptimizationEmitter(
-        archive=archive_fixture,
-        lower_bounds=[-1, -1, -1, -1],
-        upper_bounds=[1, 1, 1, 1],
-        upscale_schedule=[[2, 2], [4, 4]],
-        num_initial_samples=1,
-        seed=0,
-        batch_size=1,
-    )
+    if request.param == "bounds":
+        emitter = BayesianOptimizationEmitter(
+            archive=archive_fixture,
+            bounds=[(-1, 1)] * 4,
+            upscale_schedule=[[2, 2], [4, 4]],
+            num_initial_samples=1,
+            seed=0,
+            batch_size=1,
+        )
+    else:
+        emitter = BayesianOptimizationEmitter(
+            archive=archive_fixture,
+            lower_bounds=[-1, -1, -1, -1],
+            upper_bounds=[1, 1, 1, 1],
+            upscale_schedule=[[2, 2], [4, 4]],
+            num_initial_samples=1,
+            seed=0,
+            batch_size=1,
+        )
 
     md1, md2 = archive_fixture.dims
     all_measures = np.array(


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the PR's purpose here. -->

Previously, #649 deprecated the `bounds` parameter completely in the emitters. However, I searched around on GitHub and found that quite a few people do use it. In the interest of not breaking backwards-compatibility, I am adding back `bounds` and allowing specifying either `bounds` or `lower_bounds` and `upper_bounds`.

## TODO

<!-- Notable points that this PR has either accomplished or will accomplish. -->

- [x] Remove deprecations
- [x] Re-implement logic in EmitterBase
- [x] Add tests that use old bounds logic
- [x] Add test to check that both bounds methods cannot be specified
- [x] Modify emitters:
  - Change docstring
  - Change argument order

## Status

- [x] I have read the guidelines in
      [CONTRIBUTING.md](https://github.com/icaros-usc/pyribs/blob/master/CONTRIBUTING.md)
- [x] I have linted and formatted my code with `ruff` and `ty`
- [x] I have tested my code by running `pytest`
- [x] I have added a description of my change to the changelog in `HISTORY.md`
- [x] This PR is ready to go
