### PR TITLE
Use correct link for Lee 2024 in DensityArchive

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -11,10 +11,10 @@
 
 #### Improvements
 
+- Remove torch from dev-array-api extra since it is in the all extra ({pr}`715`)
 - Regenerate ribs.visualize baseline images due to recent update with matplotlib
   ({pr}`711`, {pr}`713`)
 - Migrate pylint config to pyproject.toml and format pyproject.toml ({pr}`710`)
-- Remove torch from dev-array-api extra since it is in the all extra ({pr}`715`)
 
 #### Documentation
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -14,6 +14,11 @@
 - Regenerate ribs.visualize baseline images due to recent update with matplotlib
   ({pr}`711`, {pr}`713`)
 - Migrate pylint config to pyproject.toml and format pyproject.toml ({pr}`710`)
+- Remove torch from dev-array-api extra since it is in the all extra ({pr}`715`)
+
+#### Documentation
+
+- Use correct link for Lee 2024 in DensityArchive ({pr}`716`)
 
 ## 0.11.0
 

--- a/ribs/archives/_density_archive.py
+++ b/ribs/archives/_density_archive.py
@@ -260,8 +260,8 @@ class DensityArchive(ArchiveBase):
             density estimator), ``"kde_sklearn"`` (KDE using
             :class:`sklearn.neighbors.KernelDensity`), and ``"cnf"`` (continuous
             normalizing flow, i.e., DDS-CNF from `Lee 2024
-            <https://arxiv.org/abs/2312.11331>`_). When ``"kde_sklearn"`` is used, this
-            archive computes *log density* rather than density; see
+            <https://dl.acm.org/doi/10.1145/3638529.3654001>`_). When ``"kde_sklearn"``
+            is used, this archive computes *log density* rather than density; see
             :meth:`sklearn.neighbors.KernelDensity.score_samples`. When ``"cnf"`` is
             used, this archive also returns *log density* since that is what the flow
             models directly. ``"cnf"`` requires installing torch and zuko.


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the PR's purpose here. -->

Lee 2024 was cited with different links in the DensityArchive documentation -- one was the ACM link, and the other was the arXiv link. Hence, Sphinx was giving the following warning:

```
.../ribs/archives/_density_archive.py:docstring of ribs.archives.DensityArchive.solution_dim:2: WARNING: Duplicate explicit target name: "lee 2024". [docutils]
```

This PR fixes the link to be consistent.

## Status

- [x] I have read the guidelines in
      [CONTRIBUTING.md](https://github.com/icaros-usc/pyribs/blob/master/CONTRIBUTING.md)
- [x] I have linted and formatted my code with `ruff` and `pylint`
- [x] I have tested my code by running `pytest`
- [x] I have added a description of my change to the changelog in `HISTORY.md`
- [x] This PR is ready to go
