### PR TITLE
Support fields as a single str for return_type="dict"|"tuple"|"pandas" in archive.data()

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,6 +6,8 @@
 
 #### API
 
+- Support fields as a single str for return_type="dict"|"tuple"|"pandas" in
+  archive.data() ({pr}`721`)
 - Add `archive_ecdf` to visualize ECDF and ECCDF of archives ({pr}`719`)
 - Add `archive_histogram` to visualize objective values in archives ({pr}`714`)
 - Implement `novelty_threshold` decay in `ProximityArchive` ({pr}`709`)

--- a/ribs/archives/_archive_base.py
+++ b/ribs/archives/_archive_base.py
@@ -258,74 +258,102 @@ class ArchiveBase(ABC):
     def data(
         self,
         fields: str,
-        return_type: Literal["dict", "tuple", "pandas"] = "dict",
+        return_type: None = None,
     ) -> np.ndarray: ...
 
     @overload
     def data(
         self,
         fields: None | Collection[str] = None,
+        return_type: None = None,
+    ) -> BatchData: ...
+
+    @overload
+    def data(
+        self,
+        fields: None | Collection[str] | str = None,
         return_type: Literal["dict"] = "dict",
     ) -> BatchData: ...
 
     @overload
     def data(
         self,
-        fields: None | Collection[str] = None,
+        fields: None | Collection[str] | str = None,
         return_type: Literal["tuple"] = "tuple",
     ) -> tuple[np.ndarray]: ...
 
     @overload
     def data(
         self,
-        fields: None | Collection[str] = None,
+        fields: None | Collection[str] | str = None,
         return_type: Literal["pandas"] = "pandas",
     ) -> ArchiveDataFrame: ...
 
     def data(
         self,
         fields: None | Collection[str] | str = None,
-        return_type: Literal["dict", "tuple", "pandas"] = "dict",
+        return_type: None | Literal["dict", "tuple", "pandas"] = None,
     ) -> np.ndarray | BatchData | tuple[np.ndarray] | ArchiveDataFrame:
         """Returns data of the elites in the archive.
+
+        .. versionchanged:: 0.12.0
+            When ``fields`` is a single str and ``return_type`` is "dict", "tuple",
+            or "pandas", we now return a dict, tuple, or ArchiveDataFrame with only
+            that field. Previously, ``return_type`` was simply ignored. Furthermore,
+            the default of ``return_type`` is now None, and it is set depending on
+            the type of ``fields``.
 
         Args:
             fields: List of fields to include, such as ``"solution"``, ``"objective"``,
                 ``"measures"``, and other fields in the archive. This can also be a
-                single str indicating a field name.
-            return_type: Data to return; see below. Ignored if ``fields`` is a str.
+                single str indicating a field name. The default of None indicates that
+                all fields in the archive should be included.
+            return_type: Data to return; see below. If ``fields`` is a str and this is
+                None, a single array is returned. If ``fields`` is a collection of str
+                or None, then this defaults to "dict".
 
         Returns:
             The data for all elites in the archive. All data returned by this method
             will be a copy, i.e., the data will not update as the archive changes. If
-            ``fields`` was a single str, the returned data will just be an array holding
-            data for the given field, such as::
+            ``fields`` is a single str and ``return_type`` is None, the returned data
+            will just be an array holding data for the given field, such as::
 
                   measures = archive.data("measures")
 
             Otherwise, the returned data can take the following forms, depending on the
             ``return_type`` argument:
 
-            - ``return_type="dict"``: Dict mapping from the field name to the field data
-              at the given indices. An example is::
+            - ``return_type="dict"`` or ``return_type=None``: Dict mapping from the
+              field name to the field data at the given indices. Some examples::
 
-                  {
-                    "solution": [[1.0, 1.0, ...], ...],
-                    "objective": [1.5, ...],
-                    "measures": [[1.0, 2.0], ...],
-                    ...
-                  }
+                  data = archive.data()  # return_type=None
+                  data = archive.data(["solution", "objective", "measures"])  # return_type=None
+                  data = archive.data(return_type="dict")  # fields=None
+                  data = archive.data(["solution", "objective", "measures"], return_type="dict")
+
+                  # {
+                  #   "solution": [[1.0, 1.0, ...], ...],
+                  #   "objective": [1.5, ...],
+                  #   "measures": [[1.0, 2.0], ...],
+                  #   ...
+                  # }
+
+                  data = archive.data("measures", return_type="dict")
+
+                  # {
+                  #   "measures": [[1.0, 2.0], ...],
+                  # }
 
               The keys in this dict can be modified with the ``fields`` arg; duplicate
-              fields will be ignored since the dict stores unique keys.
+              fields will be ignored since the dict stores unique keys. This is the
+              default return type when ``fields`` is None or a collection of str.
 
             - ``return_type="tuple"``: Tuple of arrays matching the field order in
-              ``fields``. For instance, if ``fields`` is ``["objective", "measures"]``,
-              this method would return a tuple of ``(objective_arr, measures_arr)`` that
-              could be unpacked as::
+              ``fields``. Some examples with unpacking::
 
-                  objective, measures = archive.data(["objective", "measures"],
-                                                     return_type="tuple")
+                  solutions, objectives, measures = archive.data(return_type="tuple")  # fields=None
+                  objectives, measures = archive.data(["objective", "measures"], return_type="tuple")
+                  (solutions,) = archive.data("solution", return_type="tuple")
 
               Unlike with the ``dict`` return type, duplicate fields will show up as
               duplicate entries in the tuple, e.g., ``fields=["objective",

--- a/ribs/archives/_archive_base.py
+++ b/ribs/archives/_archive_base.py
@@ -298,10 +298,10 @@ class ArchiveBase(ABC):
 
         .. versionchanged:: 0.12.0
             When ``fields`` is a single str and ``return_type`` is "dict", "tuple",
-            or "pandas", we now return a dict, tuple, or ArchiveDataFrame with only
-            that field. Previously, ``return_type`` was simply ignored. Furthermore,
-            the default of ``return_type`` is now None, and it is set depending on
-            the type of ``fields``. See :pr:`721` for more info.
+            or "pandas", we now return a dict, tuple, or ArchiveDataFrame with only that
+            field. Previously, ``return_type`` was ignored in that case. Furthermore,
+            the default of ``return_type`` is now None, and it is set depending on the
+            type of ``fields``. See :pr:`721` for more info.
 
         Args:
             fields: List of fields to include, such as ``"solution"``, ``"objective"``,

--- a/ribs/archives/_archive_base.py
+++ b/ribs/archives/_archive_base.py
@@ -301,7 +301,7 @@ class ArchiveBase(ABC):
             or "pandas", we now return a dict, tuple, or ArchiveDataFrame with only
             that field. Previously, ``return_type`` was simply ignored. Furthermore,
             the default of ``return_type`` is now None, and it is set depending on
-            the type of ``fields``.
+            the type of ``fields``. See :pr:`721` for more info.
 
         Args:
             fields: List of fields to include, such as ``"solution"``, ``"objective"``,
@@ -324,12 +324,14 @@ class ArchiveBase(ABC):
             ``return_type`` argument:
 
             - ``return_type="dict"`` or ``return_type=None``: Dict mapping from the
-              field name to the field data at the given indices. Some examples::
+              field name to the field data at the given indices. The keys in this dict
+              can be modified with the ``fields`` arg; duplicate fields will be ignored
+              since the dict stores unique keys. This is the default return type when
+              ``fields`` is None or a collection of str. Some examples::
 
-                  data = archive.data()  # return_type=None
-                  data = archive.data(["solution", "objective", "measures"])  # return_type=None
+                  # Both of these retrieve all data in the archive.
+                  data = archive.data()  # fields=None, return_type=None
                   data = archive.data(return_type="dict")  # fields=None
-                  data = archive.data(["solution", "objective", "measures"], return_type="dict")
 
                   # {
                   #   "solution": [[1.0, 1.0, ...], ...],
@@ -338,15 +340,22 @@ class ArchiveBase(ABC):
                   #   ...
                   # }
 
+                  # Both of these only retrieve the specified fields.
+                  data = archive.data(["objective", "measures"])  # return_type=None
+                  data = archive.data(["objective", "measures"], return_type="dict")
+
+                  # {
+                  #   "objective": [1.5, ...],
+                  #   "measures": [[1.0, 2.0], ...],
+                  # }
+
+                  # Both of these retrieve only a single field.
                   data = archive.data("measures", return_type="dict")
+                  data = archive.data(["measures"], return_type="dict")
 
                   # {
                   #   "measures": [[1.0, 2.0], ...],
                   # }
-
-              The keys in this dict can be modified with the ``fields`` arg; duplicate
-              fields will be ignored since the dict stores unique keys. This is the
-              default return type when ``fields`` is None or a collection of str.
 
             - ``return_type="tuple"``: Tuple of arrays matching the field order in
               ``fields``. Some examples with unpacking::

--- a/ribs/archives/_array_store.py
+++ b/ribs/archives/_array_store.py
@@ -298,16 +298,22 @@ class ArrayStore(PickleXPMixin):
     @overload
     def retrieve(
         self,
-        indices: ArrayLike,
         fields: str,
-        return_type: Literal["dict", "tuple", "pandas"] = "dict",
+        return_type: None = None,
     ) -> Array: ...
 
     @overload
     def retrieve(
         self,
-        indices: ArrayLike,
         fields: None | Collection[str] = None,
+        return_type: None = None,
+    ) -> dict[str, Array]: ...
+
+    @overload
+    def retrieve(
+        self,
+        indices: ArrayLike,
+        fields: None | Collection[str] | str = None,
         return_type: Literal["dict"] = "dict",
     ) -> dict[str, Array]: ...
 
@@ -315,7 +321,7 @@ class ArrayStore(PickleXPMixin):
     def retrieve(
         self,
         indices: ArrayLike,
-        fields: None | Collection[str] = None,
+        fields: None | Collection[str] | str = None,
         return_type: Literal["tuple"] = "tuple",
     ) -> tuple[Array]: ...
 
@@ -323,7 +329,7 @@ class ArrayStore(PickleXPMixin):
     def retrieve(
         self,
         indices: ArrayLike,
-        fields: None | Collection[str] = None,
+        fields: None | Collection[str] | str = None,
         return_type: Literal["pandas"] = "pandas",
     ) -> ArchiveDataFrame: ...
 
@@ -331,9 +337,20 @@ class ArrayStore(PickleXPMixin):
         self,
         indices: ArrayLike,
         fields: None | Collection[str] | str = None,
-        return_type: Literal["dict", "tuple", "pandas"] = "dict",
+        return_type: None | Literal["dict", "tuple", "pandas"] = None,
     ) -> Array | dict[str, Array] | tuple[Array] | ArchiveDataFrame:
         """Collects data at the given indices.
