### PR TITLE
Remove torch from dev-array-api extra since it is in the all extra

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,7 +91,6 @@ dev = [
 dev-array-api = [
   # Extras when working with the Array API. These can be pretty heavy, so they are
   # separate from `dev`.
-  "torch",
   "cupy-cuda12x",
 ]
 


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the PR's purpose here. -->

Previously, torch was in `dev-array-api` next to cupy. However, we now install torch in the `all` extra, so there is no need to put it in dev dependencies anymore, since developers are asked to install the `all` extra in `CONTRIBUTING.md`.

## Status

- [x] I have read the guidelines in
      [CONTRIBUTING.md](https://github.com/icaros-usc/pyribs/blob/master/CONTRIBUTING.md)
- [x] I have linted and formatted my code with `ruff` and `pylint`
- [x] I have tested my code by running `pytest`
- [x] I have added a description of my change to the changelog in `HISTORY.md`
- [x] This PR is ready to go
