### PR TITLE
Remove doctest syntax in examples in ribs.visualize docs

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -18,6 +18,7 @@
 
 #### Documentation
 
+- Remove doctest syntax in examples in ribs.visualize docs ({pr}`718`)
 - Use correct link for Lee 2024 in DensityArchive ({pr}`716`)
 
 ## 0.11.0

--- a/ribs/visualize/_archive_histogram.py
+++ b/ribs/visualize/_archive_histogram.py
@@ -37,86 +37,92 @@ def archive_histogram(
     many of this function's arguments are shared with ``hist``.
 
     Examples:
-        .. plot::
-            :context: close-figs
-
-            Basic Histogram of a 2D GridArchive
-
-            >>> import numpy as np
-            >>> import matplotlib.pyplot as plt
-            >>> from ribs.archives import GridArchive
-            >>> from ribs.visualize import archive_histogram
-            >>> # Populate the archive with the negative sphere function.
-            >>> archive = GridArchive(solution_dim=2,
-            ...                       dims=[100, 100],
-            ...                       ranges=[(-1, 1), (-1, 1)])
-            >>> x = np.random.uniform(-1, 1, 10000)
-            >>> y = np.random.uniform(-1, 1, 10000)
-            >>> archive.add(solution=np.stack((x, y), axis=1),
-            ...             objective=-(x**2 + y**2),
-            ...             measures=np.stack((x, y), axis=1))
-            >>> # Plot a histogram of the archive.
-            >>> plt.figure(figsize=(8, 6))
-            >>> archive_histogram(archive)
-            >>> plt.xlabel("Objective")
-            >>> plt.ylabel("Num. Elites")
-            >>> plt.show()
+        Basic Histogram of a 2D GridArchive
 
         .. plot::
             :context: close-figs
 
-            Histogram Where Bars Are Colored With a Colormap
+            import numpy as np
+            import matplotlib.pyplot as plt
+            from ribs.archives import GridArchive
+            from ribs.visualize import archive_histogram
 
-            >>> import numpy as np
-            >>> import matplotlib.pyplot as plt
-            >>> from ribs.archives import GridArchive
-            >>> from ribs.visualize import archive_histogram
-            >>> # Populate the archive with the negative sphere function.
-            >>> archive = GridArchive(solution_dim=2,
-            ...                       dims=[100, 100],
-            ...                       ranges=[(-1, 1), (-1, 1)])
-            >>> x = np.random.uniform(-1, 1, 10000)
-            >>> y = np.random.uniform(-1, 1, 10000)
-            >>> archive.add(solution=np.stack((x, y), axis=1),
-            ...             objective=-(x**2 + y**2),
-            ...             measures=np.stack((x, y), axis=1))
-            >>> # Plot a histogram of the archive.
-            >>> plt.figure(figsize=(8, 6))
-            >>> archive_histogram(archive, cmap="magma")
-            >>> plt.xlabel("Objective")
-            >>> plt.ylabel("Num. Elites")
-            >>> plt.show()
+            # Populate the archive with the negative sphere function.
+            archive = GridArchive(solution_dim=2,
+                                  dims=[100, 100],
+                                  ranges=[(-1, 1), (-1, 1)])
+            x = np.random.uniform(-1, 1, 10000)
+            y = np.random.uniform(-1, 1, 10000)
+            archive.add(solution=np.stack((x, y), axis=1),
+                        objective=-(x**2 + y**2),
+                        measures=np.stack((x, y), axis=1))
+
+            # Plot a histogram of the archive.
+            plt.figure(figsize=(8, 6))
+            archive_histogram(archive)
+            plt.xlabel("Objective")
+            plt.ylabel("Num. Elites")
+            plt.show()
+
+        Histogram Where Bars Are Colored With a Colormap
 
         .. plot::
             :context: close-figs
 
-            Histogram with More Customizations
+            import numpy as np
+            import matplotlib.pyplot as plt
+            from ribs.archives import GridArchive
+            from ribs.visualize import archive_histogram
 
-            >>> import numpy as np
-            >>> import matplotlib.pyplot as plt
-            >>> from ribs.archives import GridArchive
-            >>> from ribs.visualize import archive_histogram
-            >>> # Populate the archive with the negative sphere function.
-            >>> archive = GridArchive(solution_dim=2,
-            ...                       dims=[100, 100],
-            ...                       ranges=[(-1, 1), (-1, 1)])
-            >>> x = np.random.uniform(-1, 1, 10000)
-            >>> y = np.random.uniform(-1, 1, 10000)
-            >>> archive.add(solution=np.stack((x, y), axis=1),
-            ...             objective=-(x**2 + y**2),
-            ...             measures=np.stack((x, y), axis=1))
-            >>> # Plot a histogram of the archive.
-            >>> plt.figure(figsize=(8, 6))
-            >>> archive_histogram(
-            >>>     archive,
-            >>>     bins=50,  # Only use 50 bins.
-            >>>     vmin=-2.5,  # Minimum objective value.
-            >>>     vmax=0.5,  # Maximum objective value.
-            >>>     ylim=400,  # Set the top of the y-axis.
-            >>> )
-            >>> plt.xlabel("Objective")
-            >>> plt.ylabel("Num. Elites")
-            >>> plt.show()
+            # Populate the archive with the negative sphere function.
+            archive = GridArchive(solution_dim=2,
+                                  dims=[100, 100],
+                                  ranges=[(-1, 1), (-1, 1)])
+            x = np.random.uniform(-1, 1, 10000)
+            y = np.random.uniform(-1, 1, 10000)
+            archive.add(solution=np.stack((x, y), axis=1),
+                        objective=-(x**2 + y**2),
+                        measures=np.stack((x, y), axis=1))
+
+            # Plot a histogram of the archive.
+            plt.figure(figsize=(8, 6))
+            archive_histogram(archive, cmap="magma")
+            plt.xlabel("Objective")
+            plt.ylabel("Num. Elites")
+            plt.show()
+
+        Histogram with More Customizations
+
+        .. plot::
+            :context: close-figs
+
+            import numpy as np
+            import matplotlib.pyplot as plt
+            from ribs.archives import GridArchive
+            from ribs.visualize import archive_histogram
+
+            # Populate the archive with the negative sphere function.
+            archive = GridArchive(solution_dim=2,
+                                  dims=[100, 100],
+                                  ranges=[(-1, 1), (-1, 1)])
+            x = np.random.uniform(-1, 1, 10000)
+            y = np.random.uniform(-1, 1, 10000)
+            archive.add(solution=np.stack((x, y), axis=1),
+                        objective=-(x**2 + y**2),
+                        measures=np.stack((x, y), axis=1))
+
+            # Plot a histogram of the archive.
+            plt.figure(figsize=(8, 6))
+            archive_histogram(
+                archive,
+                bins=50,  # Only use 50 bins.
+                vmin=-2.5,  # Minimum objective value.
+                vmax=0.5,  # Maximum objective value.
+                ylim=400,  # Set the top of the y-axis.
+            )
+            plt.xlabel("Objective")
+            plt.ylabel("Num. Elites")
+            plt.show()
 
     Args:
         archive: An archive that can provide its objective values via the

--- a/ribs/visualize/_cvt_archive_3d_plot.py
+++ b/ribs/visualize/_cvt_archive_3d_plot.py
@@ -61,106 +61,113 @@ def cvt_archive_3d_plot(
     ``plot_centroids=False`` or even removing the lines completely with ``lw=0``.
 
     Examples:
+        3D Plot with Solid Cells
 
         .. plot::
             :context: close-figs
 
-            3D Plot with Solid Cells
+            import numpy as np
+            import matplotlib.pyplot as plt
+            from ribs.archives import CVTArchive
+            from ribs.visualize import cvt_archive_3d_plot
 
-            >>> import numpy as np
-            >>> import matplotlib.pyplot as plt
-            >>> from ribs.archives import CVTArchive
-            >>> from ribs.visualize import cvt_archive_3d_plot
-            >>> # Populate the archive with the negative sphere function.
-            >>> archive = CVTArchive(solution_dim=2,
-            ...                      centroids=500,
-            ...                      ranges=[(-2, 0), (-2, 0), (-2, 0)])
-            >>> x = np.random.uniform(-2, 0, 5000)
-            >>> y = np.random.uniform(-2, 0, 5000)
-            >>> z = np.random.uniform(-2, 0, 5000)
-            >>> archive.add(solution=np.stack((x, y), axis=1),
-            ...             objective=-(x**2 + y**2 + z**2),
-            ...             measures=np.stack((x, y, z), axis=1))
-            >>> # Plot the archive.
-            >>> plt.figure(figsize=(8, 6))
-            >>> cvt_archive_3d_plot(archive)
-            >>> plt.title("Negative sphere function with 3D measures")
-            >>> plt.show()
+            # Populate the archive with the negative sphere function.
+            archive = CVTArchive(solution_dim=2,
+                                 centroids=500,
+                                 ranges=[(-2, 0), (-2, 0), (-2, 0)])
+            x = np.random.uniform(-2, 0, 5000)
+            y = np.random.uniform(-2, 0, 5000)
+            z = np.random.uniform(-2, 0, 5000)
+            archive.add(solution=np.stack((x, y), axis=1),
+                        objective=-(x**2 + y**2 + z**2),
+                        measures=np.stack((x, y, z), axis=1))
 
-        .. plot::
-            :context: close-figs
+            # Plot the archive.
+            plt.figure(figsize=(8, 6))
+            cvt_archive_3d_plot(archive)
+            plt.title("Negative sphere function with 3D measures")
+            plt.show()
 
-            3D Plot with Translucent Cells
-
-            >>> import numpy as np
-            >>> import matplotlib.pyplot as plt
-            >>> from ribs.archives import CVTArchive
-            >>> from ribs.visualize import cvt_archive_3d_plot
-            >>> # Populate the archive with the negative sphere function.
-            >>> archive = CVTArchive(solution_dim=2,
-            ...                      centroids=500,
-            ...                      ranges=[(-2, 0), (-2, 0), (-2, 0)])
-            >>> x = np.random.uniform(-2, 0, 5000)
-            >>> y = np.random.uniform(-2, 0, 5000)
-            >>> z = np.random.uniform(-2, 0, 5000)
-            >>> archive.add(solution=np.stack((x, y), axis=1),
-            ...             objective=-(x**2 + y**2 + z**2),
-            ...             measures=np.stack((x, y, z), axis=1))
-            >>> # Plot the archive.
-            >>> plt.figure(figsize=(8, 6))
-            >>> cvt_archive_3d_plot(archive, cell_alpha=0.1)
-            >>> plt.title("Negative sphere function with 3D measures")
-            >>> plt.show()
+        3D Plot with Translucent Cells
 
         .. plot::
             :context: close-figs
 
-            3D "Wireframe" (Shading Turned Off)
+            import numpy as np
+            import matplotlib.pyplot as plt
+            from ribs.archives import CVTArchive
+            from ribs.visualize import cvt_archive_3d_plot
 
-            >>> import numpy as np
-            >>> import matplotlib.pyplot as plt
-            >>> from ribs.archives import CVTArchive
-            >>> from ribs.visualize import cvt_archive_3d_plot
-            >>> # Populate the archive with the negative sphere function.
-            >>> archive = CVTArchive(solution_dim=2,
-            ...                      centroids=100,
-            ...                      ranges=[(-2, 0), (-2, 0), (-2, 0)])
-            >>> x = np.random.uniform(-2, 0, 1000)
-            >>> y = np.random.uniform(-2, 0, 1000)
-            >>> z = np.random.uniform(-2, 0, 1000)
-            >>> archive.add(solution=np.stack((x, y), axis=1),
-            ...             objective=-(x**2 + y**2 + z**2),
-            ...             measures=np.stack((x, y, z), axis=1))
-            >>> # Plot the archive.
-            >>> plt.figure(figsize=(8, 6))
-            >>> cvt_archive_3d_plot(archive, cell_alpha=0.0)
-            >>> plt.title("Negative sphere function with 3D measures")
-            >>> plt.show()
+            # Populate the archive with the negative sphere function.
+            archive = CVTArchive(solution_dim=2,
+                                 centroids=500,
+                                 ranges=[(-2, 0), (-2, 0), (-2, 0)])
+            x = np.random.uniform(-2, 0, 5000)
+            y = np.random.uniform(-2, 0, 5000)
+            z = np.random.uniform(-2, 0, 5000)
+            archive.add(solution=np.stack((x, y), axis=1),
+                        objective=-(x**2 + y**2 + z**2),
+                        measures=np.stack((x, y, z), axis=1))
+
+            # Plot the archive.
+            plt.figure(figsize=(8, 6))
+            cvt_archive_3d_plot(archive, cell_alpha=0.1)
+            plt.title("Negative sphere function with 3D measures")
+            plt.show()
+
+        3D "Wireframe" (Shading Turned Off)
 
         .. plot::
             :context: close-figs
 
-            3D Wireframe with Elites as Scatter Plot
+            import numpy as np
+            import matplotlib.pyplot as plt
+            from ribs.archives import CVTArchive
+            from ribs.visualize import cvt_archive_3d_plot
 
-            >>> import numpy as np
-            >>> import matplotlib.pyplot as plt
-            >>> from ribs.archives import CVTArchive
-            >>> from ribs.visualize import cvt_archive_3d_plot
-            >>> # Populate the archive with the negative sphere function.
-            >>> archive = CVTArchive(solution_dim=2,
-            ...                      centroids=100,
-            ...                      ranges=[(-2, 0), (-2, 0), (-2, 0)])
-            >>> x = np.random.uniform(-2, 0, 1000)
-            >>> y = np.random.uniform(-2, 0, 1000)
-            >>> z = np.random.uniform(-2, 0, 1000)
-            >>> archive.add(solution=np.stack((x, y), axis=1),
-            ...             objective=-(x**2 + y**2 + z**2),
-            ...             measures=np.stack((x, y, z), axis=1))
-            >>> # Plot the archive.
-            >>> plt.figure(figsize=(8, 6))
-            >>> cvt_archive_3d_plot(archive, cell_alpha=0.0, plot_elites=True)
-            >>> plt.title("Negative sphere function with 3D measures")
-            >>> plt.show()
+            # Populate the archive with the negative sphere function.
+            archive = CVTArchive(solution_dim=2,
+                                 centroids=100,
+                                 ranges=[(-2, 0), (-2, 0), (-2, 0)])
+            x = np.random.uniform(-2, 0, 1000)
+            y = np.random.uniform(-2, 0, 1000)
+            z = np.random.uniform(-2, 0, 1000)
+            archive.add(solution=np.stack((x, y), axis=1),
+                        objective=-(x**2 + y**2 + z**2),
+                        measures=np.stack((x, y, z), axis=1))
+
+            # Plot the archive.
+            plt.figure(figsize=(8, 6))
+            cvt_archive_3d_plot(archive, cell_alpha=0.0)
+            plt.title("Negative sphere function with 3D measures")
+            plt.show()
+
+        3D Wireframe with Elites as Scatter Plot
+
+        .. plot::
+            :context: close-figs
+
+            import numpy as np
+            import matplotlib.pyplot as plt
+            from ribs.archives import CVTArchive
+            from ribs.visualize import cvt_archive_3d_plot
+
+            # Populate the archive with the negative sphere function.
+            archive = CVTArchive(solution_dim=2,
+                                 centroids=100,
+                                 ranges=[(-2, 0), (-2, 0), (-2, 0)])
+            x = np.random.uniform(-2, 0, 1000)
+            y = np.random.uniform(-2, 0, 1000)
+            z = np.random.uniform(-2, 0, 1000)
+            archive.add(solution=np.stack((x, y), axis=1),
+                        objective=-(x**2 + y**2 + z**2),
+                        measures=np.stack((x, y, z), axis=1))
+
+            # Plot the archive.
+            plt.figure(figsize=(8, 6))
+            cvt_archive_3d_plot(archive, cell_alpha=0.0, plot_elites=True)
+            plt.title("Negative sphere function with 3D measures")
+            plt.show()
 
     Args:
         archive: A 3D :class:`~ribs.archives.CVTArchive`.

--- a/ribs/visualize/_cvt_archive_heatmap.py
+++ b/ribs/visualize/_cvt_archive_heatmap.py
@@ -59,54 +59,57 @@ def cvt_archive_heatmap(
     ``plot_centroids=False`` or even removing the lines completely with ``lw=0``.
 
     Examples:
+        Heatmap of a 2D CVTArchive
 
         .. plot::
             :context: close-figs
 
-            Heatmap of a 2D CVTArchive
+            import numpy as np
+            import matplotlib.pyplot as plt
+            from ribs.archives import CVTArchive
+            from ribs.visualize import cvt_archive_heatmap
 
-            >>> import numpy as np
-            >>> import matplotlib.pyplot as plt
-            >>> from ribs.archives import CVTArchive
-            >>> from ribs.visualize import cvt_archive_heatmap
-            >>> # Populate the archive with the negative sphere function.
-            >>> archive = CVTArchive(solution_dim=2,
-            ...                      centroids=100, ranges=[(-1, 1), (-1, 1)])
-            >>> x = np.random.uniform(-1, 1, 10000)
-            >>> y = np.random.uniform(-1, 1, 10000)
-            >>> archive.add(solution=np.stack((x, y), axis=1),
-            ...             objective=-(x**2 + y**2),
-            ...             measures=np.stack((x, y), axis=1))
-            >>> # Plot a heatmap of the archive.
-            >>> plt.figure(figsize=(8, 6))
-            >>> cvt_archive_heatmap(archive)
-            >>> plt.title("Negative sphere function with 2D measures")
-            >>> plt.xlabel("x coords")
-            >>> plt.ylabel("y coords")
-            >>> plt.show()
+            # Populate the archive with the negative sphere function.
+            archive = CVTArchive(solution_dim=2,
+                                 centroids=100, ranges=[(-1, 1), (-1, 1)])
+            x = np.random.uniform(-1, 1, 10000)
+            y = np.random.uniform(-1, 1, 10000)
+            archive.add(solution=np.stack((x, y), axis=1),
+                        objective=-(x**2 + y**2),
+                        measures=np.stack((x, y), axis=1))
+
+            # Plot a heatmap of the archive.
+            plt.figure(figsize=(8, 6))
+            cvt_archive_heatmap(archive)
+            plt.title("Negative sphere function with 2D measures")
+            plt.xlabel("x coords")
+            plt.ylabel("y coords")
+            plt.show()
+
+        Heatmap of a 1D CVTArchive
 
         .. plot::
             :context: close-figs
 
-            Heatmap of a 1D CVTArchive
+            import numpy as np
+            import matplotlib.pyplot as plt
+            from ribs.archives import CVTArchive
+            from ribs.visualize import cvt_archive_heatmap
 
-            >>> import numpy as np
-            >>> import matplotlib.pyplot as plt
-            >>> from ribs.archives import CVTArchive
-            >>> from ribs.visualize import cvt_archive_heatmap
-            >>> # Populate the archive with the negative sphere function.
-            >>> archive = CVTArchive(solution_dim=2,
-            ...                      centroids=20, ranges=[(-1, 1)])
-            >>> x = np.random.uniform(-1, 1, 1000)
-            >>> archive.add(solution=np.stack((x, x), axis=1),
-            ...             objective=-x**2,
-            ...             measures=x[:, None])
-            >>> # Plot a heatmap of the archive.
-            >>> plt.figure(figsize=(8, 6))
-            >>> cvt_archive_heatmap(archive)
-            >>> plt.title("Negative sphere function with 1D measures")
-            >>> plt.xlabel("x coords")
-            >>> plt.show()
+            # Populate the archive with the negative sphere function.
+            archive = CVTArchive(solution_dim=2,
+                                 centroids=20, ranges=[(-1, 1)])
+            x = np.random.uniform(-1, 1, 1000)
+            archive.add(solution=np.stack((x, x), axis=1),
+                        objective=-x**2,
+                        measures=x[:, None])
+
+            # Plot a heatmap of the archive.
+            plt.figure(figsize=(8, 6))
+            cvt_archive_heatmap(archive)
+            plt.title("Negative sphere function with 1D measures")
+            plt.xlabel("x coords")
+            plt.show()
 
     Args:
         archive: A 1D or 2D :class:`~ribs.archives.CVTArchive`.

--- a/ribs/visualize/_grid_archive_heatmap.py
+++ b/ribs/visualize/_grid_archive_heatmap.py
@@ -47,54 +47,58 @@ def grid_archive_heatmap(
     pass in ``pcm_kwargs={"edgecolor": "black", "linewidth": 0.1}``.
 
     Examples:
-        .. plot::
-            :context: close-figs
-
-            Heatmap of a 2D GridArchive
-
-            >>> import numpy as np
-            >>> import matplotlib.pyplot as plt
-            >>> from ribs.archives import GridArchive
-            >>> from ribs.visualize import grid_archive_heatmap
-            >>> # Populate the archive with the negative sphere function.
-            >>> archive = GridArchive(solution_dim=2,
-            ...                       dims=[20, 20],
-            ...                       ranges=[(-1, 1), (-1, 1)])
-            >>> x = np.random.uniform(-1, 1, 10000)
-            >>> y = np.random.uniform(-1, 1, 10000)
-            >>> archive.add(solution=np.stack((x, y), axis=1),
-            ...             objective=-(x**2 + y**2),
-            ...             measures=np.stack((x, y), axis=1))
-            >>> # Plot a heatmap of the archive.
-            >>> plt.figure(figsize=(8, 6))
-            >>> grid_archive_heatmap(archive)
-            >>> plt.title("Negative sphere function")
-            >>> plt.xlabel("x coords")
-            >>> plt.ylabel("y coords")
-            >>> plt.show()
+        Heatmap of a 2D GridArchive
 
         .. plot::
             :context: close-figs
 
-            Heatmap of a 1D GridArchive
+            import numpy as np
+            import matplotlib.pyplot as plt
+            from ribs.archives import GridArchive
+            from ribs.visualize import grid_archive_heatmap
 
-            >>> import numpy as np
-            >>> import matplotlib.pyplot as plt
-            >>> from ribs.archives import GridArchive
-            >>> from ribs.visualize import grid_archive_heatmap
-            >>> # Populate the archive with the negative sphere function.
-            >>> archive = GridArchive(solution_dim=2,
-            ...                       dims=[20], ranges=[(-1, 1)])
-            >>> x = np.random.uniform(-1, 1, 1000)
-            >>> archive.add(solution=np.stack((x, x), axis=1),
-            ...             objective=-x**2,
-            ...             measures=x[:, None])
-            >>> # Plot a heatmap of the archive.
-            >>> plt.figure(figsize=(8, 6))
-            >>> grid_archive_heatmap(archive)
-            >>> plt.title("Negative sphere function with 1D measures")
-            >>> plt.xlabel("x coords")
-            >>> plt.show()
+            # Populate the archive with the negative sphere function.
+            archive = GridArchive(solution_dim=2,
+                                  dims=[20, 20],
+                                  ranges=[(-1, 1), (-1, 1)])
+            x = np.random.uniform(-1, 1, 10000)
+            y = np.random.uniform(-1, 1, 10000)
+            archive.add(solution=np.stack((x, y), axis=1),
+                        objective=-(x**2 + y**2),
+                        measures=np.stack((x, y), axis=1))
+
+            # Plot a heatmap of the archive.
+            plt.figure(figsize=(8, 6))
+            grid_archive_heatmap(archive)
+            plt.title("Negative sphere function")
+            plt.xlabel("x coords")
+            plt.ylabel("y coords")
+            plt.show()
+
+        Heatmap of a 1D GridArchive
+
+        .. plot::
+            :context: close-figs
+
+            import numpy as np
+            import matplotlib.pyplot as plt
+            from ribs.archives import GridArchive
+            from ribs.visualize import grid_archive_heatmap
+
+            # Populate the archive with the negative sphere function.
+            archive = GridArchive(solution_dim=2,
+                                  dims=[20], ranges=[(-1, 1)])
+            x = np.random.uniform(-1, 1, 1000)
+            archive.add(solution=np.stack((x, x), axis=1),
+                        objective=-x**2,
+                        measures=x[:, None])
+
+            # Plot a heatmap of the archive.
+            plt.figure(figsize=(8, 6))
+            grid_archive_heatmap(archive)
+            plt.title("Negative sphere function with 1D measures")
+            plt.xlabel("x coords")
+            plt.show()
 
     Args:
         archive: A 1D or 2D :class:`~ribs.archives.GridArchive`.

--- a/ribs/visualize/_parallel_axes_plot.py
+++ b/ribs/visualize/_parallel_axes_plot.py
@@ -64,30 +64,32 @@ def parallel_axes_plot(
         .. plot::
             :context: close-figs
 
-            >>> import numpy as np
-            >>> import matplotlib.pyplot as plt
-            >>> from ribs.archives import GridArchive
-            >>> from ribs.visualize import parallel_axes_plot
-            >>> # Populate the archive with the negative sphere function.
-            >>> archive = GridArchive(
-            ...               solution_dim=3, dims=[20, 20, 20, 20, 20],
-            ...               ranges=[(-1, 1), (-1, 1), (-1, 1),
-            ...                       (-1, 1), (-1, 1)],
-            ...           )
-            >>> for x in np.linspace(-1, 1, 10):
-            ...     for y in np.linspace(0, 1, 10):
-            ...         for z in np.linspace(-1, 1, 10):
-            ...             archive.add_single(
-            ...                 solution=np.array([x,y,z]),
-            ...                 objective=-(x**2 + y**2 + z**2),
-            ...                 measures=np.array([0.5*x,x,y,z,-0.5*z]),
-            ...             )
-            >>> # Plot a heatmap of the archive.
-            >>> plt.figure(figsize=(8, 6))
-            >>> parallel_axes_plot(archive)
-            >>> plt.title("Negative sphere function")
-            >>> plt.ylabel("axis values")
-            >>> plt.show()
+            import numpy as np
+            import matplotlib.pyplot as plt
+            from ribs.archives import GridArchive
+            from ribs.visualize import parallel_axes_plot
+
+            # Populate the archive with the negative sphere function.
+            archive = GridArchive(
+                          solution_dim=3, dims=[20, 20, 20, 20, 20],
+                          ranges=[(-1, 1), (-1, 1), (-1, 1),
+                                  (-1, 1), (-1, 1)],
+                      )
+            for x in np.linspace(-1, 1, 10):
+                for y in np.linspace(0, 1, 10):
+                    for z in np.linspace(-1, 1, 10):
+                        archive.add_single(
+                            solution=np.array([x,y,z]),
+                            objective=-(x**2 + y**2 + z**2),
+                            measures=np.array([0.5*x,x,y,z,-0.5*z]),
+                        )
+
+            # Plot a heatmap of the archive.
+            plt.figure(figsize=(8, 6))
+            parallel_axes_plot(archive)
+            plt.title("Negative sphere function")
+            plt.ylabel("axis values")
+            plt.show()
 
     Args:
         archive: Pyribs archive. If the archive has the ``lower_bounds`` and

--- a/ribs/visualize/_proximity_archive_plot.py
+++ b/ribs/visualize/_proximity_archive_plot.py
@@ -44,64 +44,68 @@ def proximity_archive_plot(
     value (objective values default to 0 in the ``ProximityArchive``).
 
     Examples:
-        .. plot::
-            :context: close-figs
-
-            Single color plot for diversity optimization settings.
-
-            >>> import numpy as np
-            >>> import matplotlib.pyplot as plt
-            >>> from ribs.archives import ProximityArchive
-            >>> from ribs.visualize import proximity_archive_plot
-            >>> archive = ProximityArchive(solution_dim=2,
-            ...                            measure_dim=2,
-            ...                            k_neighbors=5,
-            ...                            novelty_threshold=0.1,
-            ...                            seed=42)
-            >>> for _ in range(10):
-            ...     x = np.random.uniform(-1, 1, 100)
-            ...     y = np.random.uniform(-1, 1, 100)
-            ...     archive.add(solution=np.stack((x, y), axis=1),
-            ...                 # Objectives default to 0 in this case.
-            ...                 objective=None,
-            ...                 measures=np.stack((x, y), axis=1))
-            >>> # Plot the archive.
-            >>> plt.figure(figsize=(6, 6))
-            >>> # Notice that the colormap is just a single RGB array, and the
-            ... # colorbar is removed since it is just one color.
-            >>> proximity_archive_plot(archive, cmap=[[0.5, 0.5, 0.5]],
-            ...                        cbar=None)
-            >>> plt.xlabel("x coords")
-            >>> plt.ylabel("y coords")
-            >>> plt.show()
+        Single-color plot for diversity optimization settings.
 
         .. plot::
             :context: close-figs
 
-            Plot where the objective has been recorded while using the archive.
+            import numpy as np
+            import matplotlib.pyplot as plt
+            from ribs.archives import ProximityArchive
+            from ribs.visualize import proximity_archive_plot
 
-            >>> import numpy as np
-            >>> import matplotlib.pyplot as plt
-            >>> from ribs.archives import ProximityArchive
-            >>> from ribs.visualize import proximity_archive_plot
-            >>> archive = ProximityArchive(solution_dim=2,
-            ...                            measure_dim=2,
-            ...                            k_neighbors=5,
-            ...                            novelty_threshold=0.1,
-            ...                            seed=42)
-            >>> for _ in range(10):
-            ...     x = np.random.uniform(-1, 1, 100)
-            ...     y = np.random.uniform(-1, 1, 100)
-            ...     archive.add(solution=np.stack((x, y), axis=1),
-            ...                 objective=-(x**2 + y**2),
-            ...                 measures=np.stack((x, y), axis=1))
-            >>> # Plot the archive.
-            >>> plt.figure(figsize=(8, 6))
-            >>> proximity_archive_plot(archive)
-            >>> plt.title("Negative sphere function")
-            >>> plt.xlabel("x coords")
-            >>> plt.ylabel("y coords")
-            >>> plt.show()
+            archive = ProximityArchive(solution_dim=2,
+                                       measure_dim=2,
+                                       k_neighbors=5,
+                                       novelty_threshold=0.1,
+                                       seed=42)
+            for _ in range(10):
+                x = np.random.uniform(-1, 1, 100)
+                y = np.random.uniform(-1, 1, 100)
+                archive.add(solution=np.stack((x, y), axis=1),
+                            # Objectives default to 0 in this case.
+                            objective=None,
+                            measures=np.stack((x, y), axis=1))
+
+            # Plot the archive.
+            plt.figure(figsize=(6, 6))
+            # Notice that the colormap is just a single RGB array, and the
+            # colorbar is removed since it is just one color.
+            proximity_archive_plot(archive, cmap=[[0.5, 0.5, 0.5]],
+                                   cbar=None)
+            plt.xlabel("x coords")
+            plt.ylabel("y coords")
+            plt.show()
+
+        Plot where the objective has been recorded while using the archive.
+
+        .. plot::
+            :context: close-figs
+
+            import numpy as np
+            import matplotlib.pyplot as plt
+            from ribs.archives import ProximityArchive
+            from ribs.visualize import proximity_archive_plot
+
+            archive = ProximityArchive(solution_dim=2,
+                                       measure_dim=2,
+                                       k_neighbors=5,
+                                       novelty_threshold=0.1,
+                                       seed=42)
+            for _ in range(10):
+                x = np.random.uniform(-1, 1, 100)
+                y = np.random.uniform(-1, 1, 100)
+                archive.add(solution=np.stack((x, y), axis=1),
+                            objective=-(x**2 + y**2),
+                            measures=np.stack((x, y), axis=1))
+
+            # Plot the archive.
+            plt.figure(figsize=(8, 6))
+            proximity_archive_plot(archive)
+            plt.title("Negative sphere function")
+            plt.xlabel("x coords")
+            plt.ylabel("y coords")
+            plt.show()
 
     Args:
         archive: A 2D :class:`~ribs.archives.ProximityArchive`.

--- a/ribs/visualize/_sliding_boundaries_archive_heatmap.py
+++ b/ribs/visualize/_sliding_boundaries_archive_heatmap.py
@@ -48,30 +48,32 @@ def sliding_boundaries_archive_heatmap(
         .. plot::
             :context: close-figs
 
-            >>> import numpy as np
-            >>> import matplotlib.pyplot as plt
-            >>> from ribs.archives import SlidingBoundariesArchive
-            >>> from ribs.visualize import sliding_boundaries_archive_heatmap
-            >>> archive = SlidingBoundariesArchive(solution_dim=2,
-            ...                                    dims=[10, 20],
-            ...                                    ranges=[(-1, 1), (-1, 1)],
-            ...                                    seed=42)
-            >>> # Populate the archive with the negative sphere function.
-            >>> xy = np.clip(np.random.standard_normal((1000, 2)), -1.5, 1.5)
-            >>> archive.add(solution=xy,
-            ...             objective=-np.sum(xy**2, axis=1),
-            ...             measures=xy)
-            >>> # Plot heatmaps of the archive.
-            >>> fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(16,6))
-            >>> fig.suptitle("Negative sphere function")
-            >>> sliding_boundaries_archive_heatmap(archive, ax=ax1,
-            ...                                    boundary_lw=0.5)
-            >>> sliding_boundaries_archive_heatmap(archive, ax=ax2)
-            >>> ax1.set_title("With boundaries")
-            >>> ax2.set_title("Without boundaries")
-            >>> ax1.set(xlabel='x coords', ylabel='y coords')
-            >>> ax2.set(xlabel='x coords', ylabel='y coords')
-            >>> plt.show()
+            import numpy as np
+            import matplotlib.pyplot as plt
+            from ribs.archives import SlidingBoundariesArchive
+            from ribs.visualize import sliding_boundaries_archive_heatmap
+
+            # Populate the archive with the negative sphere function.
+            archive = SlidingBoundariesArchive(solution_dim=2,
+                                               dims=[10, 20],
+                                               ranges=[(-1, 1), (-1, 1)],
+                                               seed=42)
+            xy = np.clip(np.random.standard_normal((1000, 2)), -1.5, 1.5)
+            archive.add(solution=xy,
+                        objective=-np.sum(xy**2, axis=1),
+                        measures=xy)
+
+            # Plot heatmaps of the archive.
+            fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(16,6))
+            fig.suptitle("Negative sphere function")
+            sliding_boundaries_archive_heatmap(archive, ax=ax1,
+                                               boundary_lw=0.5)
+            sliding_boundaries_archive_heatmap(archive, ax=ax2)
+            ax1.set_title("With boundaries")
+            ax2.set_title("Without boundaries")
+            ax1.set(xlabel='x coords', ylabel='y coords')
+            ax2.set(xlabel='x coords', ylabel='y coords')
+            plt.show()
 
     Args:
         archive: A 2D :class:`~ribs.archives.SlidingBoundariesArchive`.


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the PR's purpose here. -->

Previously, we used doctest syntax in the examples in `ribs.visualize`. This means that every line is prefixed with `>>>`, which makes it troublesome to copy-paste examples from the documentation. This PR removes that syntax. More info on using the `plot` directive from Matplotlib is available [here](https://matplotlib.org/stable/api/sphinxext_plot_directive_api.html).

## TODO

<!-- Notable points that this PR has either accomplished or will accomplish. -->

- [x] Remove doctest syntax
- [x] Double check documentation

## Status

- [x] I have read the guidelines in
      [CONTRIBUTING.md](https://github.com/icaros-usc/pyribs/blob/master/CONTRIBUTING.md)
- [x] I have linted and formatted my code with `ruff` and `pylint`
- [x] I have tested my code by running `pytest`
- [x] I have added a description of my change to the changelog in `HISTORY.md`
- [x] This PR is ready to go