+
+        .. versionchanged:: 0.12.0
+            When ``fields`` is a single str and ``return_type`` is "dict", "tuple",
+            or "pandas", we now return a dict, tuple, or ArchiveDataFrame with only
+            that field. Previously, ``return_type`` was simply ignored. Furthermore,
+            the default of ``return_type`` is now None, and it is set depending on
+            the type of ``fields``.
+
+        .. seealso::
+            :meth:`ribs.archives.ArchiveBase.data` is often implemented with a call to
+            :meth:`data`, which ultimately calls this method.
 
         Args:
             indices: List of indices at which to collect data.
@@ -356,9 +373,9 @@ class ArrayStore(PickleXPMixin):
             below should be ignored.
 
             The second element is **data**, the data at the given indices. If ``fields``
-            was a single str, this will just be an array holding data for the given
-            field. Otherwise, this data can take the following forms, depending on the
-            ``return_type`` argument:
+            is a single str and ``return_type`` is None, this will just be an array
+            holding data for the given field. Otherwise, this data can take the
+            following forms, depending on the ``return_type`` argument:
 
             - ``return_type="dict"``: Dict mapping from the field name to the field data
               at the given indices. For instance, if we have an ``objective`` field and
@@ -420,13 +437,25 @@ class ArrayStore(PickleXPMixin):
             ValueError: Passed ``return_type="pandas"`` when one of the fields has >1D
                 data.
         """
-        single_field = isinstance(fields, str)
         indices = self._xp.asarray(indices, dtype=self._xp.int32, device=self._device)
 
         # Induces copy (in numpy, at least).
         occupied = self._props["occupied"][indices]
 
+        single_field = isinstance(fields, str)
+
+        # Compute default value for return_type.
+        if return_type is None:
+            return_type = "single" if single_field else "dict"
+
+        # Normalize `fields` to be an iterable.
         if single_field:
+            fields = [fields]
+        elif fields is None:
+            fields: Iterator[str] = itertools.chain(self._fields, ["index"])
+
+        # Set up return values for data.
+        if return_type == "single":
             data = None
         elif return_type in ("dict", "pandas"):
             data = {}
@@ -434,11 +463,6 @@ class ArrayStore(PickleXPMixin):
             data = []
         else:
             raise ValueError(f"Invalid return_type {return_type}.")
-
-        if single_field:
-            fields = [fields]
-        elif fields is None:
-            fields: Iterator[str] = itertools.chain(self._fields, ["index"])
 
         for name in fields:
             # Collect array data.
@@ -453,7 +477,7 @@ class ArrayStore(PickleXPMixin):
                 raise ValueError(f"`{name}` is not a field in this ArrayStore.")
 
             # Accumulate data into the return type.
-            if single_field:
+            if return_type == "single":
                 data = arr
             elif return_type == "dict":
                 data[name] = arr
@@ -488,34 +512,41 @@ class ArrayStore(PickleXPMixin):
     def data(
         self,
         fields: str,
-        return_type: Literal["dict", "tuple", "pandas"] = "dict",
+        return_type: None = None,
     ) -> Array: ...
 
     @overload
     def data(
         self,
         fields: None | Collection[str] = None,
+        return_type: None = None,
+    ) -> dict[str, Array]: ...
+
+    @overload
+    def data(
+        self,
+        fields: None | Collection[str] | str = None,
         return_type: Literal["dict"] = "dict",
     ) -> dict[str, Array]: ...
 
     @overload
     def data(
         self,
-        fields: None | Collection[str] = None,
+        fields: None | Collection[str] | str = None,
         return_type: Literal["tuple"] = "tuple",
     ) -> tuple[Array]: ...
 
     @overload
     def data(
         self,
-        fields: None | Collection[str] = None,
+        fields: None | Collection[str] | str = None,
         return_type: Literal["pandas"] = "pandas",
     ) -> ArchiveDataFrame: ...
 
     def data(
         self,
         fields: None | Collection[str] | str = None,
-        return_type: Literal["dict", "tuple", "pandas"] = "dict",
+        return_type: None | Literal["dict", "tuple", "pandas"] = None,
     ) -> Array | dict[str, Array] | tuple[Array] | ArchiveDataFrame:
         """Retrieves data for all entries in the store.
 

