### PR TITLE
Add PyTorch to ribs[all] deps

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -100,7 +100,7 @@ jobs:
           python-version: "3.12"
           channels: conda-forge,defaults
       - name: Install deps
-        run: pip install .[all,dev] torch
+        run: pip install .[all,dev]
       - name: Test coverage
         env:
           NUMBA_DISABLE_JIT: 1

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,6 +6,7 @@
 
 #### API
 
+- Add PyTorch to ribs[all] deps ({pr}`692`)
 - Add `NSLCRanker` for Novelty Search with Local Competition ({pr}`690`)
 
 ## 0.10.0

--- a/README.md
+++ b/README.md
@@ -124,19 +124,6 @@ python -c "import ribs; print(ribs.__version__)"
 
 You should see a version number in the output.
 
-### PyTorch Dependency
-
-Some components of pyribs, such as `ribs.discount_models`, depend on PyTorch.
-Since PyTorch is a large package, we do not include it in the pyribs
-dependencies by default, and we leave it to users to install PyTorch on their
-own. To this end, we recommend referring to the
-[PyTorch installation guide](https://pytorch.org/get-started/locally/). One
-installation command that may work for many users is:
-
-```bash
-pip install torch
-```
-
 ## Usage
 
 Here we show an example application of CMA-ME in pyribs. To initialize the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,8 +54,9 @@ all = [
   ### Extra dependencies used by various components. ###
   "cma",
   "pymoo",
-  # PyTorch (torch) is used in components like discount models and could be included
-  # here, but since it is so large, we leave it to users to install on their own.
+
+  # Since there are many ways to install PyTorch, we keep our dependency fairly loose.
+  "torch",
 ]
 dev = [
   # Tools


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the PR's purpose here. -->

Previously, we did not add PyTorch to the dependencies in ribs[all] because it is such a heavy dependency. However, it seems we may be taking on additional PyTorch dependencies in the future like zuko for DDS-CNF in #691. I figure it is good to keep track of the versions of these dependencies that we need, as we can't always count on things working with all versions. Thus, I am adding PyTorch to ribs[all]. Where relevant (like in the installation selector), we can add a note that ribs[all] is heavy due to depending on PyTorch. I think that if users need a smaller installation, they can choose to install just the dependencies that they want (e.g., pycma or pymoo) without installing ribs[all]. This way, ribs[all] also reflects the true dependencies that are needed for running _all_ of pyribs.

## TODO

<!-- Notable points that this PR has either accomplished or will accomplish. -->

- [x] Update deps in pyproject.toml
- [x] Remove PyTorch note in README
- [x] Remove unnecessary torch install in CI

## Status

- [x] I have read the guidelines in
      [CONTRIBUTING.md](https://github.com/icaros-usc/pyribs/blob/master/CONTRIBUTING.md)
- [x] I have linted and formatted my code with `ruff` and `pylint`
- [x] I have tested my code by running `pytest`
- [x] I have added a description of my change to the changelog in `HISTORY.md`
- [x] This PR is ready to go
