### PR TITLE
Add `__str__` for Scheduler

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,6 +6,7 @@
 
 #### API
 
+- Add `__str__` for Scheduler ({pr}`712`)
 - Implement `novelty_threshold` decay in `ProximityArchive` ({pr}`709`)
 
 #### Improvements

--- a/ribs/schedulers/_scheduler.py
+++ b/ribs/schedulers/_scheduler.py
@@ -123,6 +123,21 @@ class Scheduler:
         # The number of solutions created by each emitter.
         self._num_emitted = [None for _ in self._emitters]
 
+    def __str__(self) -> str:
+        """Returns pretty string representation of the scheduler."""
+        output = [f"{self.__class__.__name__}("]
+        output.append(f"  archive={self.archive.__class__.__name__},")
+        output.append("  emitters=[")
+        for e in self.emitters:
+            output.append(f"    {e.__class__.__name__},")
+        output.append("  ],")
+        if self._result_archive is not None:
+            output.append(f"  result_archive={self.result_archive.__class__.__name__},")
+        if self._add_mode != "batch":
+            output.append(f'  add_mode="{self._add_mode}",')
+        output.append(")")
+        return "\n".join(output)
+
     @property
     def archive(self) -> ArchiveBase:
         """Archive for storing solutions found in this scheduler."""


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the PR's purpose here. -->

Adds a `__str__` method to the Scheduler so that printing out a Scheduler gives some meaningful information. See #125 for background.

## TODO

<!-- Notable points that this PR has either accomplished or will accomplish. -->

- [ ] Add `__str__` to Scheduler
- [ ] Add test for `__str__`

## Questions

<!-- Any concerns or points of confusion? -->

Currently, the representation looks something like this:

```
Scheduler(
  archive=GridArchive,
  emitters=[
    EvolutionStrategyEmitter,
    EvolutionStrategyEmitter,
    EvolutionStrategyEmitter,
  ],
)
```

- [x] Should we include more comprehensive module names?
  - PyTorch does not include those; IMO it would be troublesome to do so and also clog up the output.
- [x] Should we add representations of the different components?
  - Perhaps later on.

## Status

- [x] I have read the guidelines in
      [CONTRIBUTING.md](https://github.com/icaros-usc/pyribs/blob/master/CONTRIBUTING.md)
- [x] I have linted and formatted my code with `ruff` and `pylint`
- [x] I have tested my code by running `pytest`
- [x] I have added a description of my change to the changelog in `HISTORY.md`
- [ ] This PR is ready to go