--- a/ribs/archives/_array_store.py
+++ b/ribs/archives/_array_store.py
@@ -345,10 +345,10 @@ class ArrayStore(PickleXPMixin):
 
         .. versionchanged:: 0.12.0
             When ``fields`` is a single str and ``return_type`` is "dict", "tuple",
-            or "pandas", we now return a dict, tuple, or ArchiveDataFrame with only
-            that field. Previously, ``return_type`` was simply ignored. Furthermore,
-            the default of ``return_type`` is now None, and it is set depending on
-            the type of ``fields``. See :pr:`721` for more info.
+            or "pandas", we now return a dict, tuple, or ArchiveDataFrame with only that
+            field. Previously, ``return_type`` was ignored in that case. Furthermore,
+            the default of ``return_type`` is now None, and it is set depending on the
+            type of ``fields``. See :pr:`721` for more info.
 
         .. seealso::
             :meth:`ribs.archives.ArchiveBase.data` is often implemented with a call to

--- a/ribs/archives/_array_store.py
+++ b/ribs/archives/_array_store.py
@@ -346,7 +346,7 @@ class ArrayStore(PickleXPMixin):
             or "pandas", we now return a dict, tuple, or ArchiveDataFrame with only
             that field. Previously, ``return_type`` was simply ignored. Furthermore,
             the default of ``return_type`` is now None, and it is set depending on
