### PR TITLE
Remove double spaces in arg descs

### DIFF
--- a/ribs/visualize/_archive_histogram.py
+++ b/ribs/visualize/_archive_histogram.py
@@ -127,7 +127,7 @@ def archive_histogram(
     Args:
         archive: An archive that can provide its objective values via the
             :meth:`~ribs.archives.ArchiveBase.data` method.
-        ax: Axes on which to plot the histogram.  If ``None``, the current axis will be
+        ax: Axes on which to plot the histogram. If ``None``, the current axis will be
             used.
         df: If provided, we will plot data from this argument instead of the data
             currently in the archive. This data can be obtained by, for instance,

--- a/ribs/visualize/_cvt_archive_heatmap.py
+++ b/ribs/visualize/_cvt_archive_heatmap.py
@@ -113,7 +113,7 @@ def cvt_archive_heatmap(
 
     Args:
         archive: A 1D or 2D :class:`~ribs.archives.CVTArchive`.
-        ax: Axes on which to plot the heatmap.  If ``None``, the current axis will be
+        ax: Axes on which to plot the heatmap. If ``None``, the current axis will be
             used.
         df: If provided, we will plot data from this argument instead of the data
             currently in the archive. This data can be obtained by, for instance,
@@ -151,7 +151,7 @@ def cvt_archive_heatmap(
             raster graphic so that the archive cells will not have to be individually
             rendered. Meanwhile, the surrounding axes, particularly text labels, will
             remain in vector format.
-        clip: Clip the heatmap cells to a given polygon.  By default, we draw the cells
+        clip: Clip the heatmap cells to a given polygon. By default, we draw the cells
             along the outer edges of the heatmap as polygons that extend beyond the
             archive bounds, but these polygons are hidden because we set the axis limits
             to be the archive bounds. Passing `clip=True` will clip the heatmap such

--- a/ribs/visualize/_grid_archive_heatmap.py
+++ b/ribs/visualize/_grid_archive_heatmap.py
@@ -102,7 +102,7 @@ def grid_archive_heatmap(
 
     Args:
         archive: A 1D or 2D :class:`~ribs.archives.GridArchive`.
-        ax: Axes on which to plot the heatmap.  If ``None``, the current axis will be
+        ax: Axes on which to plot the heatmap. If ``None``, the current axis will be
             used.
         df: If provided, we will plot data from this argument instead of the data
             currently in the archive. This data can be obtained by, for instance,

--- a/ribs/visualize/_sliding_boundaries_archive_heatmap.py
+++ b/ribs/visualize/_sliding_boundaries_archive_heatmap.py
@@ -77,7 +77,7 @@ def sliding_boundaries_archive_heatmap(
 
     Args:
         archive: A 2D :class:`~ribs.archives.SlidingBoundariesArchive`.
-        ax: Axes on which to plot the heatmap.  If ``None``, the current axis will be
+        ax: Axes on which to plot the heatmap. If ``None``, the current axis will be
             used.
         df: If provided, we will plot data from this argument instead of the data
             currently in the archive. This data can be obtained by, for instance,


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the PR's purpose here. -->

Had some double spaces spread across the docs.

## Status

- [x] I have read the guidelines in
      [CONTRIBUTING.md](https://github.com/icaros-usc/pyribs/blob/master/CONTRIBUTING.md)
- [x] I have linted and formatted my code with `ruff` and `pylint`
- [x] I have tested my code by running `pytest`
- [N/A] I have added a description of my change to the changelog in `HISTORY.md`
- [x] This PR is ready to go
