### PR TITLE
Implement `novelty_threshold` decay in `ProximityArchive`

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -15,7 +15,7 @@
 - Add `DDS-CNF` density method to `DensityArchive` ({pr}`691`, {pr}`707`)
 - Add PyTorch to ribs[all] deps ({pr}`692`)
 - Add `NSLCRanker` for Novelty Search with Local Competition ({pr}`690`)
-- Implements `novelty_threshold` decay in `ProximityArchive`({issue}`540`, {pr}`708`)
+- Implement `novelty_threshold` decay in `ProximityArchive` ({pr}`709`)
 
 #### Documentation
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,13 @@
 # History
 
+## (Forthcoming)
+
+### Changelog
+
+#### API
+
+- Implement `novelty_threshold` decay in `ProximityArchive` ({pr}`709`)
+
 ## 0.11.0
 
 ### Changelog
@@ -15,7 +23,6 @@
 - Add `DDS-CNF` density method to `DensityArchive` ({pr}`691`, {pr}`707`)
 - Add PyTorch to ribs[all] deps ({pr}`692`)
 - Add `NSLCRanker` for Novelty Search with Local Competition ({pr}`690`)
-- Implement `novelty_threshold` decay in `ProximityArchive` ({pr}`709`)
 
 #### Documentation
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -15,6 +15,7 @@
 - Add `DDS-CNF` density method to `DensityArchive` ({pr}`691`, {pr}`707`)
 - Add PyTorch to ribs[all] deps ({pr}`692`)
 - Add `NSLCRanker` for Novelty Search with Local Competition ({pr}`690`)
+- Implements `novelty_threshold` decay in `ProximityArchive`({issue}`540`, {pr}`708`)
 
 #### Documentation
 