-            the type of ``fields``.
+            the type of ``fields``. See :pr:`721` for more info.
 
         .. seealso::
             :meth:`ribs.archives.ArchiveBase.data` is often implemented with a call to

--- a/ribs/archives/_array_store.py
+++ b/ribs/archives/_array_store.py
@@ -298,6 +298,7 @@ class ArrayStore(PickleXPMixin):
     @overload
     def retrieve(
         self,
+        indices: ArrayLike,
         fields: str,
         return_type: None = None,
     ) -> Array: ...
@@ -305,6 +306,7 @@ class ArrayStore(PickleXPMixin):
     @overload
     def retrieve(
         self,
+        indices: ArrayLike,
         fields: None | Collection[str] = None,
         return_type: None = None,
     ) -> dict[str, Array]: ...

--- a/ribs/archives/_categorical_archive.py
+++ b/ribs/archives/_categorical_archive.py
@@ -758,34 +758,41 @@ class CategoricalArchive(ArchiveBase):
     def data(
         self,
         fields: str,
-        return_type: Literal["dict", "tuple", "pandas"] = "dict",
+        return_type: None = None,
     ) -> np.ndarray: ...
 
     @overload
     def data(
         self,
         fields: None | Collection[str] = None,
+        return_type: None = None,
+    ) -> BatchData: ...
+
+    @overload
+    def data(
+        self,
+        fields: None | Collection[str] | str = None,
         return_type: Literal["dict"] = "dict",
     ) -> BatchData: ...
 
     @overload
     def data(
         self,
-        fields: None | Collection[str] = None,
+        fields: None | Collection[str] | str = None,
         return_type: Literal["tuple"] = "tuple",
     ) -> tuple[np.ndarray]: ...
 
     @overload
     def data(
         self,
-        fields: None | Collection[str] = None,
+        fields: None | Collection[str] | str = None,
         return_type: Literal["pandas"] = "pandas",
     ) -> ArchiveDataFrame: ...
 
     def data(
         self,
         fields: None | Collection[str] | str = None,
-        return_type: Literal["dict", "tuple", "pandas"] = "dict",
+        return_type: None | Literal["dict", "tuple", "pandas"] = None,
     ) -> np.ndarray | BatchData | tuple[np.ndarray] | ArchiveDataFrame:
         return self._store.data(fields, return_type)
 

