### PR TITLE
Add back pylint and remove ty

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -18,7 +18,7 @@
 
 - [ ] I have read the guidelines in
       [CONTRIBUTING.md](https://github.com/icaros-usc/pyribs/blob/master/CONTRIBUTING.md)
-- [ ] I have linted and formatted my code with `ruff` and `ty`
+- [ ] I have linted and formatted my code with `ruff` and `pylint`
 - [ ] I have tested my code by running `pytest`
 - [ ] I have added a description of my change to the changelog in `HISTORY.md`
 - [ ] This PR is ready to go

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -21,9 +21,8 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     env:
-      # TODO (#609): Remove skip if possible.
-      # Skip ty since it is not yet ready for pre-commit
-      SKIP: ty
+      # Skip pylint since not all of our code passes pylint.
+      SKIP: pylint
     steps:
       - uses: actions/checkout@v4
       - uses: conda-incubator/setup-miniconda@v3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,14 +21,21 @@ repos:
         args: [--select, I, --fix]
       # Run formatter.
       - id: ruff-format
-  - repo: local
-    hooks:
-      - id: ty
-        name: ty-check
-        language: system
-        entry: ty check
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: v3.1.0
     hooks:
       - id: prettier
         types_or: [markdown, yaml]
+  # pylint runs locally due to importing modules. See
+  # https://pylint.pycqa.org/en/latest/user_guide/installation/pre-commit-integration.html
+  - repo: local
+    hooks:
+      - id: pylint
+        name: pylint
+        entry: pylint
+        language: system
+        types: [python]
+        args: [
+            "-rn", # Only display messages
+            "-sn", # Don't display the score
+          ]

--- a/.pylintrc
+++ b/.pylintrc
@@ -56,7 +56,7 @@ confidence=
 # --enable=similarities". If you want to run only the classes checker, but have
 # no Warning level messages displayed, use"--disable=all --enable=classes
 # --disable=W"
-disable=suppressed-message,arguments-differ,wildcard-import,locally-disabled,duplicate-code,no-else-return,no-else-raise,line-too-long
+disable=suppressed-message,arguments-differ,wildcard-import,locally-disabled,duplicate-code,no-else-return,no-else-raise,line-too-long,too-many-public-methods
 
 
 [REPORTS]

--- a/.pylintrc
+++ b/.pylintrc
@@ -288,7 +288,7 @@ exclude-protected=_asdict,_fields,_replace,_source,_make
 max-args=9999
 
 # Maximum number of positional arguments.
-max-positional-arguments=5
+max-positional-arguments=10
 
 # Argument names that match this expression will be ignored. Default to name
 # with leading underscore

--- a/.pylintrc
+++ b/.pylintrc
@@ -56,7 +56,7 @@ confidence=
 # --enable=similarities". If you want to run only the classes checker, but have
 # no Warning level messages displayed, use"--disable=all --enable=classes
 # --disable=W"
-disable=suppressed-message,arguments-differ,wildcard-import,locally-disabled,duplicate-code,no-else-return,no-else-raise,line-too-long,too-many-public-methods
+disable=suppressed-message,arguments-differ,wildcard-import,locally-disabled,duplicate-code,no-else-return,no-else-raise,line-too-long
 
 
 [REPORTS]
@@ -288,7 +288,7 @@ exclude-protected=_asdict,_fields,_replace,_source,_make
 max-args=9999
 
 # Maximum number of positional arguments.
-max-positional-arguments=10
+max-positional-arguments=5
 
 # Argument names that match this expression will be ignored. Default to name
 # with leading underscore
@@ -316,7 +316,7 @@ max-attributes=100
 min-public-methods=0
 
 # Maximum number of public methods for a class (see R0904).
-max-public-methods=20
+max-public-methods=9999
 
 # Maximum number of boolean expressions in a if statement
 max-bool-expr=5

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,359 @@
+[MASTER]
+
+# Specify a configuration file.
+#rcfile=
+
+# Python code to execute, usually for sys.path manipulation such as
+# pygtk.require().
+#init-hook=
+
+# Add files or directories to the blacklist. They should be base names, not
+# paths.
+ignore=docs
+
+# Add files or directories matching the regex patterns to the blacklist. The
+# regex matches against base names, not paths.
+ignore-patterns=
+
+# Pickle collected data for later comparisons.
+persistent=yes
+
+# List of plugins (as comma separated values of python modules names) to load,
+# usually to register additional checkers.
+load-plugins=
+
+# Use multiple processes to speed up Pylint.
+jobs=1
+
+# Allow loading of arbitrary C extensions. Extensions are imported into the
+# active Python interpreter and may run arbitrary code.
+unsafe-load-any-extension=no
+
+# A comma-separated list of package or module names from where C extensions may
+# be loaded. Extensions are loading into the active Python interpreter and may
+# run arbitrary code
+extension-pkg-whitelist=numpy
+
+
+[MESSAGES CONTROL]
+
+# Only show warnings with the listed confidence levels. Leave empty to show
+# all. Valid levels: HIGH, INFERENCE, INFERENCE_FAILURE, UNDEFINED
+confidence=
+
+# Enable the message, report, category or checker with the given id(s). You can
+# either give multiple identifier separated by comma (,) or put this option
+# multiple time (only on the command line, not in the configuration file where
+# it should appear only once). See also the "--disable" option for examples.
+#enable=
+
+# Disable the message, report, category or checker with the given id(s). You
+# can either give multiple identifiers separated by comma (,) or put this
+# option multiple times (only on the command line, not in the configuration
+# file where it should appear only once).You can also use "--disable=all" to
+# disable everything first and then reenable specific checks. For example, if
+# you want to run only the similarities checker, you can use "--disable=all
+# --enable=similarities". If you want to run only the classes checker, but have
+# no Warning level messages displayed, use"--disable=all --enable=classes
+# --disable=W"
+disable=suppressed-message,arguments-differ,wildcard-import,locally-disabled,duplicate-code,no-else-return,no-else-raise,line-too-long
+
+
+[REPORTS]
+
+# Set the output format. Available formats are text, parseable, colorized, msvs
+# (visual studio) and html. You can also give a reporter class, eg
+# mypackage.mymodule.MyReporterClass.
+output-format=text
+
+# Tells whether to display a full report or only the messages
+reports=yes
+
+# Python expression which should return a note less than 10 (10 is the highest
+# note). You have access to the variables errors warning, statement which
+# respectively contain the number of errors / warnings messages and the total
+# number of statements analyzed. This is used by the global evaluation report
+# (RP0004).
+evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10)
+
+# Template used to display messages. This is a python new-style format string
+# used to format the message information. See doc for all details
+#msg-template=
+
+
+[BASIC]
+
+# Good variable names which should always be accepted, separated by a comma
+good-names=i,j,k,ex,Run,_,logger
+
+# Bad variable names which should always be refused, separated by a comma
+bad-names=foo,bar,baz,toto,tutu,tata
+
+# Colon-delimited sets of names that determine each other's naming style when
+# the name regexes allow several styles.
+name-group=
+
+# List of decorators that produce properties, such as abc.abstractproperty. Add
+# to this list to register other decorators that produce valid properties.
+property-classes=abc.abstractproperty
+
+# Regular expression matching correct variable names
+variable-rgx=[a-z_][a-z0-9_]{0,30}$
+
+# Regular expression matching correct class attribute names
+class-attribute-rgx=([A-Za-z_][A-Za-z0-9_]{0,30}|(__.*__))$
+
+# Regular expression matching correct argument names
+argument-rgx=[a-z_][a-z0-9_]{0,30}$
+
+# Regular expression matching correct module names
+module-rgx=(([a-z_][a-z0-9_]*)|([A-Z][a-zA-Z0-9]+))$
+
+# Regular expression matching correct constant names
+const-rgx=(([A-Z_][A-Z0-9_]*)|(__.*__))$
+
+# Regular expression matching correct inline iteration names
+inlinevar-rgx=[A-Za-z_][A-Za-z0-9_]*$
+
+# Regular expression matching correct method names
+method-rgx=[a-z_][a-z0-9_]{0,30}$
+
+# Regular expression matching correct function names
+function-rgx=[a-z_][a-z0-9_]{0,50}$
+
+# Regular expression matching correct attribute names
+attr-rgx=[a-z_][a-z0-9_]{0,30}$
+
+# Regular expression matching correct class names
+class-rgx=[A-Z_][a-zA-Z0-9]+$
+
+# Regular expression which should only match function or class names that do
+# not require a docstring.
+no-docstring-rgx=^(test|benchmark)_|__init__
+
+# Minimum line length for functions/classes that require docstrings, shorter
+# ones are exempt.
+docstring-min-length=-1
+
+
+[ELIF]
+
+# Maximum number of nested blocks for function / method body
+max-nested-blocks=5
+
+
+[FORMAT]
+
+# Maximum number of characters on a single line. Note that we actually disable
+# line-too-long since ruff handles the formatting.
+max-line-length=88
+
+# Regexp for a line that is allowed to be longer than the limit. The first group
+# (before the `|`) matches URLs, the second matches Sphinx links, the third
+# matches pip install commands.
+ignore-long-lines=(^\s*(# )?<?https?://\S+>?$)|(^\s*<.*>`_.?$)|(^\s*pip install .*)
+
+# Allow the body of an if to be on the same line as the test if there is no
+# else.
+single-line-if-stmt=y
+
+# Maximum number of lines in a module
+max-module-lines=2000
+
+# String used as indentation unit. This is usually "    " (4 spaces) or "\t" (1
+# tab).
+indent-string='    '
+
+# Number of spaces of indent required inside a hanging  or continued line.
+indent-after-paren=4
+
+# Expected format of line ending, e.g. empty (any line ending), LF or CRLF.
+expected-line-ending-format=
+
+
+[LOGGING]
+
+# Logging modules to check that the string format arguments are in logging
+# function parameter format
+logging-modules=logging
+
+
+[MISCELLANEOUS]
+
+# List of note tags to take in consideration, separated by a comma.
+notes=FIXME,XXX,TODO
+
+
+[SIMILARITIES]
+
+# Minimum lines number of a similarity.
+min-similarity-lines=10
+
+# Ignore comments when computing similarities.
+ignore-comments=yes
+
+# Ignore docstrings when computing similarities.
+ignore-docstrings=yes
+
+# Ignore imports when computing similarities.
+ignore-imports=no
+
+
+[SPELLING]
+
+# Spelling dictionary name. Available dictionaries: none. To make it working
+# install python-enchant package.
+spelling-dict=
+
+# List of comma separated words that should not be checked.
+spelling-ignore-words=
+
+# A path to a file that contains private dictionary; one word per line.
+spelling-private-dict-file=
+
+# Tells whether to store unknown words to indicated private dictionary in
+# --spelling-private-dict-file option instead of raising a message.
+spelling-store-unknown-words=no
+
+
+[TYPECHECK]
+
+# Tells whether missing members accessed in mixin class should be ignored. A
+# mixin class is detected if its name ends with "mixin" (case insensitive).
+ignore-mixin-members=yes
+
+# List of module names for which member attributes should not be checked
+# (useful for modules/projects where namespaces are manipulated during runtime
+# and thus existing member attributes cannot be deduced by static analysis. It
+# supports qualified module names, as well as Unix pattern matching.
+ignored-modules=
+
+# List of class names for which member attributes should not be checked (useful
+# for classes with dynamically set attributes). This supports the use of
+# qualified names.
+ignored-classes=optparse.Values,thread._local,_thread._local,matplotlib.cm,tensorflow.python,tensorflow,tensorflow.train.Example,RunOptions
+
+# List of members which are set dynamically and missed by pylint inference
+# system, and so shouldn't trigger E1101 when accessed. Python regular
+# expressions are accepted.
+generated-members=set_shape,np.float32,torch.*
+
+# List of decorators that produce context managers, such as
+# contextlib.contextmanager. Add to this list to register other decorators that
+# produce valid context managers.
+contextmanager-decorators=contextlib.contextmanager
+
+
+[VARIABLES]
+
+# Tells whether we should check for unused import in __init__ files.
+init-import=no
+
+# A regular expression matching the name of dummy variables (i.e. expectedly
+# not used).
+dummy-variables-rgx=(_+[a-zA-Z0-9_]*?$)|dummy
+
+# List of additional names supposed to be defined in builtins. Remember that
+# you should avoid to define new builtins when possible.
+additional-builtins=
+
+# List of strings which can identify a callback function by name. A callback
+# name must start or end with one of those strings.
+callbacks=cb_,_cb
+
+# List of qualified module names which can have objects that can redefine
+# builtins.
+redefining-builtins-modules=six.moves,future.builtins
+
+
+[CLASSES]
+
+# List of method names used to declare (i.e. assign) instance attributes.
+defining-attr-methods=__init__,__new__,setUp
+
+# List of valid names for the first argument in a class method.
+valid-classmethod-first-arg=cls
+
+# List of valid names for the first argument in a metaclass class method.
+valid-metaclass-classmethod-first-arg=mcs
+
+# List of member names, which should be excluded from the protected access
+# warning.
+exclude-protected=_asdict,_fields,_replace,_source,_make
+
+
+[DESIGN]
+
+# Maximum number of arguments for function / method
+max-args=9999
+
+# Maximum number of positional arguments.
+max-positional-arguments=10
+
+# Argument names that match this expression will be ignored. Default to name
+# with leading underscore
+ignored-argument-names=_.*
+
+# Maximum number of locals for function / method body
+max-locals=100
+
+# Maximum number of return / yield for function / method body
+max-returns=6
+
+# Maximum number of branch for function / method body
+max-branches=100
+
+# Maximum number of statements in function / method body
+max-statements=100
+
+# Maximum number of parents for a class (see R0901).
+max-parents=7
+
+# Maximum number of attributes for a class (see R0902).
+max-attributes=100
+
+# Minimum number of public methods for a class (see R0903).
+min-public-methods=0
+
+# Maximum number of public methods for a class (see R0904).
+max-public-methods=20
+
+# Maximum number of boolean expressions in a if statement
+max-bool-expr=5
+
+
+[IMPORTS]
+
+# Deprecated modules which should not be used, separated by a comma
+deprecated-modules=optparse
+
+# Create a graph of every (i.e. internal and external) dependencies in the
+# given file (report RP0402 must not be disabled)
+import-graph=
+
+# Create a graph of external dependencies in the given file (report RP0402 must
+# not be disabled)
+ext-import-graph=
+
+# Create a graph of internal dependencies in the given file (report RP0402 must
+# not be disabled)
+int-import-graph=
+
+# Force import order to recognize a module as part of the standard
+# compatibility libraries.
+known-standard-library=
+
+# Force import order to recognize a module as part of a third party library.
+known-third-party=enchant
+
+# Analyse import fallback blocks. This can be used to support both Python 2 and
+# 3 compatible code, which means that the block might have code that exists
+# only in one or another interpreter, leading to false positives when analysed.
+analyse-fallback-blocks=no
+
+
+[EXCEPTIONS]
+
+# Exceptions that will emit a warning when being caught. Defaults to
+# "Exception"
+overgeneral-exceptions=builtins.Exception

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,8 +41,8 @@ Ready to contribute? Here's how to set up pyribs for local development.
 
 1. We roughly follow the
    [Google Style Guide](https://google.github.io/styleguide/pyguide.html) in our
-   codebase. We use ruff to enforce code format and style. To automatically
-   check for formatting and style on every commit, we use
+   codebase. We use ruff and pylint to enforce code format and style. To
+   automatically check for formatting and style on every commit, we use
    [pre-commit](https://pre-commit.com). Pre-commit should have already been
    installed with `.[dev]` above. To set it up, run:
 
@@ -54,16 +54,15 @@ Ready to contribute? Here's how to set up pyribs for local development.
    tests for your code in the `tests/` folder.
 
 1. Lint and auto-format your code using [ruff](https://docs.astral.sh/ruff/) and
-   [ty](https://docs.astral.sh/ty/). Note that pre-commit will automatically run
-   ruff and ty whenever you commit your code; you can also run it with
+   [pylint](https://www.pylint.org/). Note that pre-commit will automatically
+   run these whenever you commit your code; you can also run it with
    `pre-commit run`. You can also run the following commands on the command
    line:
 
    ```bash
    # Lint (without fixing).
    ruff check FILES
-   # Run type checking.
-   ty check FILES
+   pylint FILES
    # Sort imports.
    ruff check --select I --fix FILES
    # Run formatter.

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,6 +6,7 @@
 
 #### Improvements
 
+- Add back pylint and remove ty ({pr}`687`)
 - Fix pandas dtype in test for CategoricalArchive ({pr}`686`)
 
 ## 0.9.0

--- a/Makefile
+++ b/Makefile
@@ -37,9 +37,9 @@ clean-test: ## remove test and coverage artifacts
 	rm -rf .pytest_cache
 .PHONY: clean-test
 
-lint: ## check style with ruff
+lint: ## check style with ruff and pylint
 	ruff check
-	ty check
+	pylint ribs tests examples benchmarks
 .PHONY: lint
 
 test: ## run tests with the default Python

--- a/benchmarks/cvt_add.py
+++ b/benchmarks/cvt_add.py
@@ -39,7 +39,7 @@ from ribs.archives import CVTArchive
 
 def save_times(n_cells, results, filename="cvt_add_times.json"):
     """Saves a dict of the results to the given file."""
-    with open(filename, "w") as file:
+    with open(filename, "w", encoding="utf-8") as file:
         json.dump(
             {
                 "n_cells": n_cells,
@@ -51,7 +51,7 @@ def save_times(n_cells, results, filename="cvt_add_times.json"):
 
 def load_times(filename="cvt_add_times.json"):
     """Loads the results from the given file."""
-    with open(filename) as file:
+    with open(filename, encoding="utf-8") as file:
         data = json.load(file)
         return data["n_cells"], data["results"]
 
@@ -112,7 +112,7 @@ def main():
     def add_entries():
         nonlocal archive
         for i in range(n_batches):
-            archive.add(  # ty: ignore[unresolved-attribute]
+            archive.add(
                 all_solution_batch[i],
                 all_objective_batch[i],
                 all_measures_batch[i],

--- a/examples/bop_elites.py
+++ b/examples/bop_elites.py
@@ -98,7 +98,7 @@ def save_heatmap(archive: GridArchive, heatmap_path: str | Path) -> None:
     plt.close(plt.gcf())
 
 
-def main(
+def main(  # pylint: disable = too-many-positional-arguments
     iterations: int = 1000,
     solution_dim: int = 4,
     search_nrestarts: int = 5,
@@ -223,7 +223,7 @@ def main(
 
     # Convert metrics to Python scalars by calling .item(), since each stats value is a
     # 0-D array by default, and JSON cannot serialize 0-D arrays.
-    for metric in metrics:
+    for metric in metrics:  # pylint: disable = consider-using-dict-items
         metrics[metric]["y"] = [
             m if isinstance(m, (int, float)) else m.item() for m in metrics[metric]["y"]
         ]

--- a/examples/bop_elites.py
+++ b/examples/bop_elites.py
@@ -209,7 +209,7 @@ def main(  # pylint: disable = too-many-positional-arguments
             )
 
             save_heatmap(
-                scheduler.result_archive,  # ty: ignore[invalid-argument-type]
+                scheduler.result_archive,
                 logdir / f"heatmap_{i:08d}.png",
             )
 

--- a/examples/lunar_lander.py
+++ b/examples/lunar_lander.py
@@ -433,7 +433,7 @@ def lunar_lander_main(
     # Outputs.
     scheduler.archive.data(return_type="pandas").to_csv(outdir / "archive.csv")
     save_ccdf(scheduler.archive, str(outdir / "archive_ccdf.png"))
-    save_heatmap(scheduler.archive, str(outdir / "heatmap.png"))  # ty: ignore[invalid-argument-type]
+    save_heatmap(scheduler.archive, str(outdir / "heatmap.png"))
     save_metrics(outdir, metrics)
 
 

--- a/examples/sphere.py
+++ b/examples/sphere.py
@@ -1015,7 +1015,7 @@ def save_heatmap(archive: ArchiveBase, heatmap_path: str | Path) -> None:
     plt.close(plt.gcf())
 
 
-def sphere_main(
+def sphere_main(  # pylint: disable = too-many-positional-arguments
     algorithm: str,
     dim: int = 100,
     itrs: int = 10000,
@@ -1132,7 +1132,7 @@ def sphere_main(
 
     # Convert metrics to Python scalars by calling .item(), since each stats value is a
     # 0-D array by default, and JSON cannot serialize 0-D arrays.
-    for metric in metrics:
+    for metric in metrics:  # pylint: disable = consider-using-dict-items
         metrics[metric]["y"] = [
             m if isinstance(m, (int, float)) else m.item() for m in metrics[metric]["y"]
         ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ all = [
 dev = [
   # Tools
   "ruff>=0.13.0",
-  "ty",
+  "pylint",
   "pre-commit",
 
   # Testing

--- a/ribs/_utils.py
+++ b/ribs/_utils.py
@@ -267,7 +267,7 @@ def xp_namespace(xp: ModuleType | None) -> ModuleType:
     For more context, see:
     https://github.com/data-apis/array-api-compat/issues/342
     """
-    return np_compat if xp is None else array_namespace(xp.empty(0))  # ty: ignore[unresolved-attribute]
+    return np_compat if xp is None else array_namespace(xp.empty(0))
 
 
 class PickleXPMixin:

--- a/ribs/archives/_array_store.py
+++ b/ribs/archives/_array_store.py
@@ -286,7 +286,7 @@ class ArrayStore(PickleXPMixin):
         if is_numpy_array(arr):
             return arr
         elif is_torch_array(arr):
-            return arr.cpu().detach().numpy()  # ty: ignore[possibly-unbound-attribute]
+            return arr.cpu().detach().numpy()
         elif is_cupy_array(arr):
             return cp.asnumpy(arr)
         else:
@@ -456,17 +456,17 @@ class ArrayStore(PickleXPMixin):
             if single_field:
                 data = arr
             elif return_type == "dict":
-                data[name] = arr  # ty: ignore[invalid-assignment]
+                data[name] = arr
             elif return_type == "tuple":
-                data.append(arr)  # ty: ignore[possibly-unbound-attribute]
+                data.append(arr)
             elif return_type == "pandas":
                 arr = self._convert_to_numpy(arr)
 
                 if len(arr.shape) == 1:  # Scalar entries.
-                    data[name] = arr  # ty: ignore[invalid-assignment]
+                    data[name] = arr
                 elif len(arr.shape) == 2:  # 1D array entries.
                     for i in range(arr.shape[1]):
-                        data[f"{name}_{i}"] = arr[:, i]  # ty: ignore[invalid-assignment]
+                        data[f"{name}_{i}"] = arr[:, i]
                 else:
                     raise ValueError(
                         f"Field `{name}` has shape {arr.shape[1:]} -- "
@@ -475,7 +475,7 @@ class ArrayStore(PickleXPMixin):
 
         # Postprocess return data.
         if return_type == "tuple":
-            data = tuple(data)  # ty: ignore[invalid-argument-type]
+            data = tuple(data)
         elif return_type == "pandas":
             occupied = self._convert_to_numpy(occupied)
 

--- a/ribs/archives/_array_store.py
+++ b/ribs/archives/_array_store.py
@@ -16,7 +16,7 @@ from array_api_compat import is_cupy_array, is_numpy_array, is_torch_array
 from numpy.typing import ArrayLike
 
 with contextlib.suppress(ImportError):
-    from array_api_compat import cupy as cp
+    from array_api_compat import cupy as cp  # pylint: disable = ungrouped-imports
 
 from ribs._utils import PickleXPMixin, arr_readonly, xp_namespace
 from ribs.archives._archive_data_frame import ArchiveDataFrame
@@ -47,7 +47,7 @@ class ArrayStoreIterator:
 
         Raises RuntimeError if the store was modified.
         """
-        if self.state != self.store._props["updates"]:
+        if self.state != self.store._props["updates"]:  # pylint: disable = protected-access
             # This check should go before the StopIteration check because a call to
             # clear() would cause the len(self.store) to be 0 and thus trigger
             # StopIteration.
@@ -58,7 +58,7 @@ class ArrayStoreIterator:
         if self.iter_idx >= len(self.store):
             raise StopIteration
 
-        idx = self.store._props["occupied_list"][self.iter_idx]
+        idx = self.store._props["occupied_list"][self.iter_idx]  # pylint: disable = protected-access
         self.iter_idx += 1
 
         d = {"index": idx}

--- a/ribs/archives/_categorical_archive.py
+++ b/ribs/archives/_categorical_archive.py
@@ -374,11 +374,11 @@ class CategoricalArchive(ArchiveBase):
         #
         # All objective_sizes should be > 0 since we only retrieve counts for indices in
         # `indices`.
-        objective_sizes = aggregate(indices, 1, func="len", fill_value=0)[indices]  # ty: ignore[call-non-callable]
+        objective_sizes = aggregate(indices, 1, func="len", fill_value=0)[indices]
 
         # Compute the sum of the objectives inserted into each cell -- again, we index
         # with `indices`.
-        objective_sums = aggregate(indices, objective, func="sum", fill_value=np.nan)[  # ty: ignore[call-non-callable]
+        objective_sums = aggregate(indices, objective, func="sum", fill_value=np.nan)[
             indices
         ]
 
@@ -572,7 +572,7 @@ class CategoricalArchive(ArchiveBase):
         # elite will be inserted if there is a tie. See their default numpy
         # implementation for more info:
         # https://github.com/ml31415/numpy-groupies/blob/master/numpy_groupies/aggregate_numpy.py#L107
-        archive_argmax = aggregate(  # ty: ignore[call-non-callable]
+        archive_argmax = aggregate(
             indices, data["objective"], func="argmax", fill_value=-1
         )
         should_insert = archive_argmax[archive_argmax != -1]

--- a/ribs/archives/_cvt_archive.py
+++ b/ribs/archives/_cvt_archive.py
@@ -687,11 +687,11 @@ class CVTArchive(ArchiveBase):
         #
         # All objective_sizes should be > 0 since we only retrieve counts for indices in
         # `indices`.
-        objective_sizes = aggregate(indices, 1, func="len", fill_value=0)[indices]  # ty: ignore[call-non-callable]
+        objective_sizes = aggregate(indices, 1, func="len", fill_value=0)[indices]
 
         # Compute the sum of the objectives inserted into each cell -- again, we index
         # with `indices`.
-        objective_sums = aggregate(indices, objective, func="sum", fill_value=np.nan)[  # ty: ignore[call-non-callable]
+        objective_sums = aggregate(indices, objective, func="sum", fill_value=np.nan)[
             indices
         ]
 
@@ -885,7 +885,7 @@ class CVTArchive(ArchiveBase):
         # elite will be inserted if there is a tie. See their default numpy
         # implementation for more info:
         # https://github.com/ml31415/numpy-groupies/blob/master/numpy_groupies/aggregate_numpy.py#L107
-        archive_argmax = aggregate(  # ty: ignore[call-non-callable]
+        archive_argmax = aggregate(
             indices, data["objective"], func="argmax", fill_value=-1
         )
         should_insert = archive_argmax[archive_argmax != -1]

--- a/ribs/archives/_grid_archive.py
+++ b/ribs/archives/_grid_archive.py
@@ -492,11 +492,11 @@ class GridArchive(ArchiveBase):
         #
         # All objective_sizes should be > 0 since we only retrieve counts for indices in
         # `indices`.
-        objective_sizes = aggregate(indices, 1, func="len", fill_value=0)[indices]  # ty: ignore[call-non-callable]
+        objective_sizes = aggregate(indices, 1, func="len", fill_value=0)[indices]
 
         # Compute the sum of the objectives inserted into each cell -- again, we index
         # with `indices`.
-        objective_sums = aggregate(indices, objective, func="sum", fill_value=np.nan)[  # ty: ignore[call-non-callable]
+        objective_sums = aggregate(indices, objective, func="sum", fill_value=np.nan)[
             indices
         ]
 
@@ -690,7 +690,7 @@ class GridArchive(ArchiveBase):
         # elite will be inserted if there is a tie. See their default numpy
         # implementation for more info:
         # https://github.com/ml31415/numpy-groupies/blob/master/numpy_groupies/aggregate_numpy.py#L107
-        archive_argmax = aggregate(  # ty: ignore[call-non-callable]
+        archive_argmax = aggregate(
             indices, data["objective"], func="argmax", fill_value=-1
         )
         should_insert = archive_argmax[archive_argmax != -1]

--- a/ribs/archives/_proximity_archive.py
+++ b/ribs/archives/_proximity_archive.py
@@ -463,7 +463,7 @@ class ProximityArchive(ArchiveBase):
                 )
 
         if use_local_competition:
-            return novelty, local_competition_scores
+            return novelty, local_competition_scores  # pylint: disable = used-before-assignment
         else:
             return novelty
 

--- a/ribs/archives/_proximity_archive.py
+++ b/ribs/archives/_proximity_archive.py
@@ -702,7 +702,7 @@ class ProximityArchive(ArchiveBase):
                 # first elite will be inserted if there is a tie. See their default
                 # numpy implementation for more info:
                 # https://github.com/ml31415/numpy-groupies/blob/master/numpy_groupies/aggregate_numpy.py#L107
-                archive_argmax = aggregate(  # ty: ignore[call-non-callable]
+                archive_argmax = aggregate(
                     indices, data["objective"], func="argmax", fill_value=-1
                 )
                 should_insert = archive_argmax[archive_argmax != -1]

--- a/ribs/archives/_sliding_boundaries_archive.py
+++ b/ribs/archives/_sliding_boundaries_archive.py
@@ -536,7 +536,7 @@ class SlidingBoundariesArchive(ArchiveBase):
         cur_data.pop("index")
 
         new_data_single = list(self._buffer)  # List of dicts.
-        new_data: dict[str, list] = dict.fromkeys(new_data_single[0])  # ty: ignore[invalid-assignment]
+        new_data: dict[str, list] = dict.fromkeys(new_data_single[0])
         for name in new_data:
             new_data[name] = [d[name] for d in new_data_single]
 

--- a/ribs/archives/_sliding_boundaries_archive.py
+++ b/ribs/archives/_sliding_boundaries_archive.py
@@ -481,7 +481,7 @@ class SlidingBoundariesArchive(ArchiveBase):
 
         # We cannot use `grid_to_int_index` since that takes in an array of indices, not
         # index columns.
-        return np.ravel_multi_index(idx_cols, self._dims).astype(np.int32)
+        return np.ravel_multi_index(idx_cols, self._dims).astype(np.int32)  # pylint: disable = no-member
 
     def index_of_single(self, measures: ArrayLike) -> Int:
         """Returns the index of the measures for one solution.

--- a/ribs/archives/_utils.py
+++ b/ribs/archives/_utils.py
@@ -21,7 +21,7 @@ def parse_dtype(dtype: DTypeLike, xp: ModuleType) -> DTypeLike:
         xp = xp_namespace(xp)
         # See here for info on array API inspection:
         # https://data-apis.org/array-api/latest/API_specification/inspection.html
-        return xp.__array_namespace_info__().default_dtypes()["real floating"]  # ty: ignore[unresolved-attribute]
+        return xp.__array_namespace_info__().default_dtypes()["real floating"]
     return dtype
 
 

--- a/ribs/emitters/_bayesian_opt_emitter.py
+++ b/ribs/emitters/_bayesian_opt_emitter.py
@@ -86,6 +86,7 @@ class BayesianOptimizationEmitter(EmitterBase):
         seed: Int | None = None,
     ) -> None:
         try:
+            # pylint: disable = import-outside-toplevel
             from pymoo.algorithms.soo.nonconvex.pattern import PatternSearch
             from pymoo.optimize import minimize
             from pymoo.problems.functional import FunctionalProblem

--- a/ribs/emitters/_genetic_algorithm_emitter.py
+++ b/ribs/emitters/_genetic_algorithm_emitter.py
@@ -103,7 +103,7 @@ class GeneticAlgorithmEmitter(EmitterBase):
             **(operator_kwargs if operator_kwargs is not None else {}),
             # We assume the class takes in a seed, but this is technically not part of
             # the API.
-            seed=seed,  # ty: ignore[unknown-argument]
+            seed=seed,
         )
 
     @property

--- a/ribs/emitters/opt/_pycma_es.py
+++ b/ribs/emitters/opt/_pycma_es.py
@@ -89,7 +89,7 @@ class PyCMAEvolutionStrategy(EvolutionStrategyBase):
             # We do not want to import at the top because that would require cma to
             # always be installed, as cma would be imported whenever this class is
             # imported.
-            import cma
+            import cma  # pylint: disable = import-outside-toplevel
         except ImportError as e:
             raise ImportError(
                 "pycma must be installed -- please run `pip install cma` or "

--- a/ribs/emitters/opt/_pycma_es.py
+++ b/ribs/emitters/opt/_pycma_es.py
@@ -96,7 +96,7 @@ class PyCMAEvolutionStrategy(EvolutionStrategyBase):
                 "`conda install cma`"
             ) from e
         else:
-            self._es = cma.CMAEvolutionStrategy(x0, self.sigma0, self._opts)  # ty: ignore[possibly-unbound-attribute]
+            self._es = cma.CMAEvolutionStrategy(x0, self.sigma0, self._opts)
 
     def check_stop(self, ranking_values: np.ndarray) -> bool:
         """Checks if the optimization should stop and be reset.

--- a/ribs/emitters/rankers.py
+++ b/ribs/emitters/rankers.py
@@ -250,7 +250,7 @@ Ranks the solutions based on projection onto a direction in the archive.
     """
 
     def reset(self, emitter: EmitterBase, archive: ArchiveBase) -> None:
-        ranges = archive.upper_bounds - archive.lower_bounds  # ty: ignore[unresolved-attribute]
+        ranges = archive.upper_bounds - archive.lower_bounds
         measure_dim = len(ranges)
         unscaled_dir = self._rng.standard_normal(measure_dim)
         self._target_measure_dir = unscaled_dir * ranges
@@ -324,7 +324,7 @@ direction in the archive.
     """
 
     def reset(self, emitter: EmitterBase, archive: ArchiveBase) -> None:
-        ranges = archive.upper_bounds - archive.lower_bounds  # ty: ignore[unresolved-attribute]
+        ranges = archive.upper_bounds - archive.lower_bounds
         measure_dim = len(ranges)
         unscaled_dir = self._rng.standard_normal(measure_dim)
         self._target_measure_dir = unscaled_dir * ranges

--- a/ribs/emitters/rankers.py
+++ b/ribs/emitters/rankers.py
@@ -41,7 +41,9 @@ from collections.abc import Callable
 import numpy as np
 
 from ribs.archives import ArchiveBase
-from ribs.emitters import EmitterBase
+from ribs.emitters._emitter_base import (
+    EmitterBase,  # Avoid cyclic import since `rankers` is under `ribs.emitters`.
+)
 from ribs.typing import BatchData, Int
 
 # Since the docstrings in this module are auto-generated, Ruff does not see them.
@@ -98,7 +100,7 @@ class RankerBase(ABC):
         self._rng = np.random.default_rng(seed)
 
     @abstractmethod
-    def rank(
+    def rank(  # pylint: disable = missing-function-docstring
         self,
         emitter: EmitterBase,
         archive: ArchiveBase,
@@ -114,6 +116,7 @@ Generates a batch of indices that represents an ordering of ``data["solution"]``
 {_RANK_ARGS}
     """
 
+    # pylint: disable-next = missing-function-docstring
     def reset(self, emitter: EmitterBase, archive: ArchiveBase) -> None:
         pass
 

--- a/ribs/schedulers/_bandit_scheduler.py
+++ b/ribs/schedulers/_bandit_scheduler.py
@@ -304,8 +304,8 @@ class BanditScheduler:
         )
         return self._cur_solutions
 
-    _check_length = Scheduler._check_length
-    _validate_tell_data = Scheduler._validate_tell_data
+    _check_length = Scheduler._check_length  # pylint: disable = protected-access
+    _validate_tell_data = Scheduler._validate_tell_data  # pylint: disable = protected-access
 
     def tell_dqd(
         self,
@@ -395,14 +395,17 @@ class BanditScheduler:
         # Warn the user if nothing was inserted into the archives -- these warnings use
         # stacklevel=2 so that it's clear the error comes from tell().
         if archive_empty_before and self.archive.empty:
+            # pylint: disable-next = protected-access
             warnings.warn(Scheduler._EMPTY_WARNING.format(name="archive"), stacklevel=2)
         if (
             self._result_archive is not None
-            and result_archive_empty_before
+            and result_archive_empty_before  # pylint: disable = possibly-used-before-assignment
             and self.result_archive.empty
         ):
             warnings.warn(
-                Scheduler._EMPTY_WARNING.format(name="result_archive"), stacklevel=2
+                # pylint: disable-next = protected-access
+                Scheduler._EMPTY_WARNING.format(name="result_archive"),
+                stacklevel=2,
             )
 
         # Keep track of pos because emitters may have different batch sizes.

--- a/ribs/schedulers/_scheduler.py
+++ b/ribs/schedulers/_scheduler.py
@@ -286,7 +286,7 @@ class Scheduler:
             warnings.warn(self._EMPTY_WARNING.format(name="archive"), stacklevel=3)
         if (
             self._result_archive is not None
-            and result_archive_empty_before
+            and result_archive_empty_before  # pylint: disable = possibly-used-before-assignment
             and self.result_archive.empty
         ):
             warnings.warn(

--- a/ribs/typing.py
+++ b/ribs/typing.py
@@ -10,16 +10,16 @@ from numpy.typing import DTypeLike
 try:
     import torch
 
-    is_torch_available = True
+    IS_TORCH_AVAILABLE = True
 except ImportError:
-    is_torch_available = False
+    IS_TORCH_AVAILABLE = False
 
 try:
     import cupy as cp
 
-    is_cp_availalbe = True
+    IS_CP_AVAILALBE = True
 except ImportError:
-    is_cp_availalbe = False
+    IS_CP_AVAILALBE = False
 
 ## General types ##
 
@@ -49,11 +49,11 @@ DType = np.dtype
 Device = str | int
 
 # Modify types based on which array backends are available.
-if is_torch_available:
+if IS_TORCH_AVAILABLE:
     Array = Array | torch.Tensor
     DType = DType | torch.dtype
     Device = Device | torch.device
-if is_cp_availalbe:
+if IS_CP_AVAILALBE:
     Array = Array | cp.ndarray
     DType = DType | cp.dtype
     Device = Device | cp.cuda.Device

--- a/ribs/visualize/_cvt_archive_3d_plot.py
+++ b/ribs/visualize/_cvt_archive_3d_plot.py
@@ -272,7 +272,7 @@ def cvt_archive_3d_plot(
 
     # Default ax behavior.
     if ax is None:
-        ax: Axes3D = plt.axes(projection="3d")  # ty: ignore[invalid-assignment]
+        ax: Axes3D = plt.axes(projection="3d")
 
     ax.set_xlim(lower_bounds[0], upper_bounds[0])
     ax.set_ylim(lower_bounds[1], upper_bounds[1])

--- a/ribs/visualize/_cvt_archive_3d_plot.py
+++ b/ribs/visualize/_cvt_archive_3d_plot.py
@@ -14,7 +14,7 @@ from matplotlib.typing import ColorType
 from mpl_toolkits.mplot3d.art3d import Poly3DCollection
 from mpl_toolkits.mplot3d.axes3d import Axes3D
 from pandas import DataFrame
-from scipy.spatial import Voronoi
+from scipy.spatial import Voronoi  # pylint: disable=no-name-in-module
 
 from ribs.archives import ArchiveDataFrame, CVTArchive
 from ribs.visualize._utils import (

--- a/ribs/visualize/_cvt_archive_heatmap.py
+++ b/ribs/visualize/_cvt_archive_heatmap.py
@@ -284,8 +284,8 @@ def cvt_archive_heatmap(
 
         # Retrieve and initialize the axis.
         ax = plt.gca() if ax is None else ax
-        ax.set_xlim(lower_bounds[0], upper_bounds[0])  # ty: ignore[invalid-argument-type]
-        ax.set_ylim(lower_bounds[1], upper_bounds[1])  # ty: ignore[invalid-argument-type]
+        ax.set_xlim(lower_bounds[0], upper_bounds[0])
+        ax.set_ylim(lower_bounds[1], upper_bounds[1])
         ax.set_aspect(aspect)
 
         # Add faraway points so that the edge regions of the Voronoi diagram are filled

--- a/ribs/visualize/_cvt_archive_heatmap.py
+++ b/ribs/visualize/_cvt_archive_heatmap.py
@@ -14,7 +14,7 @@ from matplotlib.axes import Axes
 from matplotlib.cm import ScalarMappable
 from matplotlib.typing import ColorType
 from pandas import DataFrame
-from scipy.spatial import Voronoi
+from scipy.spatial import Voronoi  # pylint: disable=no-name-in-module
 
 from ribs.archives import ArchiveDataFrame, CVTArchive
 from ribs.visualize._utils import (

--- a/ribs/visualize/_grid_archive_heatmap.py
+++ b/ribs/visualize/_grid_archive_heatmap.py
@@ -207,8 +207,8 @@ def grid_archive_heatmap(
 
         # Initialize the axis.
         ax = plt.gca() if ax is None else ax
-        ax.set_xlim(lower_bounds[0], upper_bounds[0])  # ty: ignore[invalid-argument-type]
-        ax.set_ylim(lower_bounds[1], upper_bounds[1])  # ty: ignore[invalid-argument-type]
+        ax.set_xlim(lower_bounds[0], upper_bounds[0])
+        ax.set_ylim(lower_bounds[1], upper_bounds[1])
 
         ax.set_aspect(aspect)
 

--- a/ribs/visualize/_parallel_axes_plot.py
+++ b/ribs/visualize/_parallel_axes_plot.py
@@ -152,9 +152,9 @@ def parallel_axes_plot(
             cols = np.array(measure_order)
             axis_labels = [f"measure_{i}" for i in cols]
         elif all(
-            len(measure) == 2  # ty: ignore[non-subscriptable,invalid-argument-type]
-            and isinstance(measure[0], int)  # ty: ignore[non-subscriptable]
-            and isinstance(measure[1], str)  # ty: ignore[non-subscriptable]
+            len(measure) == 2
+            and isinstance(measure[0], int)
+            and isinstance(measure[1], str)
             for measure in measure_order
         ):
             cols, axis_labels = zip(*measure_order, strict=True)
@@ -179,7 +179,7 @@ def parallel_axes_plot(
 
     # Compute lower and upper bounds; take them from the archive if possible.
     if hasattr(archive, "lower_bounds"):
-        lower_bounds: np.ndarray = archive.lower_bounds  # ty: ignore[invalid-assignment]
+        lower_bounds: np.ndarray = archive.lower_bounds
     elif len(measures) > 0:
         lower_bounds = np.min(measures, axis=0) - 0.01
     else:
@@ -187,7 +187,7 @@ def parallel_axes_plot(
         lower_bounds = np.full(archive.measure_dim, -0.01)
 
     if hasattr(archive, "upper_bounds"):
-        upper_bounds: np.ndarray = archive.upper_bounds  # ty: ignore[invalid-assignment]
+        upper_bounds: np.ndarray = archive.upper_bounds
     elif len(measures) > 0:
         upper_bounds = np.max(measures, axis=0) + 0.01
     else:

--- a/ribs/visualize/_sliding_boundaries_archive_heatmap.py
+++ b/ribs/visualize/_sliding_boundaries_archive_heatmap.py
@@ -154,8 +154,8 @@ def sliding_boundaries_archive_heatmap(
 
     # Initialize the axis.
     ax = plt.gca() if ax is None else ax
-    ax.set_xlim(lower_bounds[0], upper_bounds[0])  # ty: ignore[invalid-argument-type]
-    ax.set_ylim(lower_bounds[1], upper_bounds[1])  # ty: ignore[invalid-argument-type]
+    ax.set_xlim(lower_bounds[0], upper_bounds[0])
+    ax.set_ylim(lower_bounds[1], upper_bounds[1])
     ax.set_aspect(aspect)
 
     # Create the plot.

--- a/ribs/visualize/_utils.py
+++ b/ribs/visualize/_utils.py
@@ -25,7 +25,7 @@ def retrieve_cmap(
         return plt.get_cmap(cmap)
     if isinstance(cmap, Sequence):
         return matplotlib.colors.ListedColormap(cmap)
-    return cmap  # ty: ignore[invalid-return-type]
+    return cmap
 
 
 def validate_heatmap_visual_args(
@@ -134,7 +134,7 @@ def archive_heatmap_1d(
     """
     # Initialize the axis.
     ax = plt.gca() if ax is None else ax
-    ax.set_xlim(archive.lower_bounds[0], archive.upper_bounds[0])  # ty: ignore[invalid-argument-type]
+    ax.set_xlim(archive.lower_bounds[0], archive.upper_bounds[0])
     ax.set_aspect(aspect)
 
     # Turn off yticks; this is a 1D plot so only the x-axis matters.

--- a/tests/archives/archive_base_test.py
+++ b/tests/archives/archive_base_test.py
@@ -13,6 +13,8 @@ from ribs.archives import (
 
 from .conftest import ARCHIVE_NAMES, get_archive_data
 
+# pylint: disable = redefined-outer-name
+
 MAE_ARCHIVES = (
     CategoricalArchive,
     CVTArchive,

--- a/tests/archives/archive_base_test.py
+++ b/tests/archives/archive_base_test.py
@@ -320,7 +320,7 @@ def test_best_elite_extended(add_mode):
     assert archive.best_elite["objective"].shape == ()
     assert archive.best_elite["measures"].shape == (2,)
     assert archive.best_elite["threshold"].shape == ()
-    assert archive.stats.obj_max.shape == ()  # ty: ignore[possibly-unbound-attribute]
+    assert archive.stats.obj_max.shape == ()
 
     assert np.isclose(archive.best_elite["solution"], [1, 2, 3]).all()
     assert np.isclose(archive.best_elite["objective"], 1.0)

--- a/tests/archives/archive_data_frame_test.py
+++ b/tests/archives/archive_data_frame_test.py
@@ -5,6 +5,8 @@ import pytest
 
 from ribs.archives import ArchiveDataFrame
 
+# pylint: disable = redefined-outer-name
+
 
 @pytest.fixture
 def data():

--- a/tests/archives/archive_threshold_update_test.py
+++ b/tests/archives/archive_threshold_update_test.py
@@ -1,4 +1,4 @@
-"""Tests for theshold update in archive."""
+"""Tests for threshold update in archive."""
 
 import numpy as np
 import pytest
@@ -12,10 +12,12 @@ ARCHIVES = pytest.mark.parametrize(
 
 
 def update_threshold(threshold, f_val, learning_rate):
+    """Rule for updating a single threshold."""
     return (1.0 - learning_rate) * threshold + learning_rate * f_val
 
 
 def calc_geom(base_value, exponent):
+    """Helper for computing batch updates."""
     if base_value == 1.0:
         return exponent
     top = 1 - base_value**exponent
@@ -24,6 +26,7 @@ def calc_geom(base_value, exponent):
 
 
 def calc_expected_threshold(additions, cell_value, learning_rate):
+    """Rule for computing updated thresholds with batch updates."""
     k = len(additions)
     geom = calc_geom(1.0 - learning_rate, k)
     f_star = sum(additions)
@@ -39,6 +42,7 @@ def test_threshold_update_for_one_cell(learning_rate, archive):
     objective = np.array([0.1, 0.3, 0.9, 400.0, 42.0])
     indices = np.zeros(5, dtype=np.int32)
 
+    # pylint: disable-next = protected-access
     result_test = archive._compute_thresholds(
         indices, objective, cur_threshold, learning_rate, np.float64
     )
@@ -74,6 +78,7 @@ def test_threshold_update_for_multiple_cells(learning_rate, archive):
     )  # 15 values.
     indices = np.repeat([0, 1, 2], 5)
 
+    # pylint: disable-next = protected-access
     result_test = archive._compute_thresholds(
         indices, objective, cur_threshold, learning_rate, np.float64
     )
@@ -97,6 +102,7 @@ def test_threshold_update_for_empty_objective_and_index(archive):
     objective = np.array([])  # Empty objective.
     indices = np.array([], dtype=np.int32)  # Empty index.
 
+    # pylint: disable-next = protected-access
     new_threshold = archive._compute_thresholds(
         indices, objective, cur_threshold, 0.1, np.float64
     )

--- a/tests/archives/array_store_test.py
+++ b/tests/archives/array_store_test.py
@@ -7,6 +7,8 @@ from array_api_compat import numpy as np
 
 from ribs.archives import ArrayStore
 
+# pylint: disable = redefined-outer-name
+
 
 def test_init_reserved_field(xp_and_device):
     xp, device = xp_and_device

--- a/tests/archives/conftest.py
+++ b/tests/archives/conftest.py
@@ -70,6 +70,7 @@ def get_archive_data(name, *, dtype=np.float64):
     ARCHIVE_NAMES.
     """
     # All local variables are captured at the end.
+    # pylint: disable = possibly-unused-variable
 
     # Characteristics of a single solution to insert into archive_with_elite.
     solution = np.array([1.0, 2.0, 3.0])
@@ -107,7 +108,7 @@ def get_archive_data(name, *, dtype=np.float64):
         # 0.5), (-0.5, 0.5), (-0.5, -0.5), and (0.5, -0.5). The elite in
         # archive_with_elite should match with centroid (0.5, 0.5).
         cells = 4
-        nearest_neighbors = name.removeprefix("CVTArchive-")
+        cur_nn = name.removeprefix("CVTArchive-")
         centroids = [[0.5, 0.5], [-0.5, 0.5], [-0.5, -0.5], [0.5, -0.5]]
         centroid = [0.5, 0.5]
 
@@ -115,7 +116,7 @@ def get_archive_data(name, *, dtype=np.float64):
             solution_dim=len(solution),
             centroids=centroids,
             ranges=[(-1, 1), (-1, 1)],
-            nearest_neighbors=nearest_neighbors,
+            nearest_neighbors=cur_nn,
             solution_dtype=dtype,
             objective_dtype=dtype,
             measures_dtype=dtype,
@@ -125,7 +126,7 @@ def get_archive_data(name, *, dtype=np.float64):
             solution_dim=len(solution),
             centroids=centroids,
             ranges=[(-1, 1), (-1, 1)],
-            nearest_neighbors=nearest_neighbors,
+            nearest_neighbors=cur_nn,
             solution_dtype=dtype,
             objective_dtype=dtype,
             measures_dtype=dtype,

--- a/tests/archives/cqd_score_test.py
+++ b/tests/archives/cqd_score_test.py
@@ -7,6 +7,8 @@ from ribs.archives import GridArchive, ProximityArchive, cqd_score
 
 from .conftest import get_archive_data
 
+# pylint: disable = redefined-outer-name
+
 
 @pytest.fixture
 def data():

--- a/tests/archives/custom_fields_test.py
+++ b/tests/archives/custom_fields_test.py
@@ -7,6 +7,8 @@ from ribs.archives import GridArchive
 
 from .conftest import get_archive_data
 
+# pylint: disable = redefined-outer-name
+
 
 @pytest.fixture
 def data():

--- a/tests/archives/cvt_archive_test.py
+++ b/tests/archives/cvt_archive_test.py
@@ -9,6 +9,8 @@ from ribs.archives import AddStatus, CVTArchive
 
 from .conftest import get_archive_data
 
+# pylint: disable=redefined-outer-name
+
 
 @pytest.fixture
 def data(nearest_neighbors):

--- a/tests/archives/density_archive_test.py
+++ b/tests/archives/density_archive_test.py
@@ -32,7 +32,7 @@ def test_dtype():
         bandwidth=2.0,
         dtype=np.float32,
     )
-    assert archive._measures_dtype == np.float32
+    assert archive._measures_dtype == np.float32  # pylint: disable = protected-access
 
 
 def test_measures_dtype():
@@ -43,7 +43,7 @@ def test_measures_dtype():
         bandwidth=2.0,
         measures_dtype=np.float32,
     )
-    assert archive._measures_dtype == np.float32
+    assert archive._measures_dtype == np.float32  # pylint: disable = protected-access
 
 
 def test_simultaneous_dtypes():

--- a/tests/archives/grid_archive_test.py
+++ b/tests/archives/grid_archive_test.py
@@ -7,6 +7,8 @@ from ribs.archives import AddStatus, GridArchive
 
 from .conftest import get_archive_data
 
+# pylint: disable=redefined-outer-name
+
 
 @pytest.fixture
 def data():
@@ -75,6 +77,7 @@ def assert_archive_elites(
                 measures_match = True
 
             index_match = (
+                # pylint: disable-next = possibly-used-before-assignment
                 grid_indices_batch is None or data["index"][j] == index_batch[i]
             )
 

--- a/tests/archives/proximity_archive_test.py
+++ b/tests/archives/proximity_archive_test.py
@@ -7,6 +7,8 @@ from numpy.testing import assert_allclose, assert_equal
 from ribs.archives import AddStatus, ProximityArchive
 from tests.archives.conftest import get_archive_data
 
+# pylint: disable=redefined-outer-name
+
 
 @pytest.fixture
 def data():

--- a/tests/archives/sliding_boundaries_archive_test.py
+++ b/tests/archives/sliding_boundaries_archive_test.py
@@ -8,6 +8,8 @@ from ribs.archives import AddStatus, SlidingBoundariesArchive
 from .conftest import get_archive_data
 from .grid_archive_test import assert_archive_elite
 
+# pylint: disable=redefined-outer-name
+
 
 @pytest.fixture
 def data():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,7 +29,7 @@ except ImportError:
 
 try:
     import cupy as cp
-    from cupy_backends.cuda.api.runtime import (  # ty: ignore[unresolved-import]
+    from cupy_backends.cuda.api.runtime import (
         CUDARuntimeError,
     )
 

--- a/tests/emitters/emitter_base_test.py
+++ b/tests/emitters/emitter_base_test.py
@@ -11,6 +11,8 @@ from ribs.emitters import (
     IsoLineEmitter,
 )
 
+# pylint: disable=redefined-outer-name
+
 
 @pytest.fixture(
     params=[

--- a/tests/emitters/evolution_strategy_emitter_test.py
+++ b/tests/emitters/evolution_strategy_emitter_test.py
@@ -9,6 +9,8 @@ from ribs.emitters import EvolutionStrategyEmitter
 RANKER_LIST = ["imp", "2imp", "rd", "2rd", "obj", "2obj"]
 ES_LIST = ["cma_es", "sep_cma_es", "lm_ma_es", "openai_es"]
 
+# pylint: disable=redefined-outer-name
+
 
 @pytest.fixture
 def emitter_fixture(request):

--- a/tests/emitters/optimizer_test.py
+++ b/tests/emitters/optimizer_test.py
@@ -34,10 +34,10 @@ def test_init_with_get_es(es_name):
 
     # Technically, these attributes are not part of the API, but all of our ES's have
     # them.
-    assert es.batch_size == es_kwargs["batch_size"]  # ty: ignore[unresolved-attribute]
-    assert es.sigma0 == es_kwargs["sigma0"]  # ty: ignore[unresolved-attribute]
-    assert es.solution_dim == es_kwargs["solution_dim"]  # ty: ignore[unresolved-attribute]
-    assert es.dtype == es_kwargs["dtype"]  # ty: ignore[unresolved-attribute]
+    assert es.batch_size == es_kwargs["batch_size"]
+    assert es.sigma0 == es_kwargs["sigma0"]
+    assert es.solution_dim == es_kwargs["solution_dim"]
+    assert es.dtype == es_kwargs["dtype"]
 
 
 # Gradient Optimizer Tests

--- a/tests/emitters/optimizer_test.py
+++ b/tests/emitters/optimizer_test.py
@@ -62,6 +62,7 @@ def test_init_with_get_grad_opt(grad_opt_name):
 
     assert grad_opt.theta == theta0
 
+    # pylint: disable = protected-access
     grad_opt = cast(GradientAscentOpt | AdamOpt, grad_opt)
     assert grad_opt._lr == lr
     if grad_opt_name == "adam":

--- a/tests/emitters/rankers_test.py
+++ b/tests/emitters/rankers_test.py
@@ -15,6 +15,8 @@ from ribs.emitters.rankers import (
     TwoStageRandomDirectionRanker,
 )
 
+# pylint: disable = redefined-outer-name
+
 
 @pytest.fixture
 def emitter():
@@ -120,7 +122,8 @@ def test_two_stage_random_direction(emitter):
         solution_batch[1:], objective_batch[1:], measures_batch[1:]
     )
     add_info = {
-        key: np.concatenate(([first_info[key]], second_info[key])) for key in first_info
+        key: np.concatenate(([first_info[key]], second_info[key]))
+        for key in first_info  # pylint: disable = consider-using-dict-items
     }
 
     ranker = TwoStageRandomDirectionRanker()

--- a/tests/emitters_pymoo/bayesopt_emitter_test.py
+++ b/tests/emitters_pymoo/bayesopt_emitter_test.py
@@ -6,6 +6,8 @@ import pytest
 from ribs.archives import CVTArchive, GridArchive
 from ribs.emitters import BayesianOptimizationEmitter
 
+# pylint: disable=redefined-outer-name
+
 
 @pytest.fixture
 def archive_fixture():

--- a/tests/emitters_pymoo/bayesopt_emitter_test.py
+++ b/tests/emitters_pymoo/bayesopt_emitter_test.py
@@ -78,7 +78,7 @@ def test_wrong_archive_type():
         r" BayesianOptimizationEmitter\. Expected GridArchive\.",
     ):
         BayesianOptimizationEmitter(
-            archive,  # ty: ignore[invalid-argument-type]
+            archive,
             lower_bounds=[-1],
             upper_bounds=[1],
             num_initial_samples=1,

--- a/tests/schedulers/scheduler_test.py
+++ b/tests/schedulers/scheduler_test.py
@@ -9,6 +9,8 @@ from ribs.schedulers import BanditScheduler, Scheduler
 
 from ..archives.grid_archive_test import assert_archive_elites
 
+# pylint: disable=redefined-outer-name
+
 
 @pytest.fixture
 def scheduler_fixture():

--- a/tests/schedulers/scheduler_test.py
+++ b/tests/schedulers/scheduler_test.py
@@ -64,7 +64,7 @@ def test_init_fails_with_non_list():
     emitters = GaussianEmitter(archive, sigma=1, x0=[0.0, 0.0], batch_size=1)
 
     with pytest.raises(TypeError):
-        Scheduler(archive, emitters)  # ty: ignore[invalid-argument-type]
+        Scheduler(archive, emitters)
 
 
 def test_init_fails_with_no_emitters():

--- a/tests/visualize/cvt_archive_3d_plot_test.py
+++ b/tests/visualize/cvt_archive_3d_plot_test.py
@@ -93,7 +93,7 @@ def test_3d(cvt_archive_3d):
 )
 def test_3d_custom_axis(cvt_archive_3d):
     ax = plt.axes(projection="3d")
-    cvt_archive_3d_plot(cvt_archive_3d, ax=ax)  # ty: ignore[invalid-argument-type]
+    cvt_archive_3d_plot(cvt_archive_3d, ax=ax)
 
 
 @image_comparison(

--- a/tests/visualize/cvt_archive_3d_plot_test.py
+++ b/tests/visualize/cvt_archive_3d_plot_test.py
@@ -13,6 +13,8 @@ from ribs.visualize import cvt_archive_3d_plot
 
 from .conftest import add_uniform_sphere_3d
 
+# pylint: disable=redefined-outer-name
+
 # Tolerance for root mean square difference between the pixels of the images,
 # where 255 is the max value. We have a pretty high tolerance for
 # `cvt_archive_3d_plot` since 3D rendering tends to vary a bit.

--- a/tests/visualize/cvt_archive_heatmap_test.py
+++ b/tests/visualize/cvt_archive_heatmap_test.py
@@ -14,6 +14,8 @@ from ribs.visualize import cvt_archive_heatmap
 
 from .conftest import add_uniform_sphere_1d, add_uniform_sphere_2d
 
+# pylint: disable=redefined-outer-name
+
 # Tolerance for root mean square difference between the pixels of the images,
 # where 255 is the max value. We have tolerance for `cvt_archive_heatmap` since
 # it is a bit more finicky than the other plots.

--- a/tests/visualize/grid_archive_heatmap_test.py
+++ b/tests/visualize/grid_archive_heatmap_test.py
@@ -16,6 +16,8 @@ from .conftest import (
     add_uniform_sphere_3d,
 )
 
+# pylint: disable=redefined-outer-name
+
 #
 # Fixtures
 #

--- a/tests/visualize/parallel_axes_plot_test.py
+++ b/tests/visualize/parallel_axes_plot_test.py
@@ -10,12 +10,16 @@ from ribs.visualize import parallel_axes_plot
 
 # See https://github.com/astral-sh/ruff/issues/10662
 # ruff: noqa: F401, F811
-from .grid_archive_heatmap_test import (
+from .grid_archive_heatmap_test import (  # pylint: disable = unused-import
     grid_archive_2d,
     grid_archive_3d,
     grid_archive_3d_empty,
 )
-from .proximity_archive_plot_test import proximity_archive_2d_obj
+from .proximity_archive_plot_test import (  # pylint: disable = unused-import
+    proximity_archive_2d_obj,
+)
+
+# pylint: disable=redefined-outer-name
 
 
 @image_comparison(baseline_images=["2d"], remove_text=False, extensions=["png"])

--- a/tests/visualize/proximity_archive_plot_test.py
+++ b/tests/visualize/proximity_archive_plot_test.py
@@ -11,6 +11,8 @@ from matplotlib.testing.decorators import image_comparison
 from ribs.archives import ProximityArchive
 from ribs.visualize import proximity_archive_plot
 
+# pylint: disable=redefined-outer-name
+
 #
 # Fixtures
 #

--- a/tests/visualize/sliding_boundaries_archive_heatmap_test.py
+++ b/tests/visualize/sliding_boundaries_archive_heatmap_test.py
@@ -11,6 +11,8 @@ from matplotlib.testing.decorators import image_comparison
 from ribs.archives import SlidingBoundariesArchive
 from ribs.visualize import sliding_boundaries_archive_heatmap
 
+# pylint: disable = redefined-outer-name
+
 #
 # Fixtures
 #

--- a/tutorials/qdaif.ipynb
+++ b/tutorials/qdaif.ipynb
@@ -1004,7 +1004,7 @@
     "\n",
     "# Save video in output_dir and display in this notebook.\n",
     "clip.write_videofile(str(output_dir / \"heatmap_video.mp4\"))\n",
-    "clip.display_in_notebook()  # ty: ignore[unresolved-attribute]"
+    "clip.display_in_notebook()"
    ]
   },
   {


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the PR's purpose here. -->

In #605, we removed pylint in favor of running ruff and ultimately ty. However, this has turned out to be quite poor for developer workflow, as ty tends to produce lots of spurious type checking errors -- I feel pylint strikes a better balance of performing just enough static analysis to provide useful error messages, and we have also used it for a long time on this project. Thus, I am essentially reverting #605 and removing ty.

## TODO

<!-- Notable points that this PR has either accomplished or will accomplish. -->

- [x] Add in relevant pylint macros
- [x] Check for `ty: ignore` statements
  - Removed them with: `find ribs -name "*.py" -exec sed -i 's/[[:blank:]]*# *ty: *ignore.*//g' {} +` (replace `ribs` with other directories as appropriate)
- [x] Check that CI/CD works

## Status

- [x] I have read the guidelines in
      [CONTRIBUTING.md](https://github.com/icaros-usc/pyribs/blob/master/CONTRIBUTING.md)
- [x] I have linted and formatted my code with `ruff` and `pylint`
- [x] I have tested my code by running `pytest`
- [x] I have added a description of my change to the changelog in `HISTORY.md`
- [x] This PR is ready to go
