### PR TITLE
Add Sphinx role for github badges

### DIFF
--- a/docs/_ext/colab_link.py
+++ b/docs/_ext/colab_link.py
@@ -9,6 +9,7 @@ logger = logging.getLogger(__name__)
 
 
 def add_colab_link(
+    # pylint: disable = unused-argument
     app,
     pagename,
     templatename,  # noqa: ARG001
@@ -33,7 +34,7 @@ def add_colab_link(
         button_html = f"""\
 <p>
   <a href="{colab_url}" target="_blank" rel="noopener noreferrer">
-    <img src="https://colab.research.google.com/assets/colab-badge.svg" f'alt="Open in Colab"/>
+    <img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open in Colab"/>
   </a>
 </p>
 """

--- a/docs/_ext/github_links.py
+++ b/docs/_ext/github_links.py
@@ -40,6 +40,7 @@ def make_link_node(rawtext, app, link_type, slug, options):
 
 
 def github_link_role(
+    # pylint: disable = unused-argument
     name,
     rawtext,
     text,
@@ -90,8 +91,38 @@ def github_link_role(
     return [node], []
 
 
+def github_badge_role(
+    # pylint: disable = unused-argument
+    name,  # noqa: ARG001
+    rawtext,  # noqa: ARG001
+    text,
+    lineno,  # noqa: ARG001
+    inliner,  # noqa: ARG001
+    options=None,
+    content=(),  # noqa: ARG001
+):
+    """Link to a GitHub resource with a badge."""
+    options = options or {}
+
+    # The 'text' passed to the role is the URL
+    url = utils.unescape(text)
+
+    # Badge HTML template
+    badge_html = (
+        f'<a href="{url}" target="_blank" rel="noopener noreferrer">'
+        f'<img src="https://img.shields.io/badge/github-%23121011.svg?style=for-the-badge&logo=github&logoColor=white" '
+        f'alt="Open in GitHub"/></a>'
+    )
+
+    # Create a raw node that tells Sphinx to treat this as literal HTML
+    node = nodes.raw("", badge_html, format="html")
+
+    return [node], []
+
+
 def setup(app):
     """Installs the extension."""
     app.add_role("issue", github_link_role)
     app.add_role("pr", github_link_role)
+    app.add_role("gh-badge", github_badge_role)
     app.add_config_value("github_repo_url", None, "env")

--- a/docs/examples/bop_elites.md
+++ b/docs/examples/bop_elites.md
@@ -7,6 +7,8 @@ model the objective and measure functions and select solutions to evaluate. The
 script below shows how to implement BOP-Elites on the sphere linear projection
 benchmark.
 
+{gh-badge}`https://github.com/icaros-usc/pyribs/blob/master/examples/bop_elites.py`
+
 ```{eval-rst}
 .. literalinclude:: ../../examples/bop_elites.py
     :language: python

--- a/docs/examples/cqd_score.md
+++ b/docs/examples/cqd_score.md
@@ -7,6 +7,8 @@ metric that accounts for tradeoffs between objective values and distance to
 desired measure values. Notably, the CQD Score does not depend on the
 discretization/tessellation of the archive.
 
+{gh-badge}`https://github.com/icaros-usc/pyribs/blob/master/examples/cqd_score.py`
+
 ```{eval-rst}
 .. literalinclude:: ../../examples/cqd_score.py
     :language: python

--- a/docs/examples/lunar_lander.md
+++ b/docs/examples/lunar_lander.md
@@ -4,6 +4,8 @@ This example extends the [Lunar Lander tutorial](../tutorials/lunar_lander) by
 using [Dask](https://dask.org) to distribute evaluations and thus speed things
 up. It also adds in more logging capabilities and a CLI.
 
+{gh-badge}`https://github.com/icaros-usc/pyribs/blob/master/examples/lunar_lander.py`
+
 ```{eval-rst}
 .. literalinclude:: ../../examples/lunar_lander.py
     :language: python


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the PR's purpose here. -->

Add Sphinx role for GitHub badges so that we can easily add a GitHub link, similar to our "Open in Colab" link.

## Status

- [x] I have read the guidelines in
      [CONTRIBUTING.md](https://github.com/icaros-usc/pyribs/blob/master/CONTRIBUTING.md)
- [x] I have linted and formatted my code with `ruff` and `pylint`
- [x] I have tested my code by running `pytest`
- [x] I have added a description of my change to the changelog in `HISTORY.md`
- [x] This PR is ready to go