--- a/ribs/archives/_cvt_archive.py
+++ b/ribs/archives/_cvt_archive.py
@@ -1073,34 +1073,41 @@ class CVTArchive(ArchiveBase):
     def data(
         self,
         fields: str,
-        return_type: Literal["dict", "tuple", "pandas"] = "dict",
+        return_type: None = None,
     ) -> np.ndarray: ...
 
     @overload
     def data(
         self,
         fields: None | Collection[str] = None,
+        return_type: None = None,
+    ) -> BatchData: ...
+
+    @overload
+    def data(
+        self,
+        fields: None | Collection[str] | str = None,
         return_type: Literal["dict"] = "dict",
     ) -> BatchData: ...
 
     @overload
     def data(
         self,
-        fields: None | Collection[str] = None,
+        fields: None | Collection[str] | str = None,
         return_type: Literal["tuple"] = "tuple",
     ) -> tuple[np.ndarray]: ...
 
     @overload
     def data(
         self,
-        fields: None | Collection[str] = None,
+        fields: None | Collection[str] | str = None,
         return_type: Literal["pandas"] = "pandas",
     ) -> ArchiveDataFrame: ...
 
     def data(
         self,
         fields: None | Collection[str] | str = None,
-        return_type: Literal["dict", "tuple", "pandas"] = "dict",
+        return_type: None | Literal["dict", "tuple", "pandas"] = None,
     ) -> np.ndarray | BatchData | tuple[np.ndarray] | ArchiveDataFrame:
         return self._store.data(fields, return_type)
 

