### PR TITLE
Fix incorrect insertion of non-novel solutions in ProximityArchive.add

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,6 +4,8 @@
 
 ### Changelog
 
+- Fix incorrect insertion of non-novel solutions in ProximityArchive.add when no improving solutions are present
+
 #### API
 
 - Add PyTorch to ribs[all] deps ({pr}`692`)

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,7 +4,10 @@
 
 ### Changelog
 
-- Fix incorrect insertion of non-novel solutions in ProximityArchive.add when no improving solutions are present
+#### Bugs
+
+- Fix incorrect insertion of non-novel solutions in ProximityArchive.add when no
+  improving solutions are present ({pr}`704`)
 
 #### API
 

--- a/ribs/archives/_proximity_archive.py
+++ b/ribs/archives/_proximity_archive.py
@@ -652,20 +652,23 @@ class ProximityArchive(ArchiveBase):
             # Separate out the non-novel data for further processing. Solutions that
             # were not novel enough have the potential to replace their nearest
             # neighbors in the archive.
-            data = {name: arr[not_novel_enough] for name, arr in data.items()}
-            indices = (
-                self.index_of(data["measures"])
+            not_novel_data = {name: arr[not_novel_enough] for name, arr in data.items()}
+            not_novel_indices = (
+                self.index_of(not_novel_data["measures"])
                 if n_not_novel_enough > 0
                 else np.array([], dtype=np.int32)
             )
 
+            # No longer used.
+            del data
+
             # All entries are occupied since these solutions were not novel, and their
             # index from `index_of` is the index of their nearest neighbor.
-            _, cur_data = self._store.retrieve(indices)
+            _, cur_data = self._store.retrieve(not_novel_indices)
             cur_objective = cur_data["objective"]
 
-            # Can only be used to index `data` and `indices`.
-            improve_existing = data["objective"] > cur_objective
+            # Can only be used to index `not_novel_data` and `not_novel_indices`.
+            improve_existing = not_novel_data["objective"] > cur_objective
 
             # Information to return about the addition.
             add_info = {}
@@ -675,15 +678,22 @@ class ProximityArchive(ArchiveBase):
             add_info["status"][not_novel_enough] = improve_existing
             add_info["value"] = np.empty(batch_size, dtype=self.dtypes["objective"])
             add_info["value"][novel_enough] = novel_data["objective"]
-            add_info["value"][not_novel_enough] = data["objective"] - cur_objective
+            add_info["value"][not_novel_enough] = (
+                not_novel_data["objective"] - cur_objective
+            )
             add_info["novelty"] = novelty
             add_info["local_competition"] = local_competition
 
-            # Select all solutions that can be inserted due to beating their
-            # neighbors -- at this point, there are still conflicts in the
-            # insertions, e.g., multiple solutions can map to index 0.
-            indices = indices[improve_existing]
-            data = {name: arr[improve_existing] for name, arr in data.items()}
+            # Select all solutions that can be inserted due to beating their neighbors
+            # -- at this point, there are still conflicts in the insertions, e.g.,
+            # multiple solutions can map to index 0. Note that we need to filter this
+            # data here (instead of in the if statement) because the not_novel_data is
+            # always used when adding to the archive in the next if statement; see
+            # https://github.com/icaros-usc/pyribs/pull/704/ for more info.
+            not_novel_indices = not_novel_indices[improve_existing]
+            not_novel_data = {
+                name: arr[improve_existing] for name, arr in not_novel_data.items()
+            }
             cur_objective = cur_objective[improve_existing]
 
             if np.any(improve_existing):
@@ -703,20 +713,29 @@ class ProximityArchive(ArchiveBase):
                 # numpy implementation for more info:
                 # https://github.com/ml31415/numpy-groupies/blob/master/numpy_groupies/aggregate_numpy.py#L107
                 archive_argmax = aggregate(
-                    indices, data["objective"], func="argmax", fill_value=-1
+                    not_novel_indices,
+                    not_novel_data["objective"],
+                    func="argmax",
+                    fill_value=-1,
                 )
                 should_insert = archive_argmax[archive_argmax != -1]
 
                 # Select only solutions that will be inserted into the archive.
-                indices = indices[should_insert]
-                data = {name: arr[should_insert] for name, arr in data.items()}
+                not_novel_indices = not_novel_indices[should_insert]
+                not_novel_data = {
+                    name: arr[should_insert] for name, arr in not_novel_data.items()
+                }
                 cur_objective = cur_objective[should_insert]
 
             if np.any(improve_existing) or n_novel_enough > 0:
-                combined_indices = np.concatenate((indices, novel_indices), axis=0)
+                combined_indices = np.concatenate(
+                    (not_novel_indices, novel_indices), axis=0
+                )
                 combined_data = {
-                    name: np.concatenate((data[name], novel_data[name]), axis=0)
-                    for name in data
+                    name: np.concatenate(
+                        (not_novel_data[name], novel_data[name]), axis=0
+                    )
+                    for name in novel_data
                 }
                 # Insert the solutions that improved over their neighbors, as well as
                 # the solutions that are novel.
@@ -726,7 +745,7 @@ class ProximityArchive(ArchiveBase):
                 objective_sum = (
                     self._objective_sum
                     + np.sum(novel_data["objective"])
-                    + np.sum(data["objective"] - cur_objective)
+                    + np.sum(not_novel_data["objective"] - cur_objective)
                 )
                 best_index = combined_indices[np.argmax(combined_data["objective"])]
                 self._stats_update(objective_sum, best_index)

--- a/ribs/archives/_proximity_archive.py
+++ b/ribs/archives/_proximity_archive.py
@@ -679,14 +679,14 @@ class ProximityArchive(ArchiveBase):
             add_info["novelty"] = novelty
             add_info["local_competition"] = local_competition
 
-            if np.any(improve_existing):
-                # Select all solutions that can be inserted due to beating their
-                # neighbors -- at this point, there are still conflicts in the
-                # insertions, e.g., multiple solutions can map to index 0.
-                indices = indices[improve_existing]
-                data = {name: arr[improve_existing] for name, arr in data.items()}
-                cur_objective = cur_objective[improve_existing]
+            # Select all solutions that can be inserted due to beating their
+            # neighbors -- at this point, there are still conflicts in the
+            # insertions, e.g., multiple solutions can map to index 0.
+            indices = indices[improve_existing]
+            data = {name: arr[improve_existing] for name, arr in data.items()}
+            cur_objective = cur_objective[improve_existing]
 
+            if np.any(improve_existing):
                 # Retrieve indices of solutions that _should_ be inserted into the
                 # archive. Currently, multiple solutions may be inserted at each archive
                 # index, but we only want to insert the maximum among these solutions.

--- a/tests/archives/proximity_archive_test.py
+++ b/tests/archives/proximity_archive_test.py
@@ -831,3 +831,37 @@ def test_lc_add_batch_replace_same_cell():
     )
     assert_equal(add_info["local_competition"], [1, 1, 2, 0])
     assert_allclose(add_info["value"], [1, 2, 3, 0])
