### PR TITLE
Upgrade to Ruff 0.13.0 and run wrap-docstrings

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
       - id: mixed-line-ending
       - id: trailing-whitespace
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.12.10
+    rev: v0.13.0
     hooks:
       # Lint (without fixing).
       - id: ruff-check

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -149,7 +149,6 @@ ignore = [
   "B027",  # empty-method-without-abstract-decorator; we have base class methods that are empty.
   "E501",  # line-too-long; we already have the formatter.
   "ARG002",  # unused-method-argument; we have many cases where arguments have to be included for API compatibility.
-  "PD901",  # pandas-df-variable-name; this rule is actually deprecated in ruff.
   "RUF022",  # unsorted-dunder-all; we sort it ourselves.
   "SIM108",  # if-else-block-instead-of-if-exp; rather opinionated.
   "PT011",  # pytest-raises-too-broad

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ all = [
 ]
 dev = [
   # Tools
-  "ruff",
+  "ruff>=0.13.0",
   "ty",
   "pre-commit",
 

--- a/ribs/archives/_cvt_archive.py
+++ b/ribs/archives/_cvt_archive.py
@@ -101,12 +101,12 @@ class CVTArchive(ArchiveBase):
             ``objective - (-300)``.
         seed: Value to seed the random number generator as well as
             :func:`~sklearn.cluster.k_means`. Set to None to avoid a fixed seed.
-        solution_dtype: Data type of the solution. Defaults to float64 (numpy's
-            default floating point type).
+        solution_dtype: Data type of the solution. Defaults to float64 (numpy's default
+            floating point type).
         objective_dtype: Data type of the objective. Defaults to float64 (numpy's
             default floating point type).
-        measures_dtype: Data type of the measures. Defaults to float64 (numpy's
-            default floating point type).
+        measures_dtype: Data type of the measures. Defaults to float64 (numpy's default
+            floating point type).
         dtype: DEPRECATED.
         extra_fields: Description of extra fields of data that are stored next to elite
             data like solutions and objectives. The description is a dict mapping from a

--- a/ribs/archives/_grid_archive.py
+++ b/ribs/archives/_grid_archive.py
@@ -78,12 +78,12 @@ class GridArchive(ArchiveBase):
             ``objective - (-300)``.
         seed: Value to seed the random number generator. Set to None to avoid a fixed
             seed.
-        solution_dtype: Data type of the solution. Defaults to float64 (numpy's
-            default floating point type).
+        solution_dtype: Data type of the solution. Defaults to float64 (numpy's default
+            floating point type).
         objective_dtype: Data type of the objective. Defaults to float64 (numpy's
             default floating point type).
-        measures_dtype: Data type of the measures. Defaults to float64 (numpy's
-            default floating point type).
+        measures_dtype: Data type of the measures. Defaults to float64 (numpy's default
+            floating point type).
         dtype: DEPRECATED.
         extra_fields: Description of extra fields of data that are stored next to elite
             data like solutions and objectives. The description is a dict mapping from a

--- a/ribs/archives/_proximity_archive.py
+++ b/ribs/archives/_proximity_archive.py
@@ -105,12 +105,12 @@ class ProximityArchive(ArchiveBase):
             ``objective - (-300)``.
         seed: Value to seed the random number generator. Set to None to avoid a fixed
             seed.
-        solution_dtype: Data type of the solution. Defaults to float64 (numpy's
-            default floating point type).
+        solution_dtype: Data type of the solution. Defaults to float64 (numpy's default
+            floating point type).
         objective_dtype: Data type of the objective. Defaults to float64 (numpy's
             default floating point type).
-        measures_dtype: Data type of the measures. Defaults to float64 (numpy's
-            default floating point type).
+        measures_dtype: Data type of the measures. Defaults to float64 (numpy's default
+            floating point type).
         dtype: DEPRECATED.
         extra_fields: Description of extra fields of data that are stored next to elite
             data like solutions and objectives. The description is a dict mapping from a

--- a/ribs/archives/_sliding_boundaries_archive.py
+++ b/ribs/archives/_sliding_boundaries_archive.py
@@ -145,12 +145,12 @@ class SlidingBoundariesArchive(ArchiveBase):
             ``objective - (-300)``.
         seed: Value to seed the random number generator. Set to None to avoid a fixed
             seed.
-        solution_dtype: Data type of the solution. Defaults to float64 (numpy's
-            default floating point type).
+        solution_dtype: Data type of the solution. Defaults to float64 (numpy's default
+            floating point type).
         objective_dtype: Data type of the objective. Defaults to float64 (numpy's
             default floating point type).
-        measures_dtype: Data type of the measures. Defaults to float64 (numpy's
-            default floating point type).
+        measures_dtype: Data type of the measures. Defaults to float64 (numpy's default
+            floating point type).
         dtype: DEPRECATED.
         extra_fields: Description of extra fields of data that are stored next to elite
             data like solutions and objectives. The description is a dict mapping from a

--- a/ribs/emitters/_gradient_arborescence_emitter.py
+++ b/ribs/emitters/_gradient_arborescence_emitter.py
@@ -342,7 +342,7 @@ class GradientArborescenceEmitter(EmitterBase):
             fields: Additional data for each solution. Each argument should be an array
                 with batch_size as the first dimension.
         """
-        data, add_info, jacobian = validate_batch(
+        _, add_info, jacobian = validate_batch(
             self.archive,
             {
                 "solution": solution,

--- a/ribs/emitters/_gradient_operator_emitter.py
+++ b/ribs/emitters/_gradient_operator_emitter.py
@@ -331,7 +331,7 @@ class GradientOperatorEmitter(EmitterBase):
             fields: Additional data for each solution. Each argument should be an array
                 with batch_size as the first dimension.
         """
-        data, add_info, jacobian = validate_batch(
+        _, add_info, jacobian = validate_batch(
             self.archive,
             {
                 "solution": solution,

--- a/tests/archives/array_store_test.py
+++ b/tests/archives/array_store_test.py
@@ -114,7 +114,7 @@ def test_add_wrong_keys(store):
 
 
 def test_add_mismatch_indices(store, xp_and_device):
-    xp, device = xp_and_device
+    xp, _ = xp_and_device
 
     with pytest.raises(ValueError):
         store.add(
@@ -278,7 +278,7 @@ def test_add_nothing(store, xp_and_device):
 
 
 def test_dtypes(store, xp_and_device):
-    xp, device = xp_and_device
+    xp, _ = xp_and_device
 
     store.add(
         [3, 5],
@@ -777,7 +777,7 @@ def test_data_with_tuple_return_type(store, xp_and_device):
 
 
 def test_data_with_pandas_return_type(store, xp_and_device):
-    xp, device = xp_and_device
+    xp, _ = xp_and_device
 
     store.add(
         [3, 5],
@@ -856,7 +856,7 @@ def test_iteration(store, xp_and_device):
 
 
 def test_add_during_iteration(store, xp_and_device):
-    xp, device = xp_and_device
+    xp, _ = xp_and_device
 
     store.add(
         [3],
@@ -882,7 +882,7 @@ def test_add_during_iteration(store, xp_and_device):
 
 
 def test_clear_during_iteration(store, xp_and_device):
-    xp, device = xp_and_device
+    xp, _ = xp_and_device
 
     store.add(
         [3],
@@ -899,7 +899,7 @@ def test_clear_during_iteration(store, xp_and_device):
 
 
 def test_clear_and_add_during_iteration(store, xp_and_device):
-    xp, device = xp_and_device
+    xp, _ = xp_and_device
 
     store.add(
         [3],

--- a/tests/emitters/emitter_base_test.py
+++ b/tests/emitters/emitter_base_test.py
@@ -210,7 +210,7 @@ def test_default_bounds_correct(archive_fixture):
 def test_cannot_specify_both_bounds(archive_fixture):
     archive, x0 = archive_fixture
     with pytest.raises(
-        ValueError, match="Cannot specify both bounds and lower_bounds/upper_bounds.*"
+        ValueError, match=r"Cannot specify both bounds and lower_bounds/upper_bounds.*"
     ):
         GaussianEmitter(
             archive,
@@ -282,7 +282,7 @@ def test_long_array_bound_fails(archive_fixture, bound_type):
             )
     else:
         with pytest.raises(
-            ValueError, match="Expected lower_bounds to be an array with shape .*"
+            ValueError, match=r"Expected lower_bounds to be an array with shape .*"
         ):
             GaussianEmitter(
                 archive,
@@ -293,7 +293,7 @@ def test_long_array_bound_fails(archive_fixture, bound_type):
                 upper_bounds=[1] * len(x0),
             )
         with pytest.raises(
-            ValueError, match="Expected upper_bounds to be an array with shape .*"
+            ValueError, match=r"Expected upper_bounds to be an array with shape .*"
         ):
             GaussianEmitter(
                 archive,
@@ -308,7 +308,7 @@ def test_wrong_bound_shape(archive_fixture):
     archive, x0 = archive_fixture
 
     with pytest.raises(
-        ValueError, match="Expected .*_bounds to be an array with shape .*"
+        ValueError, match=r"Expected .*_bounds to be an array with shape .*"
     ):
         GaussianEmitter(
             archive,

--- a/tests/emitters/gradient_arborescence_emitter_test.py
+++ b/tests/emitters/gradient_arborescence_emitter_test.py
@@ -43,7 +43,7 @@ def test_bounds_must_be_none():
     batch_size = 1
     archive = GridArchive(solution_dim=1, dims=[10], ranges=[(-1.0, 1.0)])
 
-    with pytest.raises(ValueError, match=".* must be set to None.*"):
+    with pytest.raises(ValueError, match=r".* must be set to None.*"):
         GradientArborescenceEmitter(
             archive,
             x0=np.array([0]),

--- a/tests/emitters_pymoo/bayesopt_emitter_test.py
+++ b/tests/emitters_pymoo/bayesopt_emitter_test.py
@@ -71,8 +71,8 @@ def test_wrong_archive_type():
     archive = CVTArchive(solution_dim=1, cells=100, ranges=[(-1, 1)])
     with pytest.raises(
         NotImplementedError,
-        match="archive type CVTArchive not implemented for"
-        " BayesianOptimizationEmitter. Expected GridArchive.",
+        match=r"archive type CVTArchive not implemented for"
+        r" BayesianOptimizationEmitter\. Expected GridArchive\.",
     ):
         BayesianOptimizationEmitter(
             archive,  # ty: ignore[invalid-argument-type]


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the PR's purpose here. -->

Misc maintenance.

## TODO

<!-- Notable points that this PR has either accomplished or will accomplish. -->

- [x] Mark `ruff>=0.13.0` in pyproject.toml
- [x] Update ruff in pre-commit
- [x] Remove deprecated ruff rule from the ignore section in pyproject.toml
- [x] Fix new ruff errors -- it appears ruff can now check for a couple more things
- [x] Ran [wrap-docstrings](github.com/btjanaka/wrap-docstrings) on the `ribs/` directory; it made some edits to the archives

## Status

- [x] I have read the guidelines in
      [CONTRIBUTING.md](https://github.com/icaros-usc/pyribs/blob/master/CONTRIBUTING.md)
- [x] I have linted and formatted my code with `ruff` and `ty`
- [x] I have tested my code by running `pytest`
- [N/A] I have added a description of my change to the changelog in `HISTORY.md`
- [x] This PR is ready to go