--- a/ribs/archives/_dns_archive.py
+++ b/ribs/archives/_dns_archive.py
@@ -480,34 +480,41 @@ class DNSArchive(ArchiveBase):
     def data(
         self,
         fields: str,
-        return_type: Literal["dict", "tuple", "pandas"] = "dict",
+        return_type: None = None,
     ) -> np.ndarray: ...
 
     @overload
     def data(
         self,
         fields: None | Collection[str] = None,
+        return_type: None = None,
+    ) -> BatchData: ...
+
+    @overload
+    def data(
+        self,
+        fields: None | Collection[str] | str = None,
         return_type: Literal["dict"] = "dict",
     ) -> BatchData: ...
 
     @overload
     def data(
         self,
-        fields: None | Collection[str] = None,
+        fields: None | Collection[str] | str = None,
         return_type: Literal["tuple"] = "tuple",
     ) -> tuple[np.ndarray]: ...
 
     @overload
     def data(
         self,
-        fields: None | Collection[str] = None,
+        fields: None | Collection[str] | str = None,
         return_type: Literal["pandas"] = "pandas",
     ) -> ArchiveDataFrame: ...
 
     def data(
         self,
         fields: None | Collection[str] | str = None,
-        return_type: Literal["dict", "tuple", "pandas"] = "dict",
+        return_type: None | Literal["dict", "tuple", "pandas"] = None,
     ) -> np.ndarray | BatchData | tuple[np.ndarray] | ArchiveDataFrame:
         return self._store.data(fields, return_type)
 

--- a/ribs/archives/_grid_archive.py
+++ b/ribs/archives/_grid_archive.py
@@ -878,34 +878,41 @@ class GridArchive(ArchiveBase):
     def data(
         self,
         fields: str,
-        return_type: Literal["dict", "tuple", "pandas"] = "dict",
+        return_type: None = None,
     ) -> np.ndarray: ...
 
     @overload
     def data(
         self,
         fields: None | Collection[str] = None,
+        return_type: None = None,
+    ) -> BatchData: ...
+
+    @overload
+    def data(
+        self,
+        fields: None | Collection[str] | str = None,
         return_type: Literal["dict"] = "dict",
     ) -> BatchData: ...
 
     @overload
     def data(
         self,
-        fields: None | Collection[str] = None,
+        fields: None | Collection[str] | str = None,
         return_type: Literal["tuple"] = "tuple",
     ) -> tuple[np.ndarray]: ...
 
     @overload
     def data(
         self,
-        fields: None | Collection[str] = None,
+        fields: None | Collection[str] | str = None,
         return_type: Literal["pandas"] = "pandas",
     ) -> ArchiveDataFrame: ...
 
     def data(
         self,
         fields: None | Collection[str] | str = None,
-        return_type: Literal["dict", "tuple", "pandas"] = "dict",
+        return_type: None | Literal["dict", "tuple", "pandas"] = None,
     ) -> np.ndarray | BatchData | tuple[np.ndarray] | ArchiveDataFrame:
         return self._store.data(fields, return_type)
 