+
+
+def test_add_novel_and_not_novel_no_improve_bug():
+    archive = ProximityArchive(
+        solution_dim=3,
+        measure_dim=2,
+        k_neighbors=1,
+        novelty_threshold=1.0,
+        local_competition=True,
+    )
+
+    # Initial solution
+    archive.add([[1, 1, 1]], [10.0], [[0, 0]])
+
+    # Add batch:
+    # Solution [2, 2, 2] is not_novel_enough and has a lower objective so it shouldn't be added.
+    # Solution [3, 3, 3] should be novel_enough so it should be added.
+    add_info = archive.add(
+        solution=[[2, 2, 2], [3, 3, 3]],
+        objective=[5.0, 10.0],
+        measures=[[0.1, 0.0], [5.0, 5.0]],
+    )
+
+    assert_equal(add_info["status"], [0, 2])
+
+    # We should have exactly 2 solutions total: original and the new novel one.
+    assert len(archive) == 2
+    assert_archive_elites(
+        archive=archive,
+        batch_size=2,
+        solution_batch=[[1, 1, 1], [3, 3, 3]],
+        objective_batch=[10.0, 10.0],
+        measures_batch=[[0, 0], [5.0, 5.0]],
+    )


### PR DESCRIPTION
## Description
Previously, when there where no improving_exiting solutions but at least one novel_enough solution the archive would insert all not_novel_enough solutions polluting the archive.

This fix ensures that only valid candidates are inserted.

Also adds test to prove behaviour.

## Status
- [x] I have read the guidelines in
      [CONTRIBUTING.md](https://github.com/icaros-usc/pyribs/blob/master/CONTRIBUTING.md)
- [x] I have linted and formatted my code with `ruff` and `pylint`
- [x] I have tested my code by running `pytest`
- [x] I have added a description of my change to the changelog in `HISTORY.md`
- [x] This PR is ready to go