--- a/README.md
+++ b/README.md
@@ -267,6 +267,7 @@ USC. For information on contributing to the repo, see
 - [Efstathios Siatras](https://siatras.com/)
 - [Milo Brontesi](https://github.com/zibasPk)
 - [Stefanos Nikolaidis](https://stefanosnikolaidis.net)
+- [Alejandro Marrero](https://github.com/amarrerod)
 
 We thank [Amy K. Hoover](http://amykhoover.com/) and
 [Julian Togelius](http://julian.togelius.com/) for their contributions deriving

--- a/README.md
+++ b/README.md
@@ -266,8 +266,8 @@ USC. For information on contributing to the repo, see
 - [Ryan Boldi](https://ryanboldi.github.io)
 - [Efstathios Siatras](https://siatras.com/)
 - [Milo Brontesi](https://github.com/zibasPk)
-- [Stefanos Nikolaidis](https://stefanosnikolaidis.net)
 - [Alejandro Marrero](https://github.com/amarrerod)
+- [Stefanos Nikolaidis](https://stefanosnikolaidis.net)
 
 We thank [Amy K. Hoover](http://amykhoover.com/) and
 [Julian Togelius](http://julian.togelius.com/) for their contributions deriving

--- a/ribs/archives/_proximity_archive.py
+++ b/ribs/archives/_proximity_archive.py
@@ -102,16 +102,17 @@ class ProximityArchive(ArchiveBase):
             *subtracted* from all objectives in the archive, e.g., if your objectives go
             as low as -300, pass in -300 so that each objective will be transformed as
             ``objective - (-300)``.
-        threshold_decay_itrs: Maximum number of call to ``add`` without inserting novel
-            solutions, before decreasing the ``novelty_threshold`` by a factor of
-            ``threshold_decay_rate``. This is an optional parameter that by default is set to
-            None, which means that the ``novelty_threshold`` is never updated.
-        threshold_decay_rate: Decay factor to reduce the ``novelty_treshold`` if there were
-            ``threshold_decay_itrs`` iterations without inserting novelty solutions.
-            This is an optional float value in the range [0.0, 1.0]. The default is
-            None, which indicates that the ``novelty_threshold`` is never updated.
-        threshold_decay_min: Minimum value for the ``novelty_treshold`` if threshold
-            decay is enabled. The default is 0.0.
+        threshold_decay_rate: Decay factor to reduce the ``novelty_threshold``. When
+            :meth:`add` is called ``threshold_decay_itrs`` times in a row without
+            inserting any novel solutions, the ``novelty_threshold`` is multiplied by
+            this rate. The default value is None, which indicates that there is no
+            decay. If passed in, it must be a float value in the range [0.0, 1.0].
+        threshold_decay_itrs: See ``threshold_decay_rate`` above. This parameter only
+            applies if ``threshold_decay_rate`` is set. The default value of 1 indicates
+            that the ``novelty_threshold`` will be decreased immediately after a call to
+            :meth:`add` has no solutions that are novel enough.
+        threshold_decay_min: Minimum value for the ``novelty_threshold`` if threshold
+            decay is enabled.
         seed: Value to seed the random number generator. Set to None to avoid a fixed
             seed.
         solution_dtype: Data type of the solutions. Defaults to float64 (numpy's default
@@ -150,8 +151,8 @@ class ProximityArchive(ArchiveBase):
         local_competition: bool = False,
         initial_capacity: Int = 128,
         qd_score_offset: Float = 0.0,
-        threshold_decay_itrs: Int | None = None,
         threshold_decay_rate: Float | None = None,
+        threshold_decay_itrs: Int = 1,
         threshold_decay_min: Float = 0.0,
         seed: Int | None = None,
         solution_dtype: DTypeLike = None,
@@ -192,29 +193,6 @@ class ProximityArchive(ArchiveBase):
         solution_dtype, objective_dtype, measures_dtype = parse_all_dtypes(
             dtype, solution_dtype, objective_dtype, measures_dtype, np
         )
-
-        # By default, threshold decay is not defined.
-        self._max_it_without_imp = None
-        if threshold_decay_itrs is not None:
-            if threshold_decay_itrs < 0:
-                raise ValueError(
-                    "threshold_decay_itrs must be either None or a positive integer."
-                )
-            if threshold_decay_rate is None or (
-                threshold_decay_rate <= 0.0 or threshold_decay_rate > 1.0
-            ):
-                raise ValueError(
-                    "If threshold_decay_itrs is not None, threshold decay must be a float in the range [0.0, 1.0]."
-                )
-            # The minimum could be 0.0
-            if threshold_decay_min < 0.0:
-                raise ValueError("threshold_decay_min must be a positive float value.")
-
-            self._max_it_without_imp = int(threshold_decay_itrs)
-            self._threshold_decay = float(threshold_decay_rate)
-            self._threshold_decay_min = float(threshold_decay_min)
-            self._its_without_imp = 0
-
         self._store = ArrayStore(
             field_desc={
                 "solution": (self.solution_dim, solution_dtype),
@@ -245,6 +223,31 @@ class ProximityArchive(ArchiveBase):
         self._objective_sum = None
         self._stats = None
         self._stats_reset()
+
+        # Set up threshold decay.
+        if threshold_decay_rate is None:
+            self._threshold_decay_rate = None
+            self._threshold_decay_itrs = None
+            self._threshold_decay_min = None
+            self._itrs_without_novel = None
+        else:
+            if threshold_decay_rate <= 0.0 or threshold_decay_rate > 1.0:
+                raise ValueError(
+                    "If passed in, threshold_decay_rate must be a float in the range [0.0, 1.0]."
+                )
+            if threshold_decay_itrs <= 0:
+                raise ValueError(
+                    "threshold_decay_itrs must be either None or a positive integer."
+                )
+            if threshold_decay_min < 0.0:
+                raise ValueError(
+                    "threshold_decay_min must be a non-negative float value."
+                )
+
+            self._threshold_decay_rate = float(threshold_decay_rate)
+            self._threshold_decay_itrs = int(threshold_decay_itrs)
+            self._threshold_decay_min = float(threshold_decay_min)
+            self._itrs_without_novel = 0
 
     ## Properties inherited from ArchiveBase ##
 
@@ -528,7 +531,8 @@ class ProximityArchive(ArchiveBase):
                 If n_novel_enough is zero, we restart the number of calls to `add`
                 without inserting novel solutions. Otherwise, the counter is incremented
                 by one. When the number of calls reaches the maximum allowed,
-                :attr:`novelty_threshold` is decreased and the number of calls restarted.
+                :attr:`novelty_threshold` is decreased and the number of calls
+                restarted.
         """
         # If n_novel_enough == 0 it means that whether LC is True or not
         # we have not inserted any novel solutions into the archive
@@ -536,21 +540,21 @@ class ProximityArchive(ArchiveBase):
         # Otherwise, we restart the counter
 
         if n_novel_enough == 0:
-            self._its_without_imp += 1
-            if self._its_without_imp == self._max_it_without_imp:
+            self._itrs_without_novel += 1
+            if self._itrs_without_novel >= self._threshold_decay_itrs:
                 # Restart the counter and set the new threshold to max(_threshold_decay_min, threshold * decay)
-                self._its_without_imp = 0
+                self._itrs_without_novel = 0
                 new_threshold = np.max(
                     [
                         self._threshold_decay_min,
-                        self._novelty_threshold * self._threshold_decay,
+                        self._novelty_threshold * self._threshold_decay_rate,
                     ]
                 )
                 self._novelty_threshold = np.asarray(
                     new_threshold, dtype=self.dtypes["measures"]
                 )
         else:
-            self._its_without_imp = 0
+            self._itrs_without_novel = 0
 
     def add(
         self,
@@ -697,7 +701,7 @@ class ProximityArchive(ArchiveBase):
                     self._store.data("measures"), **self._kdtree_kwargs
                 )
 
-            if self._max_it_without_imp:
+            if self._threshold_decay_itrs:
                 self._maybe_update_threshold(n_novel_enough)
 
             return add_info
@@ -830,7 +834,7 @@ class ProximityArchive(ArchiveBase):
                     self._store.data("measures"), **self._kdtree_kwargs
                 )
 
-            if self._max_it_without_imp:
+            if self._threshold_decay_itrs:
                 self._maybe_update_threshold(n_novel_enough)
 
             return add_info

--- a/ribs/archives/_proximity_archive.py
+++ b/ribs/archives/_proximity_archive.py
@@ -102,6 +102,16 @@ class ProximityArchive(ArchiveBase):
             *subtracted* from all objectives in the archive, e.g., if your objectives go
             as low as -300, pass in -300 so that each objective will be transformed as
             ``objective - (-300)``.
+        iterations_without_imp: Maximum number of iterations without inserting novel
+            solutions, before decreasing the ``novelty_threshold`` by a factor of
+            ``threshold_decay``. This is an optional parameter that by
+            default is set to None, which means that the ``novelty_threshold``
+            is not updated during the evolution.
+        threshold_decay: Decay factor to reduce the ``novelty_treshold`` if there were
+            ``iterations_without_imp`` iterations without inserting novelty solutions.
+            This is a optional float value in the range [0.0, 1.0]. Default is set to
+            None, which means that the ``novelty_threshold`` is not updated during
+            the evolution.
         seed: Value to seed the random number generator. Set to None to avoid a fixed
             seed.
         solution_dtype: Data type of the solutions. Defaults to float64 (numpy's default
@@ -140,6 +150,8 @@ class ProximityArchive(ArchiveBase):
         local_competition: bool = False,
         initial_capacity: Int = 128,
         qd_score_offset: Float = 0.0,
+        iterations_without_imp: Int | None = None,
+        threshold_decay: Float | None = None,
         seed: Int | None = None,
         solution_dtype: DTypeLike = None,
         objective_dtype: DTypeLike = None,
@@ -179,6 +191,24 @@ class ProximityArchive(ArchiveBase):
         solution_dtype, objective_dtype, measures_dtype = parse_all_dtypes(
             dtype, solution_dtype, objective_dtype, measures_dtype, np
         )
+
+        # By default, threshold decay is not defined.
+        self._max_it_without_imp = None
+        if iterations_without_imp is not None:
+            if iterations_without_imp < 0:
+                raise ValueError(
+                    "iterations_without_imp must be either None or a positive integer."
+                )
+            if threshold_decay is None or (
+                threshold_decay < 0.0 or threshold_decay > 1.0
+            ):
+                raise ValueError(
+                    "If iterations_without_imp is not None, threshold decay must be a float in the range [0.0, 1.0]."
+                )
+            self._max_it_without_imp = int(iterations_without_imp)
+            self._threshold_decay = float(threshold_decay)
+            self._its_without_imp = 0
+
         self._store = ArrayStore(
             field_desc={
                 "solution": (self.solution_dim, solution_dtype),
@@ -480,6 +510,30 @@ class ProximityArchive(ArchiveBase):
             multiplier = 2 ** int(np.ceil(np.log2(new_size / self.capacity)))
             self._store.resize(multiplier * self.capacity)
 
+    def __maybe_update_threshold(self):
+        """Performs threshold decay.
+
+        After :attr:`iterations_without_imp` iterations without inserting
+        any new novel solution into the archive, the :attr:`novelty_threshold`
+        is decreased to continue inserting new solutions.
+        """
+        # If n_novel_enough == 0 it means that whether LC is True or not
+        # we have not inserted any novel solutions into the archive
+        # therefore, the number of iterations without any insertion must be updated
+        self._its_without_imp += 1
+        if self._its_without_imp == self._max_it_without_imp:
+            # Restart the counter and set the new threshold to max(0.0, threshold * decay)
+            self._its_without_imp = 0
+            new_threshold = np.max(
+                [
+                    0.0,
+                    self._novelty_threshold * self._threshold_decay,
+                ]
+            )
+            self._novelty_threshold = np.asarray(
+                new_threshold, dtype=self.dtypes["measures"]
+            )
+
     def add(
         self,
         solution: ArrayLike,
@@ -625,6 +679,9 @@ class ProximityArchive(ArchiveBase):
                     self._store.data("measures"), **self._kdtree_kwargs
                 )
 
+            if self._max_it_without_imp and n_novel_enough == 0:
+                self.__maybe_update_threshold()
+
             return add_info
 
         else:
@@ -754,6 +811,9 @@ class ProximityArchive(ArchiveBase):
                 self._cur_kd_tree = KDTree(
                     self._store.data("measures"), **self._kdtree_kwargs
                 )
+
+            if self._max_it_without_imp and n_novel_enough == 0:
+                self.__maybe_update_threshold()
 
             return add_info
 

--- a/ribs/archives/_proximity_archive.py
+++ b/ribs/archives/_proximity_archive.py
@@ -508,7 +508,7 @@ class ProximityArchive(ArchiveBase):
             multiplier = 2 ** int(np.ceil(np.log2(new_size / self.capacity)))
             self._store.resize(multiplier * self.capacity)
 
-    def __maybe_update_threshold(self):
+    def _maybe_update_threshold(self):
         """Performs threshold decay.
 
         After :attr:`iterations_without_imp` iterations without inserting
@@ -678,7 +678,7 @@ class ProximityArchive(ArchiveBase):
                 )
 
             if self._max_it_without_imp and n_novel_enough == 0:
-                self.__maybe_update_threshold()
+                self._maybe_update_threshold()
 
             return add_info
 
@@ -811,7 +811,7 @@ class ProximityArchive(ArchiveBase):
                 )
 
             if self._max_it_without_imp and n_novel_enough == 0:
-                self.__maybe_update_threshold()
+                self._maybe_update_threshold()
 
             return add_info
 

--- a/ribs/archives/_proximity_archive.py
+++ b/ribs/archives/_proximity_archive.py
@@ -519,26 +519,29 @@ class ProximityArchive(ArchiveBase):
             multiplier = 2 ** int(np.ceil(np.log2(new_size / self.capacity)))
             self._store.resize(multiplier * self.capacity)
 
-    def _maybe_update_threshold(self, n_novel_enough: int):
-        """Performs threshold decay.
+    def _maybe_update_threshold(self, n_novel_enough: int) -> None:
+        """Performs threshold decay if needed.
 
-        After :attr:`threshold_decay_itrs` calls to `add` without inserting
-        any new novel solution into the archive, the :attr:`novelty_threshold`
-        is decreased to continue inserting new solutions.
+        After :attr:`threshold_decay_itrs` calls to `add` without inserting any new
+        novel solution into the archive, the :attr:`novelty_threshold` is decreased to
+        continue inserting new solutions.
 
         Args:
-            n_novel_enough (int): Number of newly novel solution added to the archive.
-                If n_novel_enough is zero, we restart the number of calls to `add`
-                without inserting novel solutions. Otherwise, the counter is incremented
-                by one. When the number of calls reaches the maximum allowed,
-                :attr:`novelty_threshold` is decreased and the number of calls
+            n_novel_enough (int): Number of newly novel solutions added to the archive.
+                If this is non-zero, we restart the number of calls to `add` without
+                inserting novel solutions. Otherwise, the counter is incremented by one.
+                When the number of calls reaches the maximum allowed,
+                :attr:`novelty_threshold` is decreased and the number of calls is
                 restarted.
         """
-        # If n_novel_enough == 0 it means that whether LC is True or not
-        # we have not inserted any novel solutions into the archive
-        # therefore, the number of iterations without any insertion must be updated
-        # Otherwise, we restart the counter
+        # Threshold decay has not been activated.
+        if self._threshold_decay_rate is None:
+            return
 
+        # If n_novel_enough == 0 it means that, whether local_competition is True or
+        # not, we have not inserted any novel solutions into the archive. Therefore, the
+        # number of iterations without any insertion must be updated. Otherwise, we
+        # restart the counter.
         if n_novel_enough == 0:
             self._itrs_without_novel += 1
             if self._itrs_without_novel >= self._threshold_decay_itrs:
@@ -701,9 +704,7 @@ class ProximityArchive(ArchiveBase):
                     self._store.data("measures"), **self._kdtree_kwargs
                 )
 
-            if self._threshold_decay_itrs:
-                self._maybe_update_threshold(n_novel_enough)
-
+            self._maybe_update_threshold(n_novel_enough)
             return add_info
 
         else:
@@ -834,9 +835,7 @@ class ProximityArchive(ArchiveBase):
                     self._store.data("measures"), **self._kdtree_kwargs
                 )
 
-            if self._threshold_decay_itrs:
-                self._maybe_update_threshold(n_novel_enough)
-
+            self._maybe_update_threshold(n_novel_enough)
             return add_info
 
     def add_single(

--- a/ribs/archives/_proximity_archive.py
+++ b/ribs/archives/_proximity_archive.py
@@ -522,31 +522,23 @@ class ProximityArchive(ArchiveBase):
     def _maybe_update_threshold(self, n_novel_enough: int) -> None:
         """Performs threshold decay if needed.
 
-        After :attr:`threshold_decay_itrs` calls to `add` without inserting any new
-        novel solution into the archive, the :attr:`novelty_threshold` is decreased to
-        continue inserting new solutions.
-
         Args:
             n_novel_enough (int): Number of newly novel solutions added to the archive.
-                If this is non-zero, we restart the number of calls to `add` without
-                inserting novel solutions. Otherwise, the counter is incremented by one.
-                When the number of calls reaches the maximum allowed,
-                :attr:`novelty_threshold` is decreased and the number of calls is
-                restarted.
         """
-        # Threshold decay has not been activated.
+        # Threshold decay has not been activated, so do nothing.
         if self._threshold_decay_rate is None:
             return
 
-        # If n_novel_enough == 0 it means that, whether local_competition is True or
-        # not, we have not inserted any novel solutions into the archive. Therefore, the
-        # number of iterations without any insertion must be updated. Otherwise, we
-        # restart the counter.
         if n_novel_enough == 0:
+            # If n_novel_enough == 0, it means that, whether local_competition is True
+            # or not, we have not inserted any novel solutions into the archive. Thus,
+            # the number of iterations without novel solutions is updated.
             self._itrs_without_novel += 1
+
             if self._itrs_without_novel >= self._threshold_decay_itrs:
-                # Restart the counter and set the new threshold to max(_threshold_decay_min, threshold * decay)
-                self._itrs_without_novel = 0
+                # If there have been at least `threshold_decay_itrs` calls to `add`
+                # without inserting any novel solutions, then we update the threshold to
+                # max(threshold_decay_min, threshold * decay).
                 new_threshold = np.max(
                     [
                         self._threshold_decay_min,
@@ -556,7 +548,11 @@ class ProximityArchive(ArchiveBase):
                 self._novelty_threshold = np.asarray(
                     new_threshold, dtype=self.dtypes["measures"]
                 )
+
+                # Restart the counter since the threshold was just updated.
+                self._itrs_without_novel = 0
         else:
+            # If n_novel_enough is not 0, then we restart the counter.
             self._itrs_without_novel = 0
 
     def add(

--- a/ribs/archives/_proximity_archive.py
+++ b/ribs/archives/_proximity_archive.py
@@ -534,7 +534,6 @@ class ProximityArchive(ArchiveBase):
         # we have not inserted any novel solutions into the archive
         # therefore, the number of iterations without any insertion must be updated
         # Otherwise, we restart the counter
-        print(self._its_without_imp, n_novel_enough, self._novelty_threshold)
 
         if n_novel_enough == 0:
             self._its_without_imp += 1

--- a/ribs/archives/_proximity_archive.py
+++ b/ribs/archives/_proximity_archive.py
@@ -102,14 +102,16 @@ class ProximityArchive(ArchiveBase):
             *subtracted* from all objectives in the archive, e.g., if your objectives go
             as low as -300, pass in -300 so that each objective will be transformed as
             ``objective - (-300)``.
-        iterations_without_imp: Maximum number of iterations without inserting novel
+        threshold_decay_itrs: Maximum number of call to ``add`` without inserting novel
             solutions, before decreasing the ``novelty_threshold`` by a factor of
-            ``threshold_decay``. This is an optional parameter that by default is set to
+            ``threshold_decay_rate``. This is an optional parameter that by default is set to
             None, which means that the ``novelty_threshold`` is never updated.
-        threshold_decay: Decay factor to reduce the ``novelty_treshold`` if there were
-            ``iterations_without_imp`` iterations without inserting novelty solutions.
+        threshold_decay_rate: Decay factor to reduce the ``novelty_treshold`` if there were
+            ``threshold_decay_itrs`` iterations without inserting novelty solutions.
             This is an optional float value in the range [0.0, 1.0]. The default is
             None, which indicates that the ``novelty_threshold`` is never updated.
+        threshold_decay_min: Minimum value for the ``novelty_treshold`` if threshold
+            decay is enabled. The default is 0.0.
         seed: Value to seed the random number generator. Set to None to avoid a fixed
             seed.
         solution_dtype: Data type of the solutions. Defaults to float64 (numpy's default
@@ -148,8 +150,9 @@ class ProximityArchive(ArchiveBase):
         local_competition: bool = False,
         initial_capacity: Int = 128,
         qd_score_offset: Float = 0.0,
-        iterations_without_imp: Int | None = None,
-        threshold_decay: Float | None = None,
+        threshold_decay_itrs: Int | None = None,
+        threshold_decay_rate: Float | None = None,
+        threshold_decay_min: Float = 0.0,
         seed: Int | None = None,
         solution_dtype: DTypeLike = None,
         objective_dtype: DTypeLike = None,
@@ -192,19 +195,24 @@ class ProximityArchive(ArchiveBase):
 
         # By default, threshold decay is not defined.
         self._max_it_without_imp = None
-        if iterations_without_imp is not None:
-            if iterations_without_imp < 0:
+        if threshold_decay_itrs is not None:
+            if threshold_decay_itrs < 0:
                 raise ValueError(
-                    "iterations_without_imp must be either None or a positive integer."
+                    "threshold_decay_itrs must be either None or a positive integer."
                 )
-            if threshold_decay is None or (
-                threshold_decay < 0.0 or threshold_decay > 1.0
+            if threshold_decay_rate is None or (
+                threshold_decay_rate <= 0.0 or threshold_decay_rate > 1.0
             ):
                 raise ValueError(
-                    "If iterations_without_imp is not None, threshold decay must be a float in the range [0.0, 1.0]."
+                    "If threshold_decay_itrs is not None, threshold decay must be a float in the range [0.0, 1.0]."
                 )
-            self._max_it_without_imp = int(iterations_without_imp)
-            self._threshold_decay = float(threshold_decay)
+            # The minimum could be 0.0
+            if threshold_decay_min < 0.0:
+                raise ValueError("threshold_decay_min must be a positive float value.")
+
+            self._max_it_without_imp = int(threshold_decay_itrs)
+            self._threshold_decay = float(threshold_decay_rate)
+            self._threshold_decay_min = float(threshold_decay_min)
             self._its_without_imp = 0
 
         self._store = ArrayStore(
@@ -508,29 +516,42 @@ class ProximityArchive(ArchiveBase):
             multiplier = 2 ** int(np.ceil(np.log2(new_size / self.capacity)))
             self._store.resize(multiplier * self.capacity)
 
-    def _maybe_update_threshold(self):
+    def _maybe_update_threshold(self, n_novel_enough: int):
         """Performs threshold decay.
 
-        After :attr:`iterations_without_imp` iterations without inserting
+        After :attr:`threshold_decay_itrs` calls to `add` without inserting
         any new novel solution into the archive, the :attr:`novelty_threshold`
         is decreased to continue inserting new solutions.
+
+        Args:
+            n_novel_enough (int): Number of newly novel solution added to the archive.
+                If n_novel_enough is zero, we restart the number of calls to `add`
+                without inserting novel solutions. Otherwise, the counter is incremented
+                by one. When the number of calls reaches the maximum allowed,
+                :attr:`novelty_threshold` is decreased and the number of calls restarted.
         """
         # If n_novel_enough == 0 it means that whether LC is True or not
         # we have not inserted any novel solutions into the archive
         # therefore, the number of iterations without any insertion must be updated
-        self._its_without_imp += 1
-        if self._its_without_imp == self._max_it_without_imp:
-            # Restart the counter and set the new threshold to max(0.0, threshold * decay)
+        # Otherwise, we restart the counter
+        print(self._its_without_imp, n_novel_enough, self._novelty_threshold)
+
+        if n_novel_enough == 0:
+            self._its_without_imp += 1
+            if self._its_without_imp == self._max_it_without_imp:
+                # Restart the counter and set the new threshold to max(_threshold_decay_min, threshold * decay)
+                self._its_without_imp = 0
+                new_threshold = np.max(
+                    [
+                        self._threshold_decay_min,
+                        self._novelty_threshold * self._threshold_decay,
+                    ]
+                )
+                self._novelty_threshold = np.asarray(
+                    new_threshold, dtype=self.dtypes["measures"]
+                )
+        else:
             self._its_without_imp = 0
-            new_threshold = np.max(
-                [
-                    0.0,
-                    self._novelty_threshold * self._threshold_decay,
-                ]
-            )
-            self._novelty_threshold = np.asarray(
-                new_threshold, dtype=self.dtypes["measures"]
-            )
 
     def add(
         self,
@@ -677,8 +698,8 @@ class ProximityArchive(ArchiveBase):
                     self._store.data("measures"), **self._kdtree_kwargs
                 )
 
-            if self._max_it_without_imp and n_novel_enough == 0:
-                self._maybe_update_threshold()
+            if self._max_it_without_imp:
+                self._maybe_update_threshold(n_novel_enough)
 
             return add_info
 
@@ -810,8 +831,8 @@ class ProximityArchive(ArchiveBase):
                     self._store.data("measures"), **self._kdtree_kwargs
                 )
 
-            if self._max_it_without_imp and n_novel_enough == 0:
-                self._maybe_update_threshold()
+            if self._max_it_without_imp:
+                self._maybe_update_threshold(n_novel_enough)
 
             return add_info
 

--- a/ribs/archives/_proximity_archive.py
+++ b/ribs/archives/_proximity_archive.py
@@ -104,14 +104,12 @@ class ProximityArchive(ArchiveBase):
             ``objective - (-300)``.
         iterations_without_imp: Maximum number of iterations without inserting novel
             solutions, before decreasing the ``novelty_threshold`` by a factor of
-            ``threshold_decay``. This is an optional parameter that by
-            default is set to None, which means that the ``novelty_threshold``
-            is not updated during the evolution.
+            ``threshold_decay``. This is an optional parameter that by default is set to
+            None, which means that the ``novelty_threshold`` is never updated.
         threshold_decay: Decay factor to reduce the ``novelty_treshold`` if there were
             ``iterations_without_imp`` iterations without inserting novelty solutions.
-            This is a optional float value in the range [0.0, 1.0]. Default is set to
-            None, which means that the ``novelty_threshold`` is not updated during
-            the evolution.
+            This is an optional float value in the range [0.0, 1.0]. The default is
+            None, which indicates that the ``novelty_threshold`` is never updated.
         seed: Value to seed the random number generator. Set to None to avoid a fixed
             seed.
         solution_dtype: Data type of the solutions. Defaults to float64 (numpy's default

--- a/tests/archives/proximity_archive_test.py
+++ b/tests/archives/proximity_archive_test.py
@@ -834,6 +834,7 @@ def test_lc_add_batch_replace_same_cell():
 
 
 def test_add_novel_and_not_novel_no_improve_bug():
+    """See https://github.com/icaros-usc/pyribs/pull/704/."""
     archive = ProximityArchive(
         solution_dim=3,
         measure_dim=2,

--- a/tests/archives/proximity_archive_test.py
+++ b/tests/archives/proximity_archive_test.py
@@ -865,3 +865,28 @@ def test_add_novel_and_not_novel_no_improve_bug():
         objective_batch=[10.0, 10.0],
         measures_batch=[[0, 0], [5.0, 5.0]],
     )
+
+
+def test_add_non_novel_solution_threshold_decay():
+    iterations = 5
+    initial_threshold = 1.0
+    archive = ProximityArchive(
+        solution_dim=3,
+        measure_dim=2,
+        k_neighbors=1,
+        novelty_threshold=initial_threshold,
+        initial_capacity=1,
+        threshold_decay=0.5,
+        iterations_without_imp=iterations,
+    )
+    assert_allclose(archive.novelty_threshold, 1.0)
+    archive.add_single([1, 2, 3], None, [0, 0])
+
+    for _ in range(iterations):
+        # Should not be added since threshold is 1.0.
+        add_info = archive.add_single([1, 2, 3], None, [0.5, 0])
+        assert add_info["status"] == 0
+        assert_allclose(add_info["novelty"], 0.5)
+
+    assert_archive_elites(archive, 1, measures_batch=[[0, 0]])
+    assert_allclose(archive.novelty_threshold, 0.5)

--- a/tests/archives/proximity_archive_test.py
+++ b/tests/archives/proximity_archive_test.py
@@ -876,17 +876,81 @@ def test_add_non_novel_solution_threshold_decay():
         k_neighbors=1,
         novelty_threshold=initial_threshold,
         initial_capacity=1,
-        threshold_decay=0.5,
-        iterations_without_imp=iterations,
+        threshold_decay_rate=0.5,
+        threshold_decay_itrs=iterations,
     )
     assert_allclose(archive.novelty_threshold, 1.0)
     archive.add_single([1, 2, 3], None, [0, 0])
 
     for _ in range(iterations):
+        assert_allclose(archive.novelty_threshold, 1.0)
         # Should not be added since threshold is 1.0.
         add_info = archive.add_single([1, 2, 3], None, [0.5, 0])
         assert add_info["status"] == 0
         assert_allclose(add_info["novelty"], 0.5)
 
-    assert_archive_elites(archive, 1, measures_batch=[[0, 0]])
+    # At this point, novelty_threshold must have been updated to 0.5
     assert_allclose(archive.novelty_threshold, 0.5)
+    assert_archive_elites(archive, 1, measures_batch=[[0, 0]])
+
+
+def test_constant_addition_novel_no_decay():
+    # Test that the novelty_threshold keeps constant when adding novel solutions
+    iterations = 5
+    initial_threshold = 1.0
+    archive = ProximityArchive(
+        solution_dim=3,
+        measure_dim=2,
+        k_neighbors=1,
+        novelty_threshold=initial_threshold,
+        initial_capacity=1,
+        threshold_decay_itrs=iterations,
+        threshold_decay_rate=0.99,
+    )
+    assert_allclose(archive.novelty_threshold, 1.0)
+    inner_measures = np.arange(iterations)
+    new_measures = np.stack([inner_measures, inner_measures], axis=1)
+    for i in range(iterations):
+        add_info = archive.add_single([1, 2, 3], None, new_measures[i])
+        # The solution was added to the archive
+        assert add_info["status"] == 2
+        # The threshold must remain the same --> 1.0
+        assert_allclose(archive.novelty_threshold, 1)
+
+    assert_archive_elites(archive, iterations, measures_batch=new_measures)
+    assert_allclose(archive.novelty_threshold, 1.0)
+
+
+def test_mix_iterations_add_with_threshold_decay():
+    iterations = 5
+    initial_threshold = 1.0
+    archive = ProximityArchive(
+        solution_dim=3,
+        measure_dim=2,
+        k_neighbors=1,
+        novelty_threshold=initial_threshold,
+        initial_capacity=1,
+        threshold_decay_itrs=iterations,
+        threshold_decay_rate=0.99,
+    )
+    assert_allclose(archive.novelty_threshold, 1.0)
+
+    # Insert and initial solution with measure [0,0] to have an reference
+    # thus, not_novel_measure should not be included anytime
+    not_novel_measure = [0.5, 0]
+
+    for i in range(iterations * 2):
+        to_insert = np.asarray([i, i]) if i % 2 == 0 else not_novel_measure
+        add_info = archive.add_single([1, 2, 3], None, to_insert)
+        if i % 2 == 0:
+            # We should have inserted a novel solution
+            # The solution was added to the archive
+            assert add_info["status"] == 2
+            # The threshold must remain the same --> 1.0
+            assert_allclose(archive.novelty_threshold, 1)
+        else:
+            # This duplicated measure was not inserted
+            assert add_info["status"] == 0
+            assert_allclose(archive.novelty_threshold, 1)
+
+    assert_allclose(archive.novelty_threshold, 1.0)

--- a/tests/archives/proximity_archive_test.py
+++ b/tests/archives/proximity_archive_test.py
@@ -869,6 +869,7 @@ def test_add_novel_and_not_novel_no_improve_bug():
 
 
 def test_add_non_novel_solution_threshold_decay():
+    """novelty_threshold decays when no novel solutions are added."""
     iterations = 5
     initial_threshold = 1.0
     archive = ProximityArchive(
@@ -890,13 +891,17 @@ def test_add_non_novel_solution_threshold_decay():
         assert add_info["status"] == 0
         assert_allclose(add_info["novelty"], 0.5)
 
-    # At this point, novelty_threshold must have been updated to 0.5
+    # At this point, novelty_threshold must have been updated to 0.5.
     assert_allclose(archive.novelty_threshold, 0.5)
     assert_archive_elites(archive, 1, measures_batch=[[0, 0]])
 
+    # Now when we add the solution, it is accepted.
+    add_info = archive.add_single([1, 2, 3], None, [0.5, 0])
+    assert_archive_elites(archive, 2, measures_batch=[[0, 0], [0.5, 0]])
 
-def test_constant_addition_novel_no_decay():
-    # Test that the novelty_threshold keeps constant when adding novel solutions
+
+def test_no_threshold_decay_when_adding_novel_solutions():
+    """novelty_threshold remains constant when adding novel solutions."""
     iterations = 5
     initial_threshold = 1.0
     archive = ProximityArchive(
@@ -906,23 +911,26 @@ def test_constant_addition_novel_no_decay():
         novelty_threshold=initial_threshold,
         initial_capacity=1,
         threshold_decay_itrs=iterations,
-        threshold_decay_rate=0.99,
+        threshold_decay_rate=0.5,
     )
     assert_allclose(archive.novelty_threshold, 1.0)
     inner_measures = np.arange(iterations)
     new_measures = np.stack([inner_measures, inner_measures], axis=1)
-    for i in range(iterations):
-        add_info = archive.add_single([1, 2, 3], None, new_measures[i])
-        # The solution was added to the archive
+
+    for m in new_measures:
+        add_info = archive.add_single([1, 2, 3], None, m)
+        # The solution was added to the archive.
         assert add_info["status"] == 2
         # The threshold must remain the same --> 1.0
-        assert_allclose(archive.novelty_threshold, 1)
+        assert_allclose(archive.novelty_threshold, 1.0)
 
     assert_archive_elites(archive, iterations, measures_batch=new_measures)
     assert_allclose(archive.novelty_threshold, 1.0)
 
 
-def test_mix_iterations_add_with_threshold_decay():
+def test_mix_novel_and_not_novel_for_threshold_decay():
+    """novelty_threshold responds correctly when we mix novel and not novel
+    solutions."""
     iterations = 5
     initial_threshold = 1.0
     archive = ProximityArchive(
@@ -932,26 +940,70 @@ def test_mix_iterations_add_with_threshold_decay():
         novelty_threshold=initial_threshold,
         initial_capacity=1,
         threshold_decay_itrs=iterations,
-        threshold_decay_rate=0.99,
+        threshold_decay_rate=0.5,
     )
     assert_allclose(archive.novelty_threshold, 1.0)
 
-    # Insert and initial solution with measure [0,0] to have an reference
-    # thus, not_novel_measure should not be included anytime
+    # Insert an initial solution with measure [0,0] to have a reference. Thus,
+    # not_novel_measure should never be included.
     not_novel_measure = [0.5, 0]
 
     for i in range(iterations * 2):
         to_insert = np.asarray([i, i]) if i % 2 == 0 else not_novel_measure
         add_info = archive.add_single([1, 2, 3], None, to_insert)
         if i % 2 == 0:
-            # We should have inserted a novel solution
-            # The solution was added to the archive
+            # We should have inserted a novel solution.
             assert add_info["status"] == 2
             # The threshold must remain the same --> 1.0
-            assert_allclose(archive.novelty_threshold, 1)
+            assert_allclose(archive.novelty_threshold, 1.0)
         else:
-            # This duplicated measure was not inserted
+            # This duplicated measure should not be inserted.
             assert add_info["status"] == 0
-            assert_allclose(archive.novelty_threshold, 1)
+            assert_allclose(archive.novelty_threshold, 1.0)
 
     assert_allclose(archive.novelty_threshold, 1.0)
+
+
+def test_add_with_threshold_decay():
+    """Since the threshold_decay tests above use add_single, this uses add() for
+    completeness."""
+    iterations = 1
+    initial_threshold = 1.0
+    archive = ProximityArchive(
+        solution_dim=3,
+        measure_dim=2,
+        k_neighbors=1,
+        novelty_threshold=initial_threshold,
+        initial_capacity=1,
+        threshold_decay_itrs=iterations,
+        threshold_decay_rate=0.5,
+    )
+    assert_allclose(archive.novelty_threshold, 1.0)
+
+    add_info = archive.add([[1, 2, 3]], [0.0], [[0.0, 0.0]])
+    assert_equal(add_info["status"], [2])
+    assert_allclose(archive.novelty_threshold, 1.0)
+
+    # One solution is novel enough while the other is not.
+    add_info = archive.add([[4, 5, 6], [7, 8, 9]], [0.0, 0.0], [[0.5, 0.0], [1.0, 0.0]])
+    assert_equal(add_info["status"], [0, 2])
+    assert_allclose(archive.novelty_threshold, 1.0)
+
+    # Neither solution is novel enough, so the threshold decreases immediately.
+    add_info = archive.add(
+        [[10, 11, 12], [13, 14, 15]], [0.0, 0.0], [[1.5, 0.0], [1.75, 0.0]]
+    )
+    assert_equal(add_info["status"], [0, 0])
+    assert_allclose(archive.novelty_threshold, 0.5)
+
+    # Now both solutions can be added.
+    add_info = archive.add(
+        [[10, 11, 12], [13, 14, 15]], [0.0, 0.0], [[1.5, 0.0], [1.75, 0.0]]
+    )
+    assert_equal(add_info["status"], [2, 2])
+    assert_allclose(archive.novelty_threshold, 0.5)
+
+    # Check the elites in the archive.
+    assert_archive_elites(
+        archive, 4, measures_batch=[[0.0, 0.0], [1.0, 0.0], [1.5, 0.0], [1.75, 0.0]]
+    )


### PR DESCRIPTION

## Description

Implements issue #540: `novelty_threshold` decay in `ProximityArchive` after X iterations without inserting any new novel solution.

## TODO

- [X] Update `ProximityArchive` to consider two new optional arguments:  `iterations_without_imp` and `threshold_decay`. `iterations_without_imp` it is either None or a positive integer. When None, `ProximityArchive`  works as expected with a fixed `novelty_threshold` value. Otherwise, it defines the maximum number of iterations without inserting novel solutions, before decreasing the ``novelty_threshold`` by a factor of `threshold_decay`. Note that `threshold_decay` is a float value in the range [0.0, 1.0], and the new `novelty_threshold` is calculated following 

$$ max(0.0, nthreshold * decay)$$ 

> where _nthreshold_ is the current value of `novelty_threshold`.

- [X] Create `__maybe_update_threshold` in `ProximityArchive`: A private method of the `ProximityArchive` that, if the decay strategy is enabled, is called every time `n_novel_enought` is zero in `add`. When the number of iterations reaches the user-defined maximum, the `novelty_threshold` is decreased. 

 - [X] Create `test_add_non_novel_solution_threshold_decay`:  Inside _proximity_archive_test_, a new test case is included to test the new functionality. The test tries to insert the same solution X iterations and, after that, checks that the `novelty_threshold` has been updated to the new expected value.

## Questions

- [x] The `__maybe_update_threshold` is a function that receives no parameters and acts over the state of the `ProximityArchive` object. I thought about including this logic directly in the `add`method. However, I believe it is cleaner to have all the logic inside a private method and call it from every branch of the `add`method when necessary.

## Status

- [X] I have read the guidelines in
      [CONTRIBUTING.md](https://github.com/icaros-usc/pyribs/blob/master/CONTRIBUTING.md)
- [X] I have linted and formatted my code with `ruff` and `pylint`
- [X] I have tested my code by running `pytest`
- [X] I have added a description of my change to the changelog in `HISTORY.md`
- [X] This PR is ready to go