--- a/ribs/archives/_proximity_archive.py
+++ b/ribs/archives/_proximity_archive.py
@@ -914,34 +914,41 @@ class ProximityArchive(ArchiveBase):
     def data(
         self,
         fields: str,
-        return_type: Literal["dict", "tuple", "pandas"] = "dict",
+        return_type: None = None,
     ) -> np.ndarray: ...
 
     @overload
     def data(
         self,
         fields: None | Collection[str] = None,
+        return_type: None = None,
+    ) -> BatchData: ...
+
+    @overload
+    def data(
+        self,
+        fields: None | Collection[str] | str = None,
         return_type: Literal["dict"] = "dict",
     ) -> BatchData: ...
 
     @overload
     def data(
         self,
-        fields: None | Collection[str] = None,
+        fields: None | Collection[str] | str = None,
         return_type: Literal["tuple"] = "tuple",
     ) -> tuple[np.ndarray]: ...
 
     @overload
     def data(
         self,
-        fields: None | Collection[str] = None,
+        fields: None | Collection[str] | str = None,
         return_type: Literal["pandas"] = "pandas",
     ) -> ArchiveDataFrame: ...
 
     def data(
         self,
         fields: None | Collection[str] | str = None,
-        return_type: Literal["dict", "tuple", "pandas"] = "dict",
+        return_type: None | Literal["dict", "tuple", "pandas"] = None,
     ) -> np.ndarray | BatchData | tuple[np.ndarray] | ArchiveDataFrame:
         return self._store.data(fields, return_type)
 

--- a/ribs/archives/_sliding_boundaries_archive.py
+++ b/ribs/archives/_sliding_boundaries_archive.py
@@ -742,34 +742,41 @@ class SlidingBoundariesArchive(ArchiveBase):
     def data(
         self,
         fields: str,
-        return_type: Literal["dict", "tuple", "pandas"] = "dict",
+        return_type: None = None,
     ) -> np.ndarray: ...
 
     @overload
     def data(
         self,
         fields: None | Collection[str] = None,
+        return_type: None = None,
+    ) -> BatchData: ...
+
+    @overload
+    def data(
+        self,
+        fields: None | Collection[str] | str = None,
         return_type: Literal["dict"] = "dict",
     ) -> BatchData: ...
 
     @overload
     def data(
         self,
-        fields: None | Collection[str] = None,
+        fields: None | Collection[str] | str = None,
         return_type: Literal["tuple"] = "tuple",
     ) -> tuple[np.ndarray]: ...
 
     @overload
     def data(
         self,
-        fields: None | Collection[str] = None,
+        fields: None | Collection[str] | str = None,
         return_type: Literal["pandas"] = "pandas",
     ) -> ArchiveDataFrame: ...
 
     def data(
         self,
         fields: None | Collection[str] | str = None,
-        return_type: Literal["dict", "tuple", "pandas"] = "dict",
+        return_type: None | Literal["dict", "tuple", "pandas"] = None,
     ) -> np.ndarray | BatchData | tuple[np.ndarray] | ArchiveDataFrame:
         return self._store.data(fields, return_type)
 

