### PR TITLE
Bring back dtype parameter for archives

### DIFF
--- a/ribs/_utils.py
+++ b/ribs/_utils.py
@@ -295,14 +295,3 @@ class PickleXPMixin:
         if self.XP_NAME in state:
             state[self.XP_NAME] = importlib.import_module(state[self.XP_NAME])
         self.__dict__.update(state)
-
-
-## Deprecations ##
-
-
-def deprecate_dtype(dtype: None) -> None:
-    if dtype is not None:
-        raise ValueError(
-            "The dtype parameter is deprecated as of pyribs 0.9.0. Please specify "
-            "solution_dtype, objective_dtype, and/or measures_dtype instead."
-        )

--- a/ribs/archives/_utils.py
+++ b/ribs/archives/_utils.py
@@ -25,6 +25,48 @@ def parse_dtype(dtype: DTypeLike, xp: ModuleType) -> DTypeLike:
     return dtype
 
 
+def parse_all_dtypes(
+    dtype: DTypeLike,
+    solution_dtype: DTypeLike,
+    objective_dtype: DTypeLike,
+    measures_dtype: DTypeLike,
+    xp: ModuleType,
+) -> DTypeLike:
+    """Parses dtypes for the archives.
+
+    Any dtypes that are `None` are set to the default "real floating" dtype for the
+    provided array backend.
+
+    Returns dtypes for the solution, objective, and measures.
+    """
+    use_dtype = dtype is not None
+    use_individual_dtypes = (
+        solution_dtype is not None
+        or objective_dtype is not None
+        or measures_dtype is not None
+    )
+
+    if use_dtype and use_individual_dtypes:
+        raise ValueError(
+            "dtype cannot be used at the same time as solution_dtype, "
+            "objective_dtype, or measures_dtype. Either pass dtype on its own,"
+            "or pass solution_dtype, objective_dtype, and/or measures_dtype."
+        )
+    elif use_individual_dtypes:
+        # Parse each dtype individually.
+        solution_dtype = parse_dtype(solution_dtype, xp)
+        objective_dtype = parse_dtype(objective_dtype, xp)
+        measures_dtype = parse_dtype(measures_dtype, xp)
+    else:
+        # Everything set to `dtype`, which may also be None to get the default case.
+        dtype = parse_dtype(dtype, xp)
+        solution_dtype = dtype
+        objective_dtype = dtype
+        measures_dtype = dtype
+
+    return solution_dtype, objective_dtype, measures_dtype
+
+
 def validate_cma_mae_settings(
     learning_rate: Float | None, threshold_min: Float, dtype: np.dtype
 ) -> tuple[np.floating, np.floating]:


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the PR's purpose here. -->

## TODO

<!-- Notable points that this PR has either accomplished or will accomplish. -->

- [ ] Update HISTORY to reflect deprecation
- [ ] Add `parse_all_dtypes` util
- [ ] Check coverage of dtype parsing utils
- [ ] Add tests with `dtype`

## Status

- [x] I have read the guidelines in
      [CONTRIBUTING.md](https://github.com/icaros-usc/pyribs/blob/master/CONTRIBUTING.md)
- [x] I have linted and formatted my code with `ruff` and `ty`
- [x] I have tested my code by running `pytest`
- [ ] I have added a description of my change to the changelog in `HISTORY.md`
- [ ] This PR is ready to go