--- a/tests/archives/archive_base_test.py
+++ b/tests/archives/archive_base_test.py
@@ -4,6 +4,7 @@ import numpy as np
 import pytest
 
 from ribs.archives import (
+    ArchiveDataFrame,
     CategoricalArchive,
     CVTArchive,
     GridArchive,
@@ -696,3 +697,55 @@ def test_pandas_data(name, with_elite, dtype):
         # Comparing the df to the list of expected data seems to make things be
         # marked unequal when the dtypes are mixed between object and scalar.
         assert list(df.iloc[0, : len(expected_data)]) == expected_data
+
+
+@pytest.mark.parametrize("name", ARCHIVE_NAMES)
+@pytest.mark.parametrize("return_type", [None, "dict", "tuple", "pandas"])
+def test_data_with_single_field(name, return_type):
+    """Test behaviors when a single field name is passed in."""
+    data = get_archive_data(name, dtype=np.float64)
+
+    res = data.archive_with_elite.data("objective", return_type=return_type)
+
+    if return_type is None:
+        assert np.allclose(res, np.asarray([data.objective]))
+    elif return_type == "dict":
+        assert isinstance(res, dict)
+        assert res.keys() == {"objective"}
+        assert np.allclose(res["objective"], np.asarray([data.objective]))
+    elif return_type == "tuple":
+        assert isinstance(res, tuple)
+        assert len(res) == 1
+        assert np.allclose(res[0], np.asarray([data.objective]))
+    elif return_type == "pandas":
+        assert isinstance(res, ArchiveDataFrame)
+        assert res.columns == ["objective"]
+        assert np.allclose(res["objective"], np.asarray([data.objective]))
+
+
+@pytest.mark.parametrize("name", ARCHIVE_NAMES)
+@pytest.mark.parametrize("fields", [None, "objective", ["objective", "measures"]])
+def test_data_with_return_type_none(name, fields):
+    """Test behaviors when return_type is None."""
+    data = get_archive_data(name, dtype=np.float64)
+
+    res = data.archive_with_elite.data(fields, return_type=None)
+
+    if fields is None:
+        assert isinstance(res, dict)
+        if isinstance(data.archive_with_elite, MAE_ARCHIVES):
+            assert res.keys() == {
+                "solution",
+                "objective",
+                "measures",
+                "threshold",
+                "index",
+            }
+        else:
+            assert res.keys() == {"solution", "objective", "measures", "index"}
+    elif fields == "objective":
+        assert isinstance(res, np.ndarray)
+        assert np.allclose(res, np.asarray([data.objective]))
+    elif fields == ["objective", "measures"]:
+        assert isinstance(res, dict)
+        assert res.keys() == {"objective", "measures"}


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the PR's purpose here. -->

Resolves #720.

The motivation of this PR is that I noticed that running `archive.data("objective", return_type="pandas")` returned an ArchiveDataFrame where there was a single column named 0. However, I would expect it to return an ArchiveDataFrame with a single column called "objective". Upon closer inspection, I found that passing `fields` as a str in the `data()` method did not really have defined behavior unless the `return_type` was the default of `dict`.

Thus, I am creating this PR, which makes the following changes:

1. `return_type` now defaults to `None` instead of `dict`
    - When `fields` is a str and `return_type` is None, `return_type` internally becomes `single`, which indicates returning a single array.
    - When `fields` is None or a collection of str and `return_type` is None, `return_type` defaults to `dict`.
    - This preserves the prior behavior of `data`, where calling `archive.data("measures")` returns just a single array, while calling `archive.data()` returns all the data in the archive as a dict.
2. When `fields` is a str and `return_type` is `dict`, `tuple`, or `pandas`, data() now returns an appropriate object with just that field.
    - This is a breaking change because previously, `archive.data("measures", return_type="dict")` would return just a single array. However, it now returns a dict instead.
    - Before, `archive.data("objective", return_type="pandas")` actually returned a DataFrame of some sort. This is actually a **bug** because according to the documentation, the `return_type` should be ignored since `fields` is a str. However, I believe the new behavior makes more sense.

Thus, the cases may be summed up as follows:

|                               | **NEW: return_type=None**                         | return_type="dict"\|"tuple"\|"pandas"                                                                 |
| ----------------------------- | ------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
| fields is None                | **NEW: return all fields in the archive as dict** | return all fields in the archive as the given type                                                    |
| fields is a collection of str | **NEW: return the listed fields as a dict**       | return the listed fields as the given type                                                            |
| fields is a str               | **NEW: return the given field as an array**       | **NEW: return only the given field as the given type** -- **OLD: return the given field as an array** |

## TODO

<!-- Notable points that this PR has either accomplished or will accomplish. -->

- [x] Update documentation and signature in ArchiveBase.data
- [x] Implement this feature and update documentation in ArrayStore.retrieve and ArrayStore.data
- [x] Update signatures for all archives that use data()
- [x] Make sure existing tests pass
- [x] Add tests for the new behavior
- [x] Double check documentation for all archives

## Status

- [x] I have read the guidelines in
      [CONTRIBUTING.md](https://github.com/icaros-usc/pyribs/blob/master/CONTRIBUTING.md)
- [x] I have linted and formatted my code with `ruff` and `pylint`
- [x] I have tested my code by running `pytest`
- [x] I have added a description of my change to the changelog in `HISTORY.md`
- [x] This PR is ready to go
